### PR TITLE
fix: update link to dev discussion

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -61,7 +61,7 @@ This ensures consistent code style throughout the project and helps identify pot
 
 ## Need Assistance?
 
-If you're unsure about something or have questions, don't hesitate to open an issue or initiate a discussion in our [zkSync Community Hub](https://github.com/zkSync-Community-Hub/zkSync-developers/discussions). We're here to assist!
+If you're unsure about something or have questions, don't hesitate to open an issue or initiate a discussion in our [zkSync Community Hub](https://github.com/zkSync-Community-Hub/zkync-developers/discussions). We're here to assist!
 
 ## What's Next?
 


### PR DESCRIPTION
# What :computer: 
I've found broken link to developer discussion, this PR fixes the link. Maybe the target [repo](https://github.com/zkSync-Community-Hub/zkync-developers/discussions) should be renamed because the repo name contains a typo.

# Why :hand:
- Keep external resources approachable.

# Evidence :camera:
No additional evidence.