### PR TITLE
Fix library default config bug

### DIFF
--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -21,7 +21,6 @@ extendConfig((config) => {
                 enabled: false,
             },
             experimental: {},
-            libraries: {}
         },
     };
     config.zksolc = { ...defaultConfig, ...config.zksolc };


### PR DESCRIPTION
A bug was introduced in bd06d2447b296546c1940c18453313d344216af7, where hardhat would always recompile because the solc cache entry differed from the input solc. One would have `libraries: {}` and the other would not include that setting.

This was due to adding `libraries: {}` to the default config and then later checking:

```
if (config.zksolc.settings.libraries) {
    input.settings.libraries = config.zksolc.settings.libraries;
}
```

Which will always evaluate to true and updates the input settings. I removed libraries from the default config but another option is to just change to check that the object has keys in the above if statement instead of checking that it exists.