### PR TITLE
chore(hardhat-zksync-solc): update solc compiler info file from release

### DIFF
--- a/.changeset/gentle-tools-press.md
+++ b/.changeset/gentle-tools-press.md
@@ -1,0 +1,5 @@
+---
+"@matterlabs/hardhat-zksync-solc": patch
+---
+
+Fetch compiler version info from the latest release

--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -3,7 +3,7 @@ import fsExtra from "fs-extra";
 import chalk from "chalk";
 import { spawnSync } from 'child_process';
 
-import { download, getZksolcUrl, isURL, isVersionInRange, saltFromUrl, saveDataToFile } from "../utils";
+import { download, getRelease, getZksolcUrl, isURL, isVersionInRange, saltFromUrl, saveDataToFile } from "../utils";
 import { 
     COMPILER_BINARY_CORRUPTION_ERROR, 
     COMPILER_VERSION_INFO_FILE_DOWNLOAD_ERROR, 
@@ -11,11 +11,12 @@ import {
     COMPILER_VERSION_RANGE_ERROR, 
     COMPILER_VERSION_WARNING, 
     DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD, 
-    ZKSOLC_BIN_REPOSITORY, 
-    ZKSOLC_BIN_VERSION_INFO, 
-    ZKSOLC_BIN_CDN_VERSION_INFO,
+    ZKSOLC_BIN_REPOSITORY,
     DEFAULT_TIMEOUT_MILISECONDS,
-    ZKSOLC_COMPILER_VERSION_INFO_DATA} from "../constants";
+    ZKSOLC_COMPILER_VERSION_MIN_VERSION,
+    ZKSOLC_BIN_OWNER,
+    ZKSOLC_BIN_REPOSITORY_NAME,
+    PLUGIN_NAME} from "../constants";
 import { ZkSyncSolcPluginError } from './../errors';
 
 export interface CompilerVersionInfo {
@@ -157,17 +158,14 @@ export class ZksolcCompilerDownloader {
         We are currently limited in that each new version requires an update of the plugin version.
     */
     private static async _downloadCompilerVersionInfo(compilersDir: string): Promise<void> {
-        /*const downloadPath = this._getCompilerVersionInfoPath(compilersDir);
-        const rawUrl = `${ZKSOLC_BIN_VERSION_INFO}/version.json`;
-        const cdnUrl = `${ZKSOLC_BIN_CDN_VERSION_INFO}/version.json`;
-        try {
-            await download(cdnUrl, downloadPath, 'hardhat-zksync', 'compiler-version-info', DEFAULT_TIMEOUT_MILISECONDS);
-        } catch (error) {
-            await download(rawUrl, downloadPath, 'hardhat-zksync', 'compiler-version-info', DEFAULT_TIMEOUT_MILISECONDS);
-        }*/
-        
+        const realease = await getRelease(ZKSOLC_BIN_OWNER, ZKSOLC_BIN_REPOSITORY_NAME, PLUGIN_NAME);
+
+        const releaseToSave = {
+            latest: realease.tag_name.slice(1, realease.tag_name.length),
+            minVersion: ZKSOLC_COMPILER_VERSION_MIN_VERSION
+        }
         const savePath = this._getCompilerVersionInfoPath(compilersDir);
-        await saveDataToFile(ZKSOLC_COMPILER_VERSION_INFO_DATA, savePath);
+        await saveDataToFile(releaseToSave, savePath);
     }
 
     private async _downloadCompiler(): Promise<string> {

--- a/packages/hardhat-zksync-solc/src/constants.ts
+++ b/packages/hardhat-zksync-solc/src/constants.ts
@@ -3,8 +3,6 @@ import { ZkSolcConfig } from './types';
 export const PLUGIN_NAME = '@matterlabs/hardhat-zksync-solc';
 export const ZK_ARTIFACT_FORMAT_VERSION = 'hh-zksolc-artifact-1';
 export const ZKSOLC_BIN_REPOSITORY = 'https://github.com/matter-labs/zksolc-bin';
-export const ZKSOLC_BIN_VERSION_INFO = `https://raw.githubusercontent.com/matter-labs/zksolc-bin/main`;
-export const ZKSOLC_BIN_CDN_VERSION_INFO = `https://cdn.jsdelivr.net/gh/matter-labs/zksolc-bin`;
 export const DEFAULT_TIMEOUT_MILISECONDS = 30000;
 export const DETECT_MISSING_LIBRARY_MODE_COMPILER_VERSION = '1.3.14';
 
@@ -34,10 +32,9 @@ export const ZKSOLC_COMPILERS_SELECTOR_MAP = {
     ]
 };
 
-export const ZKSOLC_COMPILER_VERSION_INFO_DATA = {
-    "latest": "1.3.17",
-    "minVersion": "1.3.13"
-};
+export const ZKSOLC_COMPILER_VERSION_MIN_VERSION = "1.3.13";
+export const ZKSOLC_BIN_OWNER = 'matter-labs';
+export const ZKSOLC_BIN_REPOSITORY_NAME = 'zksolc-bin';
 
 export const DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD = 24 * 60 * 60 * 1000; // 24 hours
 


### PR DESCRIPTION
# What :computer: 
* Latest compiler info we fetch from latest release and min version we get from plugin.

# Why :hand:
* We don't want to use the version.json file from zksolc-bin repo.