### PR TITLE
Implement integration testing and extend test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Run server
         run: |
           cd local-setup
-          ./start.sh &>../server.log &
+          mkdir -p ./volumes/postgres ./volumes/geth ./volumes/zksync/env/dev ./volumes/zksync/data
+          docker-compose pull
+          docker-compose up &>../server.log &
           sleep 30
 
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  compilation:
+  zksolc:
     strategy:
       matrix:
         solc: [0.8.16, 0.7.6, 0.4.22]
@@ -32,12 +32,27 @@ jobs:
         env:
           SOLC_VERSION: ${{ matrix.solc }}
 
+  zkvyper:
+    runs-on: ubuntu-latest
+    name: Compilation tests
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+
+      - name: Setup environment
+        run: |
+          yarn install
+
       - name: Test zkvyper compiler plugin
         run: |
           cd packages/hardhat-zksync-vyper
           yarn test
 
-  deployment:
+  deploy:
     runs-on: ubuntu-latest
     name: Deployment tests
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       matrix:
         solc: [0.8.16, 0.7.6, 0.4.22]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu, macos]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
 
-    name: Compilation tests
+    name: zksolc
     steps:
       - uses: actions/checkout@v2
 
@@ -34,7 +34,7 @@ jobs:
 
   zkvyper:
     runs-on: ubuntu-latest
-    name: Compilation tests
+    name: zkvyper
     steps:
       - uses: actions/checkout@v2
 
@@ -54,7 +54,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    name: Deployment tests
+    name: deploy
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Setup environment
         run: |
           yarn install
+          yarn build
 
       - name: Test zksolc example
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,7 @@ jobs:
       - name: Run server
         run: |
           cd local-setup
-          mkdir -p ./volumes/postgres ./volumes/geth ./volumes/zksync/env/dev ./volumes/zksync/data
-          docker-compose pull
-          docker-compose up &>../server.log &
-          sleep 60
+          ./start.sh &>../server.log &
 
       - uses: actions/setup-node@v2
         with:
@@ -57,6 +54,10 @@ jobs:
         run: |
           yarn install
           yarn build
+
+      - name: Wait until server is up
+        run: |
+          while ! curl -X POST -d '{"jsonrpc":"2.0","method":"net_version","id":1}' -H 'Content-Type: application/json' 0.0.0.0:3050; do sleep 1; done
 
       - name: Test zksolc example
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
 
 jobs:
-  test:
+  compilation:
     runs-on: ubuntu-latest
     name: Compilation tests
     steps:
@@ -28,3 +28,47 @@ jobs:
         run: |
           cd packages/hardhat-zksync-vyper
           yarn test
+
+  deployment:
+    runs-on: ubuntu-latest
+    name: Deployment tests
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: matter-labs/local-node
+          path: local-node
+
+      # `sleep 30` because we need to wait until server added all the tokens
+      - name: Run server
+        run: |
+          ./local-node/start.sh &>server.log &
+          sleep 30
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+
+      - name: Setup environment
+        run: |
+          yarn install
+
+      - name: Test zksolc example
+        run: |
+          cd examples/basic-example
+          yarn hardhat compile
+          yarn hardhat deploy-zksync
+
+      - name: Test zkvyper example
+        run: |
+          cd examples/vyper-example
+          yarn hardhat compile
+          yarn hardhat deploy-zksync
+
+      - name: Show logs
+        if: always()
+        run: |
+          cat server.log
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Wait until server is up
         run: |
-          while ! curl -X POST -d '{"jsonrpc":"2.0","method":"net_version","id":1}' -H 'Content-Type: application/json' 0.0.0.0:3050; do sleep 1; done
+          while ! curl -s -X POST -d '{"jsonrpc":"2.0","method":"net_version","id":1}' -H 'Content-Type: application/json' 0.0.0.0:3050; do sleep 1; done
 
       - name: Test zksolc example
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,13 @@ on:
 
 jobs:
   compilation:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        solc: [0.8.16, 0.7.6, 0.4.22]
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
     name: Compilation tests
     steps:
       - uses: actions/checkout@v2
@@ -23,6 +29,8 @@ jobs:
         run: |
           cd packages/hardhat-zksync-solc
           yarn test
+        env:
+          SOLC_VERSION: ${{ matrix.solc }}
 
       - name: Test zkvyper compiler plugin
         run: |
@@ -30,13 +38,7 @@ jobs:
           yarn test
 
   deployment:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        # solc: [0.8.16, 0.7.6]
-
-    runs-on: ${{ matrix.os }}
-
+    runs-on: ubuntu-latest
     name: Deployment tests
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,17 +34,17 @@ jobs:
     name: Deployment tests
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
         with:
-          repository: matter-labs/local-node
-          path: local-node
+          repository: matter-labs/local-setup
+          path: local-setup
 
       # `sleep 30` because we need to wait until server added all the tokens
       - name: Run server
         run: |
-          ./local-node/start.sh &>server.log &
+          ./local-setup/start.sh &>server.log &
           sleep 30
-
-      - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,13 @@ jobs:
           repository: matter-labs/local-setup
           path: local-setup
 
-      # `sleep 30` because we need to wait until server added all the tokens
       - name: Run server
         run: |
           cd local-setup
           mkdir -p ./volumes/postgres ./volumes/geth ./volumes/zksync/env/dev ./volumes/zksync/data
           docker-compose pull
           docker-compose up &>../server.log &
-          sleep 30
+          sleep 60
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
       # `sleep 30` because we need to wait until server added all the tokens
       - name: Run server
         run: |
-          ./local-setup/start.sh &>server.log &
+          cd local-setup
+          ./start.sh &>../server.log &
           sleep 30
 
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,13 @@ jobs:
           yarn test
 
   deployment:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        # solc: [0.8.16, 0.7.6]
+
+    runs-on: ${{ matrix.os }}
+
     name: Deployment tests
     steps:
       - uses: actions/checkout@v2

--- a/examples/basic-example/deploy/001_deploy.js
+++ b/examples/basic-example/deploy/001_deploy.js
@@ -39,5 +39,6 @@ module.exports = async function (hre) {
         console.log(`Contract greets us!`);
     } else {
         console.error(`Contract said something unexpected: ${greetingFromContract}`);
+        process.exit(1);
     }
 }

--- a/examples/basic-example/deploy/001_deploy.js
+++ b/examples/basic-example/deploy/001_deploy.js
@@ -38,7 +38,6 @@ module.exports = async function (hre) {
     if (greetingFromContract == greeting) {
         console.log(`Contract greets us!`);
     } else {
-        console.error(`Contract said something unexpected: ${greetingFromContract}`);
-        process.exit(1);
+        throw new Error(`Contract said something unexpected: ${greetingFromContract}`);
     }
 }

--- a/examples/basic-example/deploy/002_factory.ts
+++ b/examples/basic-example/deploy/002_factory.ts
@@ -43,5 +43,6 @@ export default async function (hre: HardhatRuntimeEnvironment) {
         console.log(`Factory contract deployed!`);
     } else {
         console.error(`Contract said something unexpected: ${greetingFromContract}`);
+        process.exit(1);
     }
 }

--- a/examples/basic-example/deploy/002_factory.ts
+++ b/examples/basic-example/deploy/002_factory.ts
@@ -42,7 +42,6 @@ export default async function (hre: HardhatRuntimeEnvironment) {
     if (greetingFromContract == 'Foo') {
         console.log(`Factory contract deployed!`);
     } else {
-        console.error(`Contract said something unexpected: ${greetingFromContract}`);
-        process.exit(1);
+        throw new Error(`Contract said something unexpected: ${greetingFromContract}`);
     }
 }

--- a/examples/basic-example/hardhat.config.ts
+++ b/examples/basic-example/hardhat.config.ts
@@ -8,8 +8,8 @@ const config: HardhatUserConfig = {
     compilerSource: "binary",
   },
   zkSyncDeploy: {
-    zkSyncNetwork: "http://127.0.0.1:3050",
-    ethNetwork: "http://127.0.0.1:8545",
+    zkSyncNetwork: "http://0.0.0.0:3050",
+    ethNetwork: "http://0.0.0.0:8545",
   },
   networks: {
     hardhat: {

--- a/examples/vyper-example/deploy/deploy.ts
+++ b/examples/vyper-example/deploy/deploy.ts
@@ -49,7 +49,6 @@ export default async function (hre: HardhatRuntimeEnvironment) {
     if (greeting == 'Hello world') {
         console.log(`Everything worked!`);
     } else {
-        console.error(`Contract said something unexpected: ${greeting}`);
-        process.exit(1);
+        throw new Error(`Contract said something unexpected: ${greeting}`);
     }
 }

--- a/examples/vyper-example/deploy/deploy.ts
+++ b/examples/vyper-example/deploy/deploy.ts
@@ -50,5 +50,6 @@ export default async function (hre: HardhatRuntimeEnvironment) {
         console.log(`Everything worked!`);
     } else {
         console.error(`Contract said something unexpected: ${greeting}`);
+        process.exit(1);
     }
 }

--- a/examples/vyper-example/hardhat.config.ts
+++ b/examples/vyper-example/hardhat.config.ts
@@ -9,8 +9,8 @@ const config: HardhatUserConfig = {
     compilerSource: "binary",
   },
   zkSyncDeploy: {
-    zkSyncNetwork: "http://127.0.0.1:3050",
-    ethNetwork: "http://127.0.0.1:8545",
+    zkSyncNetwork: "http://0.0.0.0:3050",
+    ethNetwork: "http://0.0.0.0:8545",
   },
   networks: {
     hardhat: {

--- a/packages/hardhat-zksync-solc/test/common.config.ts
+++ b/packages/hardhat-zksync-solc/test/common.config.ts
@@ -3,13 +3,8 @@ import { HardhatUserConfig } from 'hardhat/config';
 
 const config: HardhatUserConfig = {
   zksolc: {
-    compilerSource: "docker",
-    settings: {
-      experimental: {
-        dockerImage: "matterlabs/zksolc",
-        tag: "latest"
-      }
-    },
+    version: "1.1.6",
+    compilerSource: "binary",
   },
   networks: {
     hardhat: {
@@ -17,7 +12,7 @@ const config: HardhatUserConfig = {
     },
   },
   solidity: {
-    version: "0.8.12"
+    version: process.env.SOLC_VERSION || "0.8.12"
   }
 };
 

--- a/packages/hardhat-zksync-solc/test/fixture-projects/factory/contracts/Factory.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/factory/contracts/Factory.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-pragma abicoder v2;
+pragma solidity >=0.4.22 <0.9.0;
 
 contract Factory {
   address[] public ownContracts;

--- a/packages/hardhat-zksync-solc/test/fixture-projects/library/contracts/Foo.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/library/contracts/Foo.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 
 library Foo {

--- a/packages/hardhat-zksync-solc/test/fixture-projects/library/contracts/Import.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/library/contracts/Import.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 
 // import Foo.sol from current directory

--- a/packages/hardhat-zksync-solc/test/fixture-projects/linked/contracts/Foo.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/linked/contracts/Foo.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 
 library Foo {

--- a/packages/hardhat-zksync-solc/test/fixture-projects/linked/contracts/Import.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/linked/contracts/Import.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 
 // import Foo.sol from current directory

--- a/packages/hardhat-zksync-solc/test/fixture-projects/linked/hardhat.config.js
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/linked/hardhat.config.js
@@ -1,8 +1,10 @@
 const config = require('../../common.config').default;
 
-config.zksolc.settings.libraries = {
-    'contracts/Foo.sol': {
-        'Foo': '0x0123456789abcdef0123456789abcdef01234567'
+config.zksolc.settings = {
+    libraries: {
+        'contracts/Foo.sol': {
+            'Foo': '0x0123456789abcdef0123456789abcdef01234567'
+        }
     }
 }
 

--- a/packages/hardhat-zksync-solc/test/fixture-projects/nested/contracts/NestedFactory.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/nested/contracts/NestedFactory.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-pragma abicoder v2;
+pragma solidity >=0.4.22 <0.9.0;
 
 // import Foo.sol and Bar.sol from nested directories
 import "./deps/Foo.sol";

--- a/packages/hardhat-zksync-solc/test/fixture-projects/nested/contracts/deps/Foo.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/nested/contracts/deps/Foo.sol
@@ -1,13 +1,8 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-pragma abicoder v2;
+pragma solidity >=0.4.22 <0.9.0;
 
 contract FooDep {
-  function foo()
-    public
-    pure
-    returns (string memory)
-  {
+  function foo() public pure returns (string memory) {
     return "Foo";
   }    
 }

--- a/packages/hardhat-zksync-solc/test/fixture-projects/nested/contracts/deps/more_deps/Bar.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/nested/contracts/deps/more_deps/Bar.sol
@@ -1,13 +1,8 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-pragma abicoder v2;
+pragma solidity >=0.4.22 <0.9.0;
 
 contract BarDep {
-  function bar()
-    public
-    pure
-    returns (string memory)
-  {
+  function bar() public pure returns (string memory) {
     return "Bar";
   }    
 }

--- a/packages/hardhat-zksync-solc/test/fixture-projects/simple/contracts/Greeter.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/simple/contracts/Greeter.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
-pragma abicoder v2;
+pragma solidity >=0.4.22 <0.9.0;
 
 contract Greeter {
 

--- a/packages/hardhat-zksync-solc/test/tests.ts
+++ b/packages/hardhat-zksync-solc/test/tests.ts
@@ -24,6 +24,11 @@ describe('zksolc plugin', async function () {
         useEnvironment('library');
 
         it('Should successfully compile the contract with inlined library', async function () {
+            if (this.env.config.solidity.compilers[0].version.startsWith('0.4')) {
+                // This test is not applicable to Solidity 0.4.x.
+                console.log('skipped');
+                return
+            }
             await this.env.run(TASK_COMPILE);
             assert.equal(this.env.artifacts.readArtifactSync('contracts/Foo.sol:Foo').contractName, 'Foo');
             assert.equal(this.env.artifacts.readArtifactSync('contracts/Import.sol:Import').contractName, 'Import');
@@ -34,6 +39,11 @@ describe('zksolc plugin', async function () {
         useEnvironment('linked');
 
         it('Should successfully compile the contract with linked library', async function () {
+            if (this.env.config.solidity.compilers[0].version.startsWith('0.4')) {
+                // This test is not applicable to Solidity 0.4.x.
+                console.log('skipped');
+                return
+            }
             await this.env.run(TASK_COMPILE);
             assert.equal(this.env.artifacts.readArtifactSync('contracts/Foo.sol:Foo').contractName, 'Foo');
             assert.equal(this.env.artifacts.readArtifactSync('contracts/Import.sol:Import').contractName, 'Import');

--- a/packages/hardhat-zksync-vyper/test/tests.ts
+++ b/packages/hardhat-zksync-vyper/test/tests.ts
@@ -45,6 +45,10 @@ describe('zkvyper plugin', async function () {
 
             // For the dependency contract should be no further dependencies.
             assert.deepEqual(depArtifact.factoryDeps, {}, 'Unexpected factory-deps for a dependency contract');
+
+            // Check that the forwarder artifact was saved correctly.
+            const forwarderArtifact = this.env.artifacts.readArtifactSync(".__VYPER_FORWARDER_CONTRACT:__VYPER_FORWARDER_CONTRACT") as ZkSyncArtifact;
+            assert.equal(forwarderArtifact.contractName, "__VYPER_FORWARDER_CONTRACT");
         });
     });
 });


### PR DESCRIPTION
- Tests for `hardhat-zksync-solc` on both MacOS and Ubuntu, paired with `solc` v0.4 / v0.7 / v0.8.
- Tests for `hardhat-zksync-deploy` using this repo's examples and the [local-setup](https://github.com/matter-labs/local-setup) node.
- Some extra tests for `hardhat-zksync-vyper`.
