### PR TITLE
refactor(hardhat-zksync-deploy): Add support for Sepolia testnet

### DIFF
--- a/.changeset/real-cooks-end.md
+++ b/.changeset/real-cooks-end.md
@@ -1,0 +1,5 @@
+---
+"@matterlabs/hardhat-zksync-deploy": patch
+---
+
+Added support for Sepolia testnet.

--- a/examples/basic-example/package.json
+++ b/examples/basic-example/package.json
@@ -32,7 +32,7 @@
     "chalk": "4.1.2",
     "hardhat": "^2.18.1",
     "ethers": "^6.7.1",
-    "zksync2-js": "^0.2.2",
+    "zksync2-js": "^0.4.0",
     "@matterlabs/zksync-contracts": "^0.6.1",
     "@openzeppelin/contracts": "^4.9.2",
     "@openzeppelin/contracts-upgradeable": "^4.9.2"

--- a/examples/mixed-example/package.json
+++ b/examples/mixed-example/package.json
@@ -33,7 +33,7 @@
     "@nomiclabs/hardhat-vyper": "^3.0.5",
     "ethers": "^6.7.1",
     "hardhat": "^2.18.1",
-    "zksync2-js": "^0.2.2"
+    "zksync2-js": "^0.4.0"
   },
   "prettier": {
     "tabWidth": 4,

--- a/examples/node-example/package.json
+++ b/examples/node-example/package.json
@@ -38,7 +38,7 @@
     "chalk": "4.1.2",
     "hardhat": "^2.18.1",
     "ethers": "^6.7.1",
-    "zksync2-js": "^0.2.2",
+    "zksync2-js": "^0.4.0",
     "@matterlabs/zksync-contracts": "^0.6.1",
     "@openzeppelin/contracts": "^4.9.2",
     "@openzeppelin/contracts-upgradeable": "^4.9.2"

--- a/examples/noninline-libraries-example/package.json
+++ b/examples/noninline-libraries-example/package.json
@@ -32,7 +32,7 @@
       "chalk": "4.1.2",
       "hardhat": "^2.18.1",
       "ethers": "^6.7.1",
-      "zksync2-js": "^0.2.2",
+      "zksync2-js": "^0.4.0",
       "@matterlabs/zksync-contracts": "^0.6.1",
       "@openzeppelin/contracts": "^4.9.2",
       "@openzeppelin/contracts-upgradeable": "^4.9.2"

--- a/examples/verify-example/package.json
+++ b/examples/verify-example/package.json
@@ -33,7 +33,7 @@
     "chalk": "4.1.2",
     "hardhat": "^2.18.1",
     "ethers": "^6.7.1",
-    "zksync2-js": "^0.2.2"
+    "zksync2-js": "^0.4.0"
   },
   "prettier": {
     "tabWidth": 4,

--- a/examples/vyper-example/package.json
+++ b/examples/vyper-example/package.json
@@ -32,7 +32,7 @@
     "@nomiclabs/hardhat-vyper": "^3.0.5",
     "ethers": "^6.7.1",
     "hardhat": "^2.18.1",
-    "zksync2-js": "^0.2.2"
+    "zksync2-js": "^0.4.0"
   },
   "prettier": {
     "tabWidth": 4,

--- a/examples/zksync2js-example/package.json
+++ b/examples/zksync2js-example/package.json
@@ -33,7 +33,7 @@
     "chalk": "4.1.2",
     "hardhat": "^2.18.1",
     "ethers": "^6.7.1",
-    "zksync2-js": "^0.2.2"
+    "zksync2-js": "^0.4.0"
   },
   "prettier": {
     "tabWidth": 4,

--- a/packages/hardhat-zksync-chai-matchers/package.json
+++ b/packages/hardhat-zksync-chai-matchers/package.json
@@ -59,7 +59,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.6.0",
     "typescript": "^5.1.6",
-    "zksync2-js": "^0.2.2",
+    "zksync2-js": "^0.4.0",
     "@matterlabs/zksync-contracts": "^0.6.1",
     "@openzeppelin/contracts": "^4.8.3"
   },

--- a/packages/hardhat-zksync-deploy/package.json
+++ b/packages/hardhat-zksync-deploy/package.json
@@ -54,12 +54,12 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.6.0",
     "typescript": "^5.1.6",
