### PR TITLE
fix(hardhat-zksync-vyper): Proper User-Agent for getRelease

### DIFF
--- a/.changeset/long-brooms-battle.md
+++ b/.changeset/long-brooms-battle.md
@@ -1,0 +1,5 @@
+---
+"@matterlabs/hardhat-zksync-vyper": patch
+---
+
+Proper User-Agent for getRelease function

--- a/packages/hardhat-zksync-vyper/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/downloader.ts
@@ -4,19 +4,19 @@ import chalk from "chalk";
 import { spawnSync } from 'child_process';
 
 import { download, getRelease, getZkvyperUrl, isURL, isVersionInRange, saveDataToFile } from "../utils";
-import { 
-    COMPILER_BINARY_CORRUPTION_ERROR, 
-    COMPILER_VERSION_INFO_FILE_DOWNLOAD_ERROR, 
-    COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR, 
-    COMPILER_VERSION_RANGE_ERROR, 
-    COMPILER_VERSION_WARNING, 
-    DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD, 
-    DEFAULT_TIMEOUT_MILISECONDS, 
-    PLUGIN_NAME, 
-    ZKVYPER_BIN_OWNER, 
-    ZKVYPER_BIN_REPOSITORY, 
-    ZKVYPER_BIN_REPOSITORY_NAME, 
-    ZKVYPER_COMPILER_VERSION_MIN_VERSION, 
+import {
+    COMPILER_BINARY_CORRUPTION_ERROR,
+    COMPILER_VERSION_INFO_FILE_DOWNLOAD_ERROR,
+    COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR,
+    COMPILER_VERSION_RANGE_ERROR,
+    COMPILER_VERSION_WARNING,
+    DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD,
+    DEFAULT_TIMEOUT_MILISECONDS,
+    USER_AGENT,
+    ZKVYPER_BIN_OWNER,
+    ZKVYPER_BIN_REPOSITORY,
+    ZKVYPER_BIN_REPOSITORY_NAME,
+    ZKVYPER_COMPILER_VERSION_MIN_VERSION,
 } from "../constants";
 import { ZkSyncVyperPluginError } from "../errors";
 
@@ -45,11 +45,11 @@ export class ZkVyperCompilerDownloader {
                 }
                 compilerVersionInfo = await ZkVyperCompilerDownloader._getCompilerVersionInfo(compilersDir);
             }
-            
+
             if (compilerVersionInfo === undefined) {
                 throw new ZkSyncVyperPluginError(COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR);
             }
-            
+
             if (version === 'latest' || version === compilerVersionInfo.latest) {
                 version = compilerVersionInfo.latest;
             } else if (!isVersionInRange(version, compilerVersionInfo)) {
@@ -67,7 +67,7 @@ export class ZkVyperCompilerDownloader {
     private static _instance: ZkVyperCompilerDownloader;
     public static compilerVersionInfoCachePeriodMs = DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD;
 
-    /** 
+    /**
      * Use `getDownloaderWithVersionValidated` to create an instance of this class.
      */
     private constructor(
@@ -88,12 +88,12 @@ export class ZkVyperCompilerDownloader {
         return path.join(this._compilersDirectory, 'zkvyper', `zkvyper-v${this._version}`);
     }
 
-    public async isCompilerDownloaded(): Promise<boolean> {        
+    public async isCompilerDownloaded(): Promise<boolean> {
         if (this._configCompilerPath) {
             await this._verifyCompiler();
             return true;
         }
-        
+
         const compilerPath = this.getCompilerPath();
         return fsExtra.pathExists(compilerPath);
     }
@@ -147,7 +147,7 @@ export class ZkVyperCompilerDownloader {
     }
 
     private static async _downloadCompilerVersionInfo(compilersDir: string): Promise<void> {
-        const realease = await getRelease(ZKVYPER_BIN_OWNER, ZKVYPER_BIN_REPOSITORY_NAME, PLUGIN_NAME);
+        const realease = await getRelease(ZKVYPER_BIN_OWNER, ZKVYPER_BIN_REPOSITORY_NAME, USER_AGENT);
 
         const releaseToSave = {
             latest: realease.tag_name.slice(1, realease.tag_name.length),

--- a/packages/hardhat-zksync-vyper/src/constants.ts
+++ b/packages/hardhat-zksync-vyper/src/constants.ts
@@ -6,6 +6,8 @@ export const ZKVYPER_BIN_REPOSITORY = 'https://github.com/matter-labs/zkvyper-bi
 export const DEFAULT_TIMEOUT_MILISECONDS = 30000;
 export const TASK_COMPILE_VYPER_CHECK_ERRORS = 'compile:vyper:check-errors';
 export const TASK_COMPILE_VYPER_LOG_COMPILATION_ERRORS = 'compile:vyper:log:compilation-errors';
+// User agent of MacOSX Chrome 120.0.0.0
+export const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
 export const defaultZkVyperConfig: ZkVyperConfig = {
     version: 'latest',


### PR DESCRIPTION
# What :computer: 
Fixes param for `getRelease` func, now it will be real User-Agent.

# Why :hand:
Requesting server with wrong User-Agent may be resulted in rate-limiting, random 403 errs, and so on.

# Evidence :camera:
It was broken (and still worked, since having proper UA not a must 😅 ) with name of plugin used as User-Agent, so no bad will happen if we will use proper UA.
