### PR TITLE
Fix cache invalidation

### DIFF
--- a/packages/hardhat-zksync-solc/package.json
+++ b/packages/hardhat-zksync-solc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterlabs/hardhat-zksync-solc",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Hardhat plugin to compile smart contracts for the zkSync network",
   "repository": "github:matter-labs/hardhat-zksync",
   "homepage": "https://github.com/matter-labs/hardhat-zksync/tree/main/packages/hardhat-zksync-solc",

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,7 +428,7 @@
     glob "^8.0.1"
 
 "@matterlabs/hardhat-zksync-solc@link:packages/hardhat-zksync-solc":
-  version "0.3.8"
+  version "0.3.9"
   dependencies:
     "@nomiclabs/hardhat-docker" "^2.0.0"
     dockerode "^3.3.4"


### PR DESCRIPTION
Turns out that if we try to save the correct `solcVersion` to `build-info` and `cache` when using docker, it results in a permanently invalid cache, since we change the `solcVersion` after checking the cache and before saving it. Since we can only get it after the compilation (from the artifacts), there is no way to prevent it.

Invalid cache means recompiling everything every time, which is suboptimal and results in a terrible UX.

Hence, the solution, unfortunately, is to save an invalid `solcVersion` when using docker (alongside the valid ones - `output.version`, `output.long_version` and `output.zk_version` which should be used if needed).

Still, when using binary `zksolc` releases, everything should work smoothly.