### PR TITLE
fix(hardhat-zksync-node): Proper user_agent for getRelease

### DIFF
--- a/.changeset/sour-dancers-tie.md
+++ b/.changeset/sour-dancers-tie.md
@@ -1,0 +1,5 @@
+---
+"@matterlabs/hardhat-zksync-node": patch
+---
+
+Proper User-Agent for getRelease function

--- a/packages/hardhat-zksync-node/src/constants.ts
+++ b/packages/hardhat-zksync-node/src/constants.ts
@@ -2,6 +2,8 @@ export const PLUGIN_NAME = '@matterlabs/hardhat-zksync-node';
 
 export const ZKNODE_BIN_OWNER = 'matter-labs';
 export const ZKNODE_BIN_REPOSITORY_NAME = 'era-test-node';
+// User agent of MacOSX Chrome 120.0.0.0
+export const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
 export const TASK_NODE_ZKSYNC = 'node-zksync';
 export const TASK_NODE_ZKSYNC_CREATE_SERVER = 'node-zksync:create-server';

--- a/packages/hardhat-zksync-node/src/downloader.ts
+++ b/packages/hardhat-zksync-node/src/downloader.ts
@@ -6,6 +6,7 @@ import {
     DEFAULT_RELEASE_CACHE_FILE_NAME,
     DEFAULT_RELEASE_VERSION_INFO_CACHE_PERIOD,
     PLUGIN_NAME,
+    USER_AGENT,
     ZKNODE_BIN_OWNER,
     ZKNODE_BIN_REPOSITORY_NAME,
 } from './constants';
@@ -25,13 +26,13 @@ export class RPCServerDownloader {
 
     public async downloadIfNeeded(force: boolean): Promise<void> {
         if (force) {
-            await this._download(await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, PLUGIN_NAME, this._tag));
+            await this._download(await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, USER_AGENT, this._tag));
             return;
         }
 
         if (this.isLatestTag()) {
             if (!(await this._isLatestReleaseInfoValid())) {
-                const release = await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, PLUGIN_NAME, this._tag);
+                const release = await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, USER_AGENT, this._tag);
 
                 if (await this._isBinaryPathExists(release.tag_name)) {
                     await this._postProcessDownload(release.tag_name);
@@ -47,7 +48,7 @@ export class RPCServerDownloader {
                 return;
             }
 
-            const release = await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, PLUGIN_NAME, this._tag);
+            const release = await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, USER_AGENT, this._tag);
 
             if (info
                 && info.latest === release.tag_name
@@ -61,7 +62,7 @@ export class RPCServerDownloader {
         }
 
         if (!(await this._isBinaryPathExists(this._tag))) {
-            await this._download(await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, PLUGIN_NAME, this._tag));
+            await this._download(await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, USER_AGENT, this._tag));
         }
     }
 


### PR DESCRIPTION
# What :computer: 
Fixes param for `getRelease` func, now it will be real User-Agent.

# Why :hand:
Requesting server with wrong User-Agent may be resulted in rate-limiting, random 403 errs, and so on.

# Evidence :camera:
It was broken (and still worked, since having proper UA not a must 😅 ) with name of plugin used as User-Agent, so no bad will happen if we will use proper UA.