-    "zksync2-js": "^0.2.2"
+    "zksync2-js": "^0.4.0"
   },
   "peerDependencies": {
     "ethers": "^6.7.1",
     "hardhat": "^2.18.1",
-    "zksync2-js": "^0.2.2"
+    "zksync2-js": "^0.4.0"
   },
   "prettier": {
     "tabWidth": 4,

--- a/packages/hardhat-zksync-deploy/src/deployer.ts
+++ b/packages/hardhat-zksync-deploy/src/deployer.ts
@@ -9,7 +9,7 @@ import { isHttpNetworkConfig } from './utils';
 
 const ZKSOLC_ARTIFACT_FORMAT_VERSION = 'hh-zksolc-artifact-1';
 const ZKVYPER_ARTIFACT_FORMAT_VERSION = 'hh-zkvyper-artifact-1';
-const SUPPORTED_L1_TESTNETS = ['mainnet', 'rinkeby', 'ropsten', 'kovan', 'goerli'];
+const SUPPORTED_L1_TESTNETS = ['mainnet', 'rinkeby', 'ropsten', 'kovan', 'goerli','sepolia'];
 
 /**
  * An entity capable of deploying contracts to the zkSync network.
@@ -89,7 +89,7 @@ export class Deployer {
             ethWeb3Provider =
                 ethNetwork === 'localhost'
                     ? this._createDefaultEthProvider()
-                    : new ethers.JsonRpcProvider(ethNetwork);
+                    : new ethers.JsonRpcProvider((networks[ethNetwork] as HttpNetworkConfig).url);
         }
 
         zkWeb3Provider = new zk.Provider((network.config as HttpNetworkConfig).url);

--- a/packages/hardhat-zksync-deploy/src/plugin.ts
+++ b/packages/hardhat-zksync-deploy/src/plugin.ts
@@ -182,7 +182,7 @@ async function deployOneLibrary(
 
     console.info(chalk.yellow(`Deploying ${generateFullQuailfiedNameString(contractFQN)} .....`));
     const contract = await deployer.deploy(artifact, []);
-    console.info(chalk.green(`Deployed ${generateFullQuailfiedNameString(contractFQN)} at ${contract.address}`));
+    console.info(chalk.green(`Deployed ${generateFullQuailfiedNameString(contractFQN)} at ${await contract.getAddress()}`));
 
     const contractInfo:ContractInfo = {
         contractFQN,

--- a/packages/hardhat-zksync-node/package.json
+++ b/packages/hardhat-zksync-node/package.json
@@ -60,11 +60,11 @@
     "sinon-chai": "^3.7.0",
     "ts-node": "^10.6.0",
     "typescript": "^5.1.6",
-    "zksync2-js": "^0.2.0"
+    "zksync2-js": "^0.4.0"
   },
   "peerDependencies": {
     "hardhat": "^2.18.1",
-    "zksync2-js": "^0.2.0"
+    "zksync2-js": "^0.4.0"
   },
   "prettier": {
     "tabWidth": 4,

--- a/packages/hardhat-zksync-toolbox/package.json
+++ b/packages/hardhat-zksync-toolbox/package.json
@@ -56,7 +56,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.6.0",
     "typescript": "^5.1.6",
-    "zksync2-js": "^0.2.2"
+    "zksync2-js": "^0.4.0"
   },
   "peerDependencies": {
     "@matterlabs/hardhat-zksync-chai-matchers": "^1.0.0",

--- a/packages/hardhat-zksync-verify-vyper/package.json
+++ b/packages/hardhat-zksync-verify-vyper/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "@matterlabs/hardhat-zksync-vyper": "^1.0.0",
     "axios": "^1.4.0",
-    "chalk": "4.1.2"
+    "chalk": "4.1.2",
+    "zksync2-js":"^0.4.0"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-vyper": "^3.0.5",

--- a/packages/hardhat-zksync-verify/package.json
+++ b/packages/hardhat-zksync-verify/package.json
@@ -35,7 +35,8 @@
     "@matterlabs/hardhat-zksync-solc": "^1.0.0",
     "@nomicfoundation/hardhat-verify": "^2.0.0",
     "axios": "^1.4.0",
-    "chalk": "4.1.2"
+    "chalk": "4.1.2",
+    "zksync2-js":"^0.4.0"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-verify": "^2.0.0",

--- a/packages/hardhat-zksync-zksync2js/package.json
+++ b/packages/hardhat-zksync-zksync2js/package.json
@@ -57,12 +57,12 @@
     "sinon": "^9.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",
-    "zksync2-js": "^0.2.2",
+    "zksync2-js": "^0.4.0",
     "rlp": "3.0.0",
     "ethers": "^6.7.1"
   },
   "peerDependencies": {
-    "zksync2-js": "^0.2.2",
+    "zksync2-js": "^0.4.0",
     "ethers": "^6.7.1"
   },
   "prettier": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -794,17 +794,6 @@
     chalk "4.1.2"
     fs-extra "^11.1.1"
 
-"@matterlabs/hardhat-zksync-solc@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-0.4.1.tgz#e8e67d947098d7bb8925f968544d34e522af5a9c"
-  integrity sha512-fdlGf/2yZR5ihVNc2ubea1R/nNFXRONL29Fgz5FwB3azB13rPb76fkQgcFIg9zSufHsEy6zUUT029NkxLNA9Sw==
-  dependencies:
-    "@nomiclabs/hardhat-docker" "^2.0.0"
-    chalk "4.1.2"
-    dockerode "^3.3.4"
-    fs-extra "^11.1.1"
-    semver "^7.5.1"
-
 "@matterlabs/hardhat-zksync-solc@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-1.0.0.tgz#4da54b59fb4fa9c2ba22a3bb2e6150cf1d70028c"
@@ -818,7 +807,7 @@
     semver "^7.5.1"
 
 "@matterlabs/hardhat-zksync-solc@link:packages/hardhat-zksync-solc":
-  version "1.0.1"
+  version "1.0.3"
   dependencies:
     "@nomiclabs/hardhat-docker" "^2.0.0"
     chalk "4.1.2"
@@ -835,15 +824,15 @@
     "@openzeppelin/upgrades-core" "^1.31.0"
 
 "@matterlabs/hardhat-zksync-verify@link:packages/hardhat-zksync-verify":
-  version "1.0.0"
+  version "1.1.0"
   dependencies:
-    "@matterlabs/hardhat-zksync-solc" "0.4.1"
-    "@nomicfoundation/hardhat-verify" "^1.1.1"
+    "@matterlabs/hardhat-zksync-solc" "^1.0.0"
+    "@nomicfoundation/hardhat-verify" "^2.0.0"
     axios "^1.4.0"
     chalk "4.1.2"
 
 "@matterlabs/hardhat-zksync-vyper@link:packages/hardhat-zksync-vyper":
-  version "1.0.0"
+  version "1.0.3"
   dependencies:
     "@nomiclabs/hardhat-docker" "^2.0.0"
     chalk "4.1.2"
@@ -1067,10 +1056,10 @@
     debug "^4.1.1"
     lodash.isequal "^4.5.0"
 
-"@nomicfoundation/hardhat-verify@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-1.1.1.tgz#6a433d777ce0172d1f0edf7f2d3e1df14b3ecfc1"
-  integrity sha512-9QsTYD7pcZaQFEA3tBb/D/oCStYDiEVDN7Dxeo/4SCyHRSm86APypxxdOMEPlGmXsAvd+p1j/dTODcpxb8aztA==
+"@nomicfoundation/hardhat-verify@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.1.tgz#1b9d707516f8e5db4e1d6bd679acbfd71e567928"
+  integrity sha512-TuJrhW5p9x92wDRiRhNkGQ/wzRmOkfCLkoRg8+IRxyeLigOALbayQEmkNiGWR03vGlxZS4znXhKI7y97JwZ6Og==
   dependencies:
     "@ethersproject/abi" "^5.1.2"
     "@ethersproject/address" "^5.0.2"
@@ -7491,15 +7480,10 @@ zksync-crypto@^0.6.1:
   resolved "https://registry.yarnpkg.com/zksync-crypto/-/zksync-crypto-0.6.2.tgz#319dc9b1a274c1c8feaa40f81636ef326eb2c28b"
   integrity sha512-Ry8c9kixDu3rlGCZDOg1UhzKDYe93iOZ7/Z6N1bkkrVKhmZJTIc7h+1kOjOyyhaSaHwBt8quMeBAaZKjtUeB2Q==
 
-zksync-web3@^0.14.3:
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.14.4.tgz#0b70a7e1a9d45cc57c0971736079185746d46b1f"
-  integrity sha512-kYehMD/S6Uhe1g434UnaMN+sBr9nQm23Ywn0EUP5BfQCsbjcr3ORuS68PosZw8xUTu3pac7G6YMSnNHk+fwzvg==
-
-zksync2-js@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/zksync2-js/-/zksync2-js-0.2.2.tgz#d673661a6ddf933d1f17c119e82111a111f05793"
-  integrity sha512-4DUZZI2Hk8tOBCUbdwwZvI+BEszCwN6C06bN1zm3N1/+wqIMVu0q64PtWzoTX0VZmC11UOz3yrXTeNUNjj9xww==
+zksync2-js@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/zksync2-js/-/zksync2-js-0.4.0.tgz#e9984ae4a9b4450105b1e9565a0dd2e010aa5bd3"
+  integrity sha512-0Z+Yhqz6ZEkw3HHrbNZZT07zb631ALWqbe2exS7DFAqrSxACXx48/sqeYzpTXLJuNiqBXQYrVnHXzIeeqHKSxA==
 
 zksync@^0.13.1:
   version "0.13.1"


### PR DESCRIPTION
# What :computer: 
Bumped version for zksync2-js and added support for Sepolia test-net.

# Why :hand:
Goerli test-net incoming deprecation.
