### PR TITLE
hardhat-zksync-verify: propagate libraries to contract verification request

### DIFF
--- a/packages/hardhat-zksync-verify/package.json
+++ b/packages/hardhat-zksync-verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterlabs/hardhat-zksync-verify",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Hardhat plugin to verify smart contracts for the zkSync network",
   "repository": "github:matter-labs/hardhat-zksync",
   "homepage": "https://github.com/matter-labs/hardhat-zksync/tree/main/packages/hardhat-zksync-verify",

--- a/packages/hardhat-zksync-verify/src/plugin.ts
+++ b/packages/hardhat-zksync-verify/src/plugin.ts
@@ -4,6 +4,7 @@ import { isFullyQualifiedName, parseFullyQualifiedName } from 'hardhat/utils/con
 import { MULTIPLE_MATCHING_CONTRACTS, CONTRACT_NAME_NOT_FOUND, NO_MATCHING_CONTRACT } from './constants';
 import { Bytecode, extractMatchingContractInformation } from './solc/bytecode';
 import { ZkSyncVerifyPluginError } from './errors';
+import { Libraries } from './types';
 
 export async function inferContractArtifacts(
     artifacts: Artifacts,
@@ -68,12 +69,12 @@ Instead, this name was received: ${contractFQN}`
     }
 }
 
-export function getSolidityStandardJsonInput(resolvedFiles: ResolvedFile[]): any {
+export function getSolidityStandardJsonInput(resolvedFiles: ResolvedFile[], libraries: Libraries = {}): any {
     return {
         language: 'Solidity',
         sources: Object.fromEntries(
             resolvedFiles.map((file) => [file.sourceName, { content: file.content.rawContent }])
         ),
-        settings: { optimizer: { enabled: true } },
+        settings: { optimizer: { enabled: true }, libraries },
     };
 }

--- a/packages/hardhat-zksync-verify/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify/src/task-actions.ts
@@ -146,6 +146,7 @@ export async function verifyContract(
     await hre.run(TASK_VERIFY_VERIFY_MINIMUM_BUILD, {
         minimumBuild,
         contractInformation,
+        libraries,
         address,
         compilerZksolcVersion,
         solcVersion,
@@ -157,6 +158,7 @@ export async function verifyMinimumBuild(
     {
         minimumBuild,
         contractInformation,
+        libraries,
         address,
         compilerZksolcVersion,
         solcVersion,
@@ -181,7 +183,7 @@ export async function verifyMinimumBuild(
     if (minimumBuildContractBytecode === matchedBytecode) {
         const request: ZkSyncBlockExplorerVerifyRequest = {
             contractAddress: address,
-            sourceCode: getSolidityStandardJsonInput(dependencyGraph.getResolvedFiles()),
+            sourceCode: getSolidityStandardJsonInput(dependencyGraph.getResolvedFiles(), libraries),
             codeFormat: JSON_INPUT_CODE_FORMAT,
             contractName: contractInformation.contractName,
             compilerSolcVersion: solcVersion,

--- a/yarn.lock
+++ b/yarn.lock
@@ -423,7 +423,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@matterlabs/hardhat-zksync-deploy@link:packages/hardhat-zksync-deploy":
-  version "0.6.2"
+  version "0.6.3"
   dependencies:
     chalk "4.1.2"
 
@@ -434,14 +434,6 @@
     chalk "4.1.2"
     dockerode "^3.3.4"
 
-"@matterlabs/hardhat-zksync-verify@link:packages/hardhat-zksync-verify":
-  version "0.1.3"
-  dependencies:
-    "@matterlabs/hardhat-zksync-solc" "0.3.14"
-    axios "^1.3.4"
-    chalk "4.1.2"
-    dockerode "^3.3.4"
-
 "@matterlabs/hardhat-zksync-vyper@link:packages/hardhat-zksync-vyper":
   version "0.1.7"
   dependencies:
@@ -449,7 +441,7 @@
     chalk "4.1.2"
     dockerode "^3.3.4"
 
-"@matterlabs/zksync-contracts@^0.5.1", "@matterlabs/zksync-contracts@^0.5.2":
+"@matterlabs/zksync-contracts@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@matterlabs/zksync-contracts/-/zksync-contracts-0.5.2.tgz#1488c967f1d60ad9f00121a70d89a79f9a18dc01"
   integrity sha512-4hLKAsCGlTa/vC0u/j0rgX2TT5OV8cALNcxG5ismi2TqoTvx7I0kQUPEPl/AZshTb652Y0SMKJc6ayLJgolr1g==
@@ -759,12 +751,12 @@
     lodash "^4.17.11"
     semver "^6.3.0"
 
-"@openzeppelin/contracts-upgradeable@^4.8.0", "@openzeppelin/contracts-upgradeable@^4.8.2":
+"@openzeppelin/contracts-upgradeable@^4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.2.tgz#edef522bdbc46d478481391553bababdd2199e27"
   integrity sha512-zIggnBwemUmmt9IS73qxi+tumALxCY4QEs3zLCII78k0Gfse2hAOdAkuAeLUzvWUpneMUfFE5sGHzEUSTvn4Ag==
 
-"@openzeppelin/contracts@^4.8.0", "@openzeppelin/contracts@^4.8.2":
+"@openzeppelin/contracts@^4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.2.tgz#d815ade0027b50beb9bcca67143c6bcc3e3923d6"
   integrity sha512-kEUOgPQszC0fSYWpbh2kT94ltOJwj1qfT2DWo+zVttmGmf97JZ99LspePNaeeaLhCImaHVeBbjaQFZQn7+Zc5g==
@@ -2792,7 +2784,7 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-hardhat@^2.12.6, hardhat@^2.13.0:
+hardhat@^2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.13.0.tgz#d52a0ec9b733a651687e5b1c1b0ee9a11a30f3d0"
   integrity sha512-ZlzBOLML1QGlm6JWyVAG8lVTEAoOaVm1in/RU2zoGAnYEoD1Rp4T+ZMvrLNhHaaeS9hfjJ1gJUBfiDr4cx+htQ==


### PR DESCRIPTION
As shown in the [documentation](https://era.zksync.io/docs/api/hardhat/compiling-libraries.html#openzeppelin-utility-libraries), non-inlinable libraries have to be specified in `hardhat.config.ts`.

Their deployment works well; however, when it comes to verifying contracts deployed with such settings, the verification fails as the libraries' settings are incorrectly propagated along the way.

**This PR fixes this so that the verification works for all contracts (i.e., containing non-inlinable libs and the regular ones.)**

_Note: it has been tested from the CLI and programmatically, making the following snippet compatible:_

```typescript
  await deployer.hre.run("verify:verify", {
    address: contractAddress,
    contract: contractFullyQualifiedName,
    constructorArguments: constructorArguments,
    libraries: {
      "contracts/CustomLib.sol": {
        CustomLib: customLibAddress,
      },
      // ...
    },
  });
```