### PR TITLE
Bugfix: hre.network.config.zksync

### DIFF
--- a/packages/hardhat-zksync-deploy/src/deployer.ts
+++ b/packages/hardhat-zksync-deploy/src/deployer.ts
@@ -44,7 +44,7 @@ export class Deployer {
     } {
         const networkName = network.name;
 
-        if (!network.zksync) {
+        if (!network.config.zksync) {
             throw new ZkSyncDeployPluginError(
                 `Only deploying to zkSync network is supported.\nNetwork '${networkName}' in 'hardhat.config' needs to have 'zksync' flag set to 'true'.`
             );


### PR DESCRIPTION
The zksync property of the defaultNetwork is stored in .config, otherwise one cannot create a new instance of Deployer() as it always throws the ZkSyncDeployPluginError(only deploying on zksync is supported)

Please contact me if this is not a bug, I cannot get to create an istance of this Class in my code.