### PR TITLE
chore(hardhat-zksync-solc): get latest release from redirect URL

### DIFF
--- a/.changeset/ten-foxes-approve.md
+++ b/.changeset/ten-foxes-approve.md
@@ -1,0 +1,5 @@
+---
+"@matterlabs/hardhat-zksync-solc": patch
+---
+
+Get latest release from redirect URL

--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -3,7 +3,7 @@ import fsExtra from "fs-extra";
 import chalk from "chalk";
 import { spawnSync } from 'child_process';
 
-import { download, getRelease, getZksolcUrl, isURL, isVersionInRange, saltFromUrl, saveDataToFile } from "../utils";
+import { download, getZksolcUrl, isURL, isVersionInRange, saltFromUrl, saveDataToFile, getLatestRelease } from "../utils";
 import {
     COMPILER_BINARY_CORRUPTION_ERROR,
     COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR,
@@ -148,10 +148,10 @@ export class ZksolcCompilerDownloader {
         We are currently limited in that each new version requires an update of the plugin version.
     */
     private static async _downloadCompilerVersionInfo(compilersDir: string): Promise<void> {
-        const realease = await getRelease(ZKSOLC_BIN_OWNER, ZKSOLC_BIN_REPOSITORY_NAME, USER_AGENT);
+        const latestRelease = await getLatestRelease(ZKSOLC_BIN_OWNER, ZKSOLC_BIN_REPOSITORY_NAME, USER_AGENT);
 
         const releaseToSave = {
-            latest: realease.tag_name.slice(1, realease.tag_name.length),
+            latest: latestRelease,
             minVersion: ZKSOLC_COMPILER_VERSION_MIN_VERSION
         }
         const savePath = this._getCompilerVersionInfoPath(compilersDir);

--- a/packages/hardhat-zksync-solc/src/utils.ts
+++ b/packages/hardhat-zksync-solc/src/utils.ts
@@ -252,32 +252,40 @@ export async function download(
     );
 }
 
-export async function getRelease(owner: string, repo: string, userAgent: string, tag: string = 'latest', timeout: number = DEFAULT_TIMEOUT_MILISECONDS): Promise<any> {
-    let url = `https://api.github.com/repos/${owner}/${repo}/releases/`;
-    url = tag != 'latest' ? url + `tags/${tag}` : url + `latest`;
+export async function getLatestRelease(owner: string, repo: string, userAgent: string, timeout: number = DEFAULT_TIMEOUT_MILISECONDS): Promise<any> {
+    let url = `https://github.com/${owner}/${repo}/releases/latest`;
+    let redirectUrlPattern = `https://github.com/${owner}/${repo}/releases/tag/v`
 
-    const { getGlobalDispatcher, request } = await import("undici");
+    const { request } = await import("undici");
 
-    let dispatcher: Dispatcher = getGlobalDispatcher();
-
-    // Fetch the url
     const response = await request(url, {
-        dispatcher,
         headersTimeout: timeout,
-        maxRedirections: 10,
+        maxRedirections: 0,
         method: "GET",
         headers: {
             "User-Agent": `${userAgent}`,
         },
     });
 
-    if (response.statusCode >= 200 && response.statusCode <= 299) {
-        return await response.body.json();
+    // Check if the response is a redirect
+    if (response.statusCode >= 300 && response.statusCode < 400) {
+        // Get the URL from the 'location' header
+        if (response.headers.location) {
+            // Check if the redirect URL matches the expected pattern
+            if (response.headers.location.startsWith(redirectUrlPattern)) {
+                // Extract the tag from the redirect URL
+                return response.headers.location.substring(redirectUrlPattern.length);
+            }
+
+            throw new ZkSyncSolcPluginError(`Unexpected redirect URL: ${response.headers.location} for URL: ${url}`);
+        } else {
+            // Throw an error if the 'location' header is missing in a redirect response
+            throw new ZkSyncSolcPluginError(`Redirect location not found for URL: ${url}`);
+        }
+    } else {
+        // Throw an error for non-redirect responses
+        throw new ZkSyncSolcPluginError(`Unexpected response status: ${response.statusCode} for URL: ${url}`);
     }
-
-    const text = await response.body.text();
-
-    throw new ZkSyncSolcPluginError(`GitHub API request failed for URL: ${url} (status ${response.statusCode}). Error: ${text}`);
 }
 
 export async function saveDataToFile(data: any, targetPath: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,7 +808,7 @@
   version "1.2.0"
 
 "@matterlabs/hardhat-zksync-deploy@link:packages/hardhat-zksync-deploy":
-  version "1.1.0"
+  version "1.1.1"
   dependencies:
     "@matterlabs/hardhat-zksync-solc" "^1.0.4"
     chalk "4.1.2"


### PR DESCRIPTION
# What :computer: 
* Get latest release from redirect URL

# Why :hand:
* When fetching releases from GH api it can throttle and thus break the flow