### PR TITLE
export some items from hardhat-zksync-solc

### DIFF
--- a/packages/hardhat-zksync-solc/package.json
+++ b/packages/hardhat-zksync-solc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterlabs/hardhat-zksync-solc",
-  "version": "0.3.14-beta.2",
+  "version": "0.3.14-beta.3",
   "description": "Hardhat plugin to compile smart contracts for the zkSync network",
   "repository": "github:matter-labs/hardhat-zksync",
   "homepage": "https://github.com/matter-labs/hardhat-zksync/tree/main/packages/hardhat-zksync-solc",

--- a/packages/hardhat-zksync-solc/src/constants.ts
+++ b/packages/hardhat-zksync-solc/src/constants.ts
@@ -2,6 +2,7 @@ import { ZkSolcConfig } from './types';
 
 export const PLUGIN_NAME = '@matterlabs/hardhat-zksync-solc';
 export const ZK_ARTIFACT_FORMAT_VERSION = 'hh-zksolc-artifact-1';
+export const ZKSOLC_BIN_REPOSITORY = 'https://github.com/matter-labs/zksolc-bin';
 export const LATEST_VERSION = '1.2.1';
 
 export const defaultZkSolcConfig: ZkSolcConfig = {

--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -180,8 +180,8 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, async (args: { solcVersion: string
                 hre.config.zksolc.version,
                 salt
             );
-            console.info(chalk.yellow(`Downloading zksolc from ${compilerUrl}`));
             if(!fs.existsSync(compilerPath)) {
+                console.info(chalk.yellow(`Downloading zksolc from ${compilerUrl}`));
                 try {
                     await download(compilerUrl, compilerPath);
                     console.info(chalk.green(`zksolc successfully downloaded`));

--- a/packages/hardhat-zksync-solc/src/utils.ts
+++ b/packages/hardhat-zksync-solc/src/utils.ts
@@ -42,14 +42,18 @@ export function sha1(str: string): string {
     return crypto.createHash('sha1').update(str).digest('hex');
 }
 
-export function getZksolcUrl(version: string): string {
+export function saltFromUrl(url: string): string {
+    return sha1(url);
+}
+
+export function getZksolcUrl(repo: string, version: string): string {
     // @ts-ignore
     const platform = { darwin: 'macosx', linux: 'linux', win32: 'windows' }[process.platform];
     // @ts-ignore
     const toolchain = { linux: '-musl', win32: '-gnu', darwin: '' }[process.platform];
     const arch = process.arch == 'x64' ? 'amd64' : process.arch;
     const ext = process.platform == 'win32' ? '.exe' : '';
-    return `https://github.com/matter-labs/zksolc-bin/raw/main/${platform}-${arch}/zksolc-${platform}-${arch}${toolchain}-v${version}${ext}`;
+    return `${repo}/raw/main/${platform}-${arch}/zksolc-${platform}-${arch}${toolchain}-v${version}${ext}`;
 }
 
 export function pluralize(n: number, singular: string, plural?: string) {


### PR DESCRIPTION
Besides exporting some needed items, it is also ensured that the compiler is not re-downloaded when not needed