### PR TITLE
fix userconfig zksolc settings

### DIFF
--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -13,7 +13,7 @@ import { spawnSync } from 'child_process';
 
 const ZK_ARTIFACT_FORMAT_VERSION = 'hh-zksolc-artifact-1';
 
-extendConfig((config) => {
+extendConfig((config, userConfig) => {
     const defaultConfig = {
         version: 'latest',
         compilerSource: 'binary',
@@ -26,8 +26,8 @@ extendConfig((config) => {
         },
     };
 
-    config.zksolc = { ...defaultConfig, ...config.zksolc };
-    config.zksolc.settings = { ...defaultConfig.settings, ...config.zksolc.settings };
+    config.zksolc = { ...defaultConfig, ...userConfig?.zksolc };
+    config.zksolc.settings = { ...defaultConfig.settings, ...userConfig?.zksolc?.settings };
 });
 
 extendEnvironment((hre) => {

--- a/packages/hardhat-zksync-solc/src/types.ts
+++ b/packages/hardhat-zksync-solc/src/types.ts
@@ -2,7 +2,7 @@ import { Artifact } from 'hardhat/types';
 
 export interface ZkSolcConfig {
     version: string; // Currently ignored.
-    compilerSource: 'binary' | 'docker'; // Docker support is currently in an early experimental state.
+    compilerSource: string; // Docker support is currently in an early experimental state.
     settings: {
         // Path to zksolc binary. If compilerSource == "docker", this option is ignored.
         // By default, zksolc in $PATH is used.


### PR DESCRIPTION
In the current setup, `config.zksolc` will always be undefined because it's not using the user supplied config. See here: https://github.com/NomicFoundation/hardhat-ts-plugin-boilerplate/blob/master/src/index.ts#L13-L20

So all deploys are using the `defaultConfig` with the optimizer off even if the user sets something different in `hardhat.config.ts`