### PR TITLE
fix: add no compile flag to hardhat verify

### DIFF
--- a/.changeset/orange-years-sip.md
+++ b/.changeset/orange-years-sip.md
@@ -1,0 +1,5 @@
+---
+"@matterlabs/hardhat-zksync-verify": patch
+---
+
+Add noCompile flag to the contract verification script to not recompile the contracts before sending verification request

--- a/packages/hardhat-zksync-verify/package.json
+++ b/packages/hardhat-zksync-verify/package.json
@@ -32,8 +32,9 @@
     "README.md"
   ],
   "dependencies": {
-    "axios": "^1.4.0",
     "@matterlabs/hardhat-zksync-solc": "0.4.1",
+    "@nomicfoundation/hardhat-verify": "^1.0.2",
+    "axios": "^1.4.0",
     "chalk": "4.1.2",
     "dockerode": "^3.3.4"
   },

--- a/packages/hardhat-zksync-verify/src/index.ts
+++ b/packages/hardhat-zksync-verify/src/index.ts
@@ -21,7 +21,9 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
     hre.network.verifyURL = hre.network.config.verifyURL ?? TESTNET_VERIFY_URL;
 });
 
-task(TASK_VERIFY, 'Verifies contract on Ethereum and zkSync networks').setAction(verify);
+task(TASK_VERIFY, 'Verifies contract on Ethereum and zkSync networks')
+    .addFlag("noCompile", "Run verify without compile")
+    .setAction(verify);
 
 subtask(TASK_VERIFY_VERIFY).setAction(verifyContract);
 

--- a/packages/hardhat-zksync-verify/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify/src/task-actions.ts
@@ -41,6 +41,7 @@ export async function verify(
         contract: string;
         constructorArgsParams: any[];
         libraries: string;
+        noCompile: boolean;
     },
     hre: HardhatRuntimeEnvironment,
     runSuper: RunSuperFunction<TaskArguments>
@@ -69,6 +70,7 @@ export async function verify(
         constructorArguments: constructorArguments,
         contract: args.contract,
         libraries,
+        noCompile: args.noCompile,
     });
 }
 

--- a/packages/hardhat-zksync-verify/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify/src/task-actions.ts
@@ -120,7 +120,7 @@ export async function getConstructorArguments(
 }
 
 export async function verifyContract(
-    { address, contract: contractFQN, constructorArguments, libraries }: TaskArguments,
+    { address, contract: contractFQN, constructorArguments, libraries, noCompile }: TaskArguments,
     hre: HardhatRuntimeEnvironment,
     runSuper: RunSuperFunction<TaskArguments>
 ): Promise<number> {
@@ -138,7 +138,9 @@ export async function verifyContract(
 
     const compilerVersions: string[] = await hre.run(TASK_VERIFY_GET_COMPILER_VERSIONS);
 
-    await hre.run(TASK_COMPILE, { quiet: true });
+    if (!noCompile) {
+        await hre.run(TASK_COMPILE, { quiet: true });
+    }
 
     const contractInformation: ContractInformation = await hre.run(TASK_VERIFY_GET_CONTRACT_INFORMATION, {
         contractFQN: contractFQN,

--- a/packages/hardhat-zksync-verify/src/types.ts
+++ b/packages/hardhat-zksync-verify/src/types.ts
@@ -18,7 +18,10 @@ export interface VerificationArgs {
     libraries?: string;
 
     // --list-networks flag
-    listNetworks: boolean;
+    listNetworks?: boolean;
+
+    // Do not compile contracts before verifying
+    noCompile?: boolean;
 }
 
 export interface Libraries {


### PR DESCRIPTION
This adds `noCompile` flag to the contract verification script to not recompile the contracts before sending verification request.
Made similar as in etherscan: https://github.com/NomicFoundation/hardhat/pull/3372

Also moved: `@nomicfoundation/hardhat-verify` from devDependencies to dependencies, because it is used in production build as well and causes a runtime error.