### PR TITLE
Add the actual solc version to the artifacts when using docker

### DIFF
--- a/examples/basic-example/hardhat.config.ts
+++ b/examples/basic-example/hardhat.config.ts
@@ -4,7 +4,7 @@ import { HardhatUserConfig } from 'hardhat/config';
 
 const config: HardhatUserConfig = {
   zksolc: {
-    version: "1.1.5",
+    version: "1.1.6",
     compilerSource: "binary",
   },
   zkSyncDeploy: {

--- a/packages/hardhat-zksync-solc/package.json
+++ b/packages/hardhat-zksync-solc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterlabs/hardhat-zksync-solc",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Hardhat plugin to compile smart contracts for the zkSync network",
   "repository": "github:matter-labs/hardhat-zksync",
   "homepage": "https://github.com/matter-labs/hardhat-zksync/tree/main/packages/hardhat-zksync-solc",

--- a/packages/hardhat-zksync-solc/src/compile/index.ts
+++ b/packages/hardhat-zksync-solc/src/compile/index.ts
@@ -7,7 +7,7 @@ import {
     pullImageIfNecessary,
     dockerImage,
     compileWithDocker,
-    getSolcVersion
+    getSolcVersion,
 } from './docker';
 import { CompilerInput } from 'hardhat/types';
 import { pluginError } from '../utils';
@@ -61,9 +61,6 @@ export class DockerCompiler implements ICompiler {
         const versionOutput = await getSolcVersion(this.docker, this.dockerImage);
         const longVersion = versionOutput.match(/^Version: (.*)$/)![1];
         const version = longVersion.split('+')[0];
-        return {
-            version,
-            longVersion
-        }
+        return { version, longVersion };
     }
 }

--- a/packages/hardhat-zksync-solc/src/compile/index.ts
+++ b/packages/hardhat-zksync-solc/src/compile/index.ts
@@ -7,6 +7,7 @@ import {
     pullImageIfNecessary,
     dockerImage,
     compileWithDocker,
+    getSolcVersion
 } from './docker';
 import { CompilerInput } from 'hardhat/types';
 import { pluginError } from '../utils';
@@ -42,7 +43,7 @@ export class BinaryCompiler implements ICompiler {
 export class DockerCompiler implements ICompiler {
     protected constructor(public dockerImage: Image, public docker: HardhatDocker) {}
 
-    public static async initialize(config: ZkSolcConfig): Promise<ICompiler> {
+    public static async initialize(config: ZkSolcConfig): Promise<DockerCompiler> {
         await validateDockerIsInstalled();
 
         const image = dockerImage(config.settings.experimental?.dockerImage, config.settings.experimental?.tag);
@@ -54,5 +55,15 @@ export class DockerCompiler implements ICompiler {
 
     public async compile(input: CompilerInput, _config: ZkSolcConfig) {
         return await compileWithDocker(input, this.docker, this.dockerImage);
+    }
+
+    public async solcVersion() {
+        const versionOutput = await getSolcVersion(this.docker, this.dockerImage);
+        const longVersion = versionOutput.match(/^Version: (.*)$/)![1];
+        const version = longVersion.split('+')[0];
+        return {
+            version,
+            longVersion
+        }
     }
 }

--- a/packages/hardhat-zksync-vyper/package.json
+++ b/packages/hardhat-zksync-vyper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterlabs/hardhat-zksync-vyper",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Hardhat plugin to compile Vyper smart contracts for the zkSync network",
   "repository": "github:matter-labs/hardhat-zksync",
   "homepage": "https://github.com/matter-labs/hardhat-zksync/tree/main/packages/hardhat-zksync-vyper",

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,13 +428,13 @@
     glob "^8.0.1"
 
 "@matterlabs/hardhat-zksync-solc@link:packages/hardhat-zksync-solc":
-  version "0.3.7"
+  version "0.3.8"
   dependencies:
     "@nomiclabs/hardhat-docker" "^2.0.0"
     dockerode "^3.3.4"
 
 "@matterlabs/hardhat-zksync-vyper@link:packages/hardhat-zksync-vyper":
-  version "0.1.1"
+  version "0.1.2"
   dependencies:
     "@nomiclabs/hardhat-docker" "^2.0.0"
     dockerode "^3.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4468,11 +4468,6 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zksync-web3@^0.7.8:
-  version "0.7.9"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.7.9.tgz#fbb9a17f4b297c0fb9361de2a0d85ff2aac5becc"
-  integrity sha512-B0pitKvEQGJuWkY2UWjXrL1YgHghXEoDaq6acVZnB62TRF099GV58Fzi7Fnqt+Nw14A7Wc9iJ2AHD4GBTLFgkg==
-
 zksync-web3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.8.0.tgz#4a7d93cd59e03b241448088fff5eaa98d82bb26d"


### PR DESCRIPTION
Note that it's not in the actual contracts' artifacts, but rather in the build-info files and cache.