### PR TITLE
Allow both solc and zksolc compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ node_modules
 # Compilation output
 build-test/
 dist
+artifacts-zk/
+cache-zk/
 
 # Code coverage artifacts
 coverage

--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -1,6 +1,7 @@
 import {
     TASK_COMPILE_SOLIDITY_RUN_SOLC,
     TASK_COMPILE_SOLIDITY_GET_ARTIFACT_FROM_COMPILATION_OUTPUT,
+    TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD
 } from 'hardhat/builtin-tasks/task-names';
 import { extendEnvironment, subtask } from 'hardhat/internal/core/config/config-env';
 import './type-extensions';
@@ -108,4 +109,20 @@ subtask(TASK_COMPILE_SOLIDITY_RUN_SOLC, async (args: { input: any; solcPath: str
     args.input.settings.optimizer.enabled = true
 
     return await compile(zksolc, args.input);
+});
+
+// This task searches for the required solc version in the system and downloads it if not found.
+// zksolc currently uses solc found in $PATH so this task is not needed for the most part.
+// It is overriden to prevent unnecessary downloads.
+subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, async (args: { solcVersion: string }, hre, runSuper) => {
+    if (hre.network.zksync !== true) {
+        return runSuper(args)
+    }
+    // return dummy value, it's not used anywhere anyway
+    return {
+        compilerPath: '',
+        isSolsJs: false,
+        version: args.solcVersion,
+        longVersion: args.solcVersion,
+    };
 });

--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -97,11 +97,15 @@ subtask(TASK_COMPILE_SOLIDITY_RUN_SOLC, async (args: { input: any; solcPath: str
         },
     };
 
-    const zksolc = { ...defaultConfig, ...hre.config.zksync };
+    const zksolc = { ...defaultConfig, ...hre.config.zksolc };
 
-    if (hre.config?.zksync?.settings.libraries) {
-        args.input.settings.libraries = hre.config.zksync.settings.libraries;
+    if (hre.config?.zksolc?.settings.libraries) {
+        args.input.settings.libraries = hre.config.zksolc.settings.libraries;
     }
-  
+    
+    // TODO: If solidity optimizer is not enabled, the libraries are not inlined and
+    // we have to manually pass them into zksolc. So for now we force the optimization.
+    args.input.settings.optimizer.enabled = true
+
     return await compile(zksolc, args.input);
 });

--- a/packages/hardhat-zksync-solc/src/type-extensions.ts
+++ b/packages/hardhat-zksync-solc/src/type-extensions.ts
@@ -4,11 +4,11 @@ import { ZkSolcConfig } from './types';
 
 declare module 'hardhat/types/config' {
     interface HardhatUserConfig {
-        zksync?: Partial<ZkSolcConfig>;
+        zksolc?: Partial<ZkSolcConfig>;
     }
 
     interface HardhatConfig {
-        zksync?: ZkSolcConfig;
+        zksolc?: ZkSolcConfig;
     }
 
     interface HardhatNetworkUserConfig {

--- a/packages/hardhat-zksync-solc/src/type-extensions.ts
+++ b/packages/hardhat-zksync-solc/src/type-extensions.ts
@@ -4,10 +4,32 @@ import { ZkSolcConfig } from './types';
 
 declare module 'hardhat/types/config' {
     interface HardhatUserConfig {
-        zksolc?: Partial<ZkSolcConfig>;
+        zksync?: Partial<ZkSolcConfig>;
     }
 
     interface HardhatConfig {
-        zksolc: ZkSolcConfig;
+        zksync?: ZkSolcConfig;
+    }
+
+    interface HardhatNetworkUserConfig {
+        zksync?: boolean;
+    }
+
+    interface HttpNetworkUserConfig {
+        zksync: boolean;
+    }
+
+    interface HardhatNetworkConfig {
+        zksync: boolean;
+    }
+
+    interface HttpNetworkConfig {
+        zksync: boolean;
+    }
+}
+
+declare module 'hardhat/types/runtime' {
+    interface Network {
+        zksync: boolean;
     }
 }

--- a/packages/hardhat-zksync-solc/test/fixture-projects/factory/hardhat.config.js
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/factory/hardhat.config.js
@@ -13,6 +13,11 @@ module.exports = {
       }
     },
   },
+  networks: {
+    localhost: {
+      zksync: true,
+    },
+  },
   solidity: {
       version: "0.8.11"
   }

--- a/packages/hardhat-zksync-solc/test/fixture-projects/library/hardhat.config.js
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/library/hardhat.config.js
@@ -13,6 +13,11 @@ module.exports = {
       }
     },
   },
+  networks: {
+    localhost: {
+      zksync: true,
+    },
+  },
   solidity: {
       version: "0.8.11"
   }

--- a/packages/hardhat-zksync-solc/test/fixture-projects/linked/hardhat.config.js
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/linked/hardhat.config.js
@@ -18,6 +18,11 @@ module.exports = {
       }
     },
   },
+  networks: {
+    localhost: {
+      zksync: true,
+    },
+  },
   solidity: {
       version: "0.8.11"
   }

--- a/packages/hardhat-zksync-solc/test/fixture-projects/nested/hardhat.config.js
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/nested/hardhat.config.js
@@ -13,6 +13,11 @@ module.exports = {
       }
     },
   },
+  networks: {
+    localhost: {
+      zksync: true,
+    },
+  },
   solidity: {
       version: "0.8.11"
   }

--- a/packages/hardhat-zksync-solc/test/fixture-projects/simple/hardhat.config.js
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/simple/hardhat.config.js
@@ -13,6 +13,11 @@ module.exports = {
       }
     },
   },
+  networks: {
+    localhost: {
+      zksync: true,
+    },
+  },
   solidity: {
       version: "0.8.11"
   }

--- a/packages/hardhat-zksync-solc/test/helpers.ts
+++ b/packages/hardhat-zksync-solc/test/helpers.ts
@@ -13,7 +13,7 @@ export function useEnvironment(fixtureProjectName: string, networkName = 'localh
     beforeEach('Loading hardhat environment', function () {
         process.chdir(path.join(__dirname, 'fixture-projects', fixtureProjectName));
         process.env.HARDHAT_NETWORK = networkName;
-
+        
         this.env = require('hardhat');
         this.env.run(TASK_CLEAN);
     });


### PR DESCRIPTION
One point of feedback that keeps coming up from devs is not having the ability to compile using standard solidity and zksolc within a project. This PR adds the logic so that both solc and zksolc tasks can run and the artifacts are stored separately. Optimism uses similar logic so it follows a set standard of having `artifacts-zk` & `cache-zk` paths.

A `zksync` network boolean is added and if it is true it loads the full zksolc compiler config. That way users can separate how they want to compile by network without changing anything