### PR TITLE
fix: use min ^4.6.0 version of @openzeppelin/contracts-upgradeable to avoid conflicts

### DIFF
--- a/packages/hardhat-zksync-upgradable/package.json
+++ b/packages/hardhat-zksync-upgradable/package.json
@@ -42,7 +42,7 @@
     "@matterlabs/hardhat-zksync-deploy": "^0.6.3",
     "@matterlabs/hardhat-zksync-solc": "^0.4.0",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
-    "@openzeppelin/contracts-upgradeable": "^4.9.2",
+    "@openzeppelin/contracts-upgradeable": "^4.6.0",
     "@openzeppelin/hardhat-upgrades": "^1.22.1",
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^18.11.17",
@@ -63,7 +63,7 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@openzeppelin/contracts-upgradeable": "^4.9.2"
+    "@openzeppelin/contracts-upgradeable": "^4.6.0"
   },
   "prettier": {
     "tabWidth": 4,

--- a/yarn.lock
+++ b/yarn.lock
@@ -719,7 +719,7 @@
     ts-morph "^19.0.0"
 
 "@matterlabs/hardhat-zksync-node@link:packages/hardhat-zksync-node":
-  version "0.0.1-beta.1"
+  version "0.0.1-beta.4"
   dependencies:
     "@matterlabs/hardhat-zksync-solc" "0.4.2"
     axios "^1.4.0"
@@ -959,10 +959,10 @@
     deep-eql "^4.0.1"
     ordinal "^1.0.3"
 
-"@nomicfoundation/hardhat-verify@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-1.0.2.tgz#f84b9dfcb9478ed9cd1b360b6d12b7f4d8872881"
-  integrity sha512-IBEWGY9EtXhVTChTmA83m/Nd9VZ/u/bCU2SZkF6c01QbQB7qcimzY1V35hiFcpJLVZ39rV8J2rmedVdfXB+99w==
+"@nomicfoundation/hardhat-verify@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.0.tgz#aa5b26827b67e3b82dae595167b32979c527fc39"
+  integrity sha512-DlzeYWcPtcD82AD1wSsmjPjrbuESSKlY5XMvUYnr5YMQc81yGUc++U3M7ghHo0JSnZEUhXq+hDc8/HkpOZ6h8A==
   dependencies:
     "@ethersproject/abi" "^5.1.2"
     "@ethersproject/address" "^5.0.2"
@@ -1092,6 +1092,11 @@
   integrity sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==
   dependencies:
     which "^3.0.0"
+
+"@openzeppelin/contracts-upgradeable@^4.6.0":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.3.tgz#ff17a80fb945f5102571f8efecb5ce5915cc4811"
+  integrity sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A==
 
 "@openzeppelin/contracts-upgradeable@^4.9.2":
   version "4.9.2"


### PR DESCRIPTION
If I want to have `@matterlabs/zksync-contracts` and `@matterlabs/hardhat-zksync-upgradable` in my project atm `npm i` fails without `--force` as `@matterlabs/zksync-contracts`  has `@openzeppelin/contracts` peer dependency `v4.6.0` and `@matterlabs/hardhat-zksync-upgradable` requires at least `v4.9.2`.

As we can't update `@openzeppelin/contracts` version in `@matterlabs/zksync-contracts` now (first we need to upgrade it for our bridge), this PR is to allow minimum `^v4.6.0`. for `@matterlabs/hardhat-zksync-upgradable`.