### PR TITLE
chore(hardhat-zksync-vyper): get latest release from redirect URL

### DIFF
--- a/.changeset/ninety-carrots-hug.md
+++ b/.changeset/ninety-carrots-hug.md
@@ -1,0 +1,6 @@
+---
+"@matterlabs/hardhat-zksync-vyper": patch
+---
+
+- Get latest release from redirect URL
+- Change User Agent

--- a/packages/hardhat-zksync-vyper/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/downloader.ts
@@ -3,7 +3,7 @@ import fsExtra from "fs-extra";
 import chalk from "chalk";
 import { spawnSync } from 'child_process';
 
-import { download, getRelease, getZkvyperUrl, isURL, isVersionInRange, saveDataToFile } from "../utils";
+import { download, getLatestRelease, getZkvyperUrl, isURL, isVersionInRange, saveDataToFile } from "../utils";
 import { 
     COMPILER_BINARY_CORRUPTION_ERROR, 
     COMPILER_VERSION_INFO_FILE_DOWNLOAD_ERROR, 
@@ -12,7 +12,7 @@ import {
     COMPILER_VERSION_WARNING, 
     DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD, 
     DEFAULT_TIMEOUT_MILISECONDS, 
-    PLUGIN_NAME, 
+    USER_AGENT, 
     ZKVYPER_BIN_OWNER, 
     ZKVYPER_BIN_REPOSITORY, 
     ZKVYPER_BIN_REPOSITORY_NAME, 
@@ -147,10 +147,10 @@ export class ZkVyperCompilerDownloader {
     }
 
     private static async _downloadCompilerVersionInfo(compilersDir: string): Promise<void> {
-        const realease = await getRelease(ZKVYPER_BIN_OWNER, ZKVYPER_BIN_REPOSITORY_NAME, PLUGIN_NAME);
+        const latestRelease = await getLatestRelease(ZKVYPER_BIN_OWNER, ZKVYPER_BIN_REPOSITORY_NAME, USER_AGENT);
 
         const releaseToSave = {
-            latest: realease.tag_name.slice(1, realease.tag_name.length),
+            latest: latestRelease,
             minVersion: ZKVYPER_COMPILER_VERSION_MIN_VERSION
         }
         const savePath = this._getCompilerVersionInfoPath(compilersDir);

--- a/packages/hardhat-zksync-vyper/src/constants.ts
+++ b/packages/hardhat-zksync-vyper/src/constants.ts
@@ -7,6 +7,9 @@ export const DEFAULT_TIMEOUT_MILISECONDS = 30000;
 export const TASK_COMPILE_VYPER_CHECK_ERRORS = 'compile:vyper:check-errors';
 export const TASK_COMPILE_VYPER_LOG_COMPILATION_ERRORS = 'compile:vyper:log:compilation-errors';
 
+// User agent of MacOSX Chrome 120.0.0.0
+export const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
 export const defaultZkVyperConfig: ZkVyperConfig = {
     version: 'latest',
     compilerSource: 'binary',


### PR DESCRIPTION
# What :computer: 
* Get latest release from redirect URL
* Change User Agent

# Why :hand:
* When latest release is fetched from the GH api, it can throttle thus breaking the flow