### PR TITLE
Make zksolc path configurable 

### DIFF
--- a/packages/hardhat-zksync-solc/package.json
+++ b/packages/hardhat-zksync-solc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterlabs/hardhat-zksync-solc",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Hardhat plugin to compile smart contracts for the zkSync network",
   "repository": "github:matter-labs/hardhat-zksync",
   "homepage": "https://github.com/matter-labs/hardhat-zksync/tree/main/packages/hardhat-zksync-solc",

--- a/packages/hardhat-zksync-solc/src/compile/binary.ts
+++ b/packages/hardhat-zksync-solc/src/compile/binary.ts
@@ -1,19 +1,12 @@
-import { exec, spawnSync } from 'child_process';
+import { exec } from 'child_process';
 import { ZkSolcConfig } from '../types';
-import { pluginError } from '../utils';
 
-// Checks whether `zksolc` is available in `$PATH`.
-export function checkZksolcBinary() {
-    const inPath = spawnSync('which', ['zksolc']).status === 0;
-    if (!inPath) {
-        throw pluginError('`zksolc` binary is either not installed or not in $PATH');
-    }
-}
-
-export async function compileWithBinary(input: any, config: ZkSolcConfig): Promise<any> {
+export async function compileWithBinary(input: any, config: ZkSolcConfig, solcPath: string): Promise<any> {
     const output: string = await new Promise((resolve, reject) => {
         const process = exec(
-            `zksolc --standard-json ${config?.settings?.optimizer?.enabled ? '--optimize' : ''}`,
+            `${config.settings.compilerPath} --standard-json --solc ${solcPath} ${
+                config.settings.optimizer?.enabled ? '--optimize' : ''
+            }`,
             {
                 maxBuffer: 1024 * 1024 * 500,
             },

--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -3,14 +3,32 @@ import {
     TASK_COMPILE_SOLIDITY_GET_ARTIFACT_FROM_COMPILATION_OUTPUT,
     TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD,
 } from 'hardhat/builtin-tasks/task-names';
-import { extendEnvironment, subtask } from 'hardhat/internal/core/config/config-env';
+import { extendEnvironment, extendConfig, subtask } from 'hardhat/internal/core/config/config-env';
 import './type-extensions';
-import { FactoryDeps, ZkSolcConfig } from './types';
+import { FactoryDeps } from './types';
 import { Artifacts, getArtifactFromContractOutput } from 'hardhat/internal/artifacts';
 import { compile } from './compile';
-import { zeroxlify } from './utils';
+import { zeroxlify, pluginError } from './utils';
+import { spawnSync } from 'child_process';
 
 const ZK_ARTIFACT_FORMAT_VERSION = 'hh-zksolc-artifact-1';
+
+extendConfig((config) => {
+    const defaultConfig = {
+        version: 'latest',
+        compilerSource: 'binary',
+        settings: {
+            compilerPath: 'zksolc',
+            optimizer: {
+                enabled: false,
+            },
+            experimental: {},
+        },
+    };
+
+    config.zksolc = { ...defaultConfig, ...config.zksolc };
+    config.zksolc.settings = { ...defaultConfig.settings, ...config.zksolc.settings };
+});
 
 extendEnvironment((hre) => {
     if (hre.network.config.zksync) {
@@ -30,6 +48,13 @@ extendEnvironment((hre) => {
         hre.config.paths.artifacts = artifactsPath;
         hre.config.paths.cache = cachePath;
         (hre as any).artifacts = new Artifacts(artifactsPath);
+
+        // If solidity optimizer is not enabled, the libraries are not inlined and
+        // we have to manually pass them into zksolc. So for now we force the optimization.
+        hre.config.solidity.compilers.forEach((compiler) => {
+            let settings = compiler.settings || {};
+            compiler.settings = { ...settings, optimizer: { enabled: true } };
+        });
     }
 });
 
@@ -82,46 +107,50 @@ subtask(
 
 subtask(TASK_COMPILE_SOLIDITY_RUN_SOLC, async (args: { input: any; solcPath: string }, hre, runSuper) => {
     if (hre.network.zksync !== true) {
-        return runSuper(args);
+        return await runSuper(args);
     }
 
-    const defaultConfig: ZkSolcConfig = {
-        version: 'latest',
-        compilerSource: 'binary',
-        settings: {
-            optimizer: {
-                enabled: true,
-            },
-            experimental: {},
-        },
-    };
-
-    const zksolc = { ...defaultConfig, ...hre.config.zksolc };
-
-    if (hre.config?.zksolc?.settings.libraries) {
+    if (hre.config.zksolc.settings.libraries) {
         args.input.settings.libraries = hre.config.zksolc.settings.libraries;
     }
 
-    // TODO: If solidity optimizer is not enabled, the libraries are not inlined and
-    // we have to manually pass them into zksolc. So for now we force the optimization.
-    args.input.settings.optimizer.enabled = true;
-
-    return await compile(zksolc, args.input);
+    return await compile(hre.config.zksolc, args.input, args.solcPath);
 });
 
-// This task searches for the required solc version in the system and downloads it if not found.
-// zksolc currently uses solc found in $PATH so this task is not needed for the most part.
-// It is overriden to prevent unnecessary downloads.
+// This task is overriden to:
+// - prevent unnecessary solc downloads when using docker
+// - validate zksolc binary
+// - validate solc version required by zksolc
 subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, async (args: { solcVersion: string }, hre, runSuper) => {
     if (hre.network.zksync !== true) {
-        return runSuper(args);
+        return await runSuper(args);
     }
 
-    // return dummy value, it's not used anywhere anyway
-    return {
-        compilerPath: '',
-        isSolsJs: false,
-        version: args.solcVersion,
-        longVersion: args.solcVersion,
-    };
+    if (hre.config.zksolc.compilerSource === 'docker') {
+        // return dummy value, it's not used anywhere anyway
+        return {
+            compilerPath: '',
+            isSolsJs: false,
+            version: args.solcVersion,
+            longVersion: args.solcVersion,
+        };
+    }
+
+    const solcBuild = await runSuper(args);
+    const compilerPath = hre.config.zksolc.settings.compilerPath;
+
+    const versionOutput = spawnSync(compilerPath, ['--version']);
+    if (versionOutput.status !== 0) {
+        throw pluginError(`Specified zksolc binary is not found or invalid`);
+    }
+
+    const version = versionOutput.stdout.toString().match(/\d+\.\d+\.\d+/);
+    if (version != solcBuild.version) {
+        throw pluginError(
+            `Specified solc version is incompatible with installed zksolc. ` +
+                `Found: ${solcBuild.version}, expected: ${version}`
+        );
+    }
+
+    return solcBuild;
 });

--- a/packages/hardhat-zksync-solc/src/type-extensions.ts
+++ b/packages/hardhat-zksync-solc/src/type-extensions.ts
@@ -8,7 +8,7 @@ declare module 'hardhat/types/config' {
     }
 
     interface HardhatConfig {
-        zksolc?: ZkSolcConfig;
+        zksolc: ZkSolcConfig;
     }
 
     interface HardhatNetworkUserConfig {

--- a/packages/hardhat-zksync-solc/src/types.ts
+++ b/packages/hardhat-zksync-solc/src/types.ts
@@ -4,6 +4,9 @@ export interface ZkSolcConfig {
     version: string; // Currently ignored.
     compilerSource: 'binary' | 'docker'; // Docker support is currently in an early experimental state.
     settings: {
+        // Path to zksolc binary. If compilerSource == "docker", this option is ignored.
+        // By default, zksolc in $PATH is used.
+        compilerPath: string;
         optimizer: {
             enabled: boolean;
         };


### PR DESCRIPTION
- makes path to `zksolc` configurable and does not rely on it being in `$PATH`
- makes use of `solc` provided/downloaded by hardhat (instead of the one in `$PATH`)
- enforces `solc` version to be compatible with `zksolc`