### PR TITLE
add goerli and bump zksync-web3 version

### DIFF
--- a/packages/hardhat-zksync-deploy/package.json
+++ b/packages/hardhat-zksync-deploy/package.json
@@ -53,12 +53,12 @@
     "rimraf": "^3.0.2",
     "ts-node": "^8.1.0",
     "typescript": "~4.4.2",
-    "zksync-web3": "^0.2.3"
+    "zksync-web3": "^0.3.3"
   },
   "peerDependencies": {
     "ethers": "~5.5.2",
     "hardhat": "^2.0.0",
-    "zksync-web3": "^0.2.3"
+    "zksync-web3": "^0.3.3"
   },
   "prettier": {
     "tabWidth": 4,

--- a/packages/hardhat-zksync-deploy/src/deployer.ts
+++ b/packages/hardhat-zksync-deploy/src/deployer.ts
@@ -6,7 +6,7 @@ import { ZkSyncArtifact } from './types';
 import { pluginError } from './helpers';
 
 const ARTIFACT_FORMAT_VERSION = 'hh-zksolc-artifact-1';
-const SUPPORTED_L1_TESTNETS = ['mainnet', 'rinkeby', 'ropsten', 'kovan'];
+const SUPPORTED_L1_TESTNETS = ['mainnet', 'rinkeby', 'ropsten', 'kovan', 'goerli'];
 
 /**
  * An entity capable of deploying contracts to the zkSync network.

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,9 +709,10 @@
     glob "^7.1.3"
 
 "@matterlabs/hardhat-zksync-solc@link:packages/hardhat-zksync-solc":
-  version "0.1.1"
+  version "0.2.2"
   dependencies:
     "@nomiclabs/hardhat-docker" "^2.0.0"
+    dockerode "^3.3.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -5249,3 +5250,8 @@ zksync-web3@^0.2.3:
   version "0.2.11"
   resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.2.11.tgz#52a428e5665dd6ca739797f8542da735c9ea985c"
   integrity sha512-ENaioGNFusA9MwA6VfmaprdX68za3z9jx7SXVfy4VB0uAUkrpP8yvtcfMwM5a7DNB2gHdBWMh3jI0ZEr5hzdAA==
+
+zksync-web3@^0.3.3:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.3.4.tgz#2e136771f7ef6c564a4d311598d84cd42a112396"
+  integrity sha512-3/RrN5KmVIm2t4NlUvIYf10Nm7agBJTdhdWlg5iBAl3HkaBCgvyHTXiftv6GD5qor430Rdj9A0UIs8JWtf4jeQ==


### PR DESCRIPTION
Goerli is now the default L1 testnet. Bumped zksync-web3, otherwise all deploys would fail since 0.2 is missing the chainId tx serialization

Not sure how you guys prefer to do npm releases, so I left the package version as is