### PR TITLE
chore(hardhat-zksync-vyper): update vyper compiler info file from rel…

### DIFF
--- a/.changeset/twenty-timers-visit.md
+++ b/.changeset/twenty-timers-visit.md
@@ -1,0 +1,5 @@
+---
+"@matterlabs/hardhat-zksync-vyper": patch
+---
+
+Fetch compiler version info from the latest release

--- a/packages/hardhat-zksync-vyper/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/downloader.ts
@@ -3,19 +3,20 @@ import fsExtra from "fs-extra";
 import chalk from "chalk";
 import { spawnSync } from 'child_process';
 
-import { download, getZkvyperUrl, isURL, isVersionInRange, saveDataToFile } from "../utils";
+import { download, getRelease, getZkvyperUrl, isURL, isVersionInRange, saveDataToFile } from "../utils";
 import { 
     COMPILER_BINARY_CORRUPTION_ERROR, 
-    COMPILER_VERSION_INFO_DATA, 
     COMPILER_VERSION_INFO_FILE_DOWNLOAD_ERROR, 
     COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR, 
     COMPILER_VERSION_RANGE_ERROR, 
     COMPILER_VERSION_WARNING, 
     DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD, 
     DEFAULT_TIMEOUT_MILISECONDS, 
-    ZKVYPER_BIN_CDN_VERSION_INFO, 
+    PLUGIN_NAME, 
+    ZKVYPER_BIN_OWNER, 
     ZKVYPER_BIN_REPOSITORY, 
-    ZKVYPER_BIN_VERSION_INFO, 
+    ZKVYPER_BIN_REPOSITORY_NAME, 
+    ZKVYPER_COMPILER_VERSION_MIN_VERSION, 
 } from "../constants";
 import { ZkSyncVyperPluginError } from "../errors";
 
@@ -146,16 +147,14 @@ export class ZkVyperCompilerDownloader {
     }
 
     private static async _downloadCompilerVersionInfo(compilersDir: string): Promise<void> {
-        const downloadPath = this._getCompilerVersionInfoPath(compilersDir);
-        await saveDataToFile(COMPILER_VERSION_INFO_DATA,downloadPath);
-        //const rawUrl = `${ZKVYPER_BIN_VERSION_INFO}/version.json`;
-        //const cdnUrl = `${ZKVYPER_BIN_CDN_VERSION_INFO}/version.json`
-        //try{
-        //    await download(cdnUrl,downloadPath,'hardhat-zksync-zkvyper', 'compiler-version-info',DEFAULT_TIMEOUT_MILISECONDS)
-        //}catch(error){
-        //    await download(rawUrl, downloadPath,'hardhat-zksync-zkvyper', 'compiler-version-info', DEFAULT_TIMEOUT_MILISECONDS);
-        //}
+        const realease = await getRelease(ZKVYPER_BIN_OWNER, ZKVYPER_BIN_REPOSITORY_NAME, PLUGIN_NAME);
 
+        const releaseToSave = {
+            latest: realease.tag_name.slice(1, realease.tag_name.length),
+            minVersion: ZKVYPER_COMPILER_VERSION_MIN_VERSION
+        }
+        const savePath = this._getCompilerVersionInfoPath(compilersDir);
+        await saveDataToFile(releaseToSave, savePath);
     }
 
     private async _downloadCompiler(): Promise<string> {

--- a/packages/hardhat-zksync-vyper/src/constants.ts
+++ b/packages/hardhat-zksync-vyper/src/constants.ts
@@ -3,8 +3,6 @@ import { ZkVyperConfig } from './types';
 export const PLUGIN_NAME = '@matterlabs/hardhat-zksync-vyper';
 export const SOLIDITY_EXTENSION = '.sol';
 export const ZKVYPER_BIN_REPOSITORY = 'https://github.com/matter-labs/zkvyper-bin';
-export const ZKVYPER_BIN_VERSION_INFO = `https://raw.githubusercontent.com/matter-labs/zkvyper-bin/main`;
-export const ZKVYPER_BIN_CDN_VERSION_INFO = `https://cdn.jsdelivr.net/gh/matter-labs/zkvyper-bin`;
 export const DEFAULT_TIMEOUT_MILISECONDS = 30000;
 export const TASK_COMPILE_VYPER_CHECK_ERRORS = 'compile:vyper:check-errors';
 export const TASK_COMPILE_VYPER_LOG_COMPILATION_ERRORS = 'compile:vyper:log:compilation-errors';
@@ -28,6 +26,11 @@ export const UNSUPPORTED_VYPER_VERSIONS = [
     '0.3.7',
 ];
 
+export const ZKVYPER_COMPILER_VERSION_MIN_VERSION = "1.3.9";
+
+export const ZKVYPER_BIN_OWNER = 'matter-labs';
+export const ZKVYPER_BIN_REPOSITORY_NAME = 'zkvyper-bin';
+
 export const DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD = 24 * 60 * 60 * 1000; // 24 hours
 
 export const COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR = 'Could not find zkvyper compiler version info file. Please check your internet connection and try again.';
@@ -39,8 +42,3 @@ export const COMPILER_BINARY_CORRUPTION_ERROR = (compilerPath: string) => `The z
 export const COMPILING_INFO_MESSAGE = (zksolcVersion: string, solcVersion: string) => `Compiling contracts for zkSync Era with zkvyper v${zksolcVersion} and vyper v${solcVersion}`;
 
 export const VYPER_VERSION_ERROR = 'Vyper versions 0.3.4 to 0.3.7 are not supported by zkvyper. Please use vyper 0.3.3 or >=0.3.8 in your hardhat.config file instead.'
-
-export const COMPILER_VERSION_INFO_DATA = {
-    "latest": "1.3.13",
-    "minVersion": "1.3.9"
-}


### PR DESCRIPTION
…ease

# What :computer: 
* Latest compiler info we fetch from latest release and min version we get from plugin.

# Why :hand:
* We don't want to use the version.json file from zkvyper-bin repo.