### PR TITLE
chore: revert vyper path normalization for windows os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,12 @@ jobs:
           SOLC_VERSION: ${{ matrix.solc }}
 
   zkvyper:
-   strategy:
+    strategy:
       matrix:
         os: [ubuntu, windows]
 
     runs-on: ${{ matrix.os }}-latest
+    
     name: zkvyper
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,7 @@ jobs:
           SOLC_VERSION: ${{ matrix.solc }}
 
   zkvyper:
-    strategy:
-      matrix:
-        os: [ubuntu, windows]
-
-    runs-on: ${{ matrix.os }}-latest
-    
+    runs-on: ubuntu-latest
     name: zkvyper
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,11 @@ jobs:
           SOLC_VERSION: ${{ matrix.solc }}
 
   zkvyper:
-    runs-on: ubuntu-latest
+   strategy:
+      matrix:
+        os: [ubuntu, windows]
+
+    runs-on: ${{ matrix.os }}-latest
     name: zkvyper
     steps:
       - uses: actions/checkout@v2

--- a/packages/hardhat-zksync-solc/test/compiler-files/macos/solc-macos:Zone.Identifier
+++ b/packages/hardhat-zksync-solc/test/compiler-files/macos/solc-macos:Zone.Identifier
@@ -1,4 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=https://github.com/ethereum/solidity/releases
-HostUrl=https://objects.githubusercontent.com/github-production-release-asset-2e65be/40892817/d8c0c93a-8522-4772-be33-c8cb04a26d5d?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231225%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231225T225829Z&X-Amz-Expires=300&X-Amz-Signature=61e0d8865c9f98cd83643330f76ef3bb17b565f0d77aa45da8f5ca438d673973&X-Amz-SignedHeaders=host&actor_id=131957563&key_id=0&repo_id=40892817&response-content-disposition=attachment%3B%20filename%3Dsolc-macos&response-content-type=application%2Foctet-stream

--- a/packages/hardhat-zksync-solc/test/compiler-files/macos/zksolc-macosx-arm64-v1.3.17:Zone.Identifier
+++ b/packages/hardhat-zksync-solc/test/compiler-files/macos/zksolc-macosx-arm64-v1.3.17:Zone.Identifier
@@ -1,4 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=https://github.com/matter-labs/zksolc-bin/releases
-HostUrl=https://objects.githubusercontent.com/github-production-release-asset-2e65be/423900857/a181a32b-51d2-443d-9c35-101bc5898a91?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20231225%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231225T225424Z&X-Amz-Expires=300&X-Amz-Signature=b8068888dfde3a94f2627d1617a39d4117cedb8e47c1a93d087df2eb4b9af6f1&X-Amz-SignedHeaders=host&actor_id=131957563&key_id=0&repo_id=423900857&response-content-disposition=attachment%3B%20filename%3Dzksolc-macosx-arm64-v1.3.17&response-content-type=application%2Foctet-stream

--- a/packages/hardhat-zksync-vyper/src/index.ts
+++ b/packages/hardhat-zksync-vyper/src/index.ts
@@ -69,7 +69,6 @@ subtask(TASK_COMPILE_VYPER_RUN_BINARY, async (args: { inputPaths: string[]; vype
         hre.config.zkvyper,
         args.inputPaths,
         hre.config.paths.sources,
-        hre.config.paths.root,
         args.vyperPath,
     );
 

--- a/packages/hardhat-zksync-vyper/src/types.ts
+++ b/packages/hardhat-zksync-vyper/src/types.ts
@@ -44,8 +44,3 @@ export interface CompilerOptions {
     compilerPath?: string;
     sourcesPath?: string;
 }
-
-export interface CompilerOutput {
-    [fqn: string]: any;
-    version: string;
-}

--- a/packages/hardhat-zksync-vyper/test/tests.ts
+++ b/packages/hardhat-zksync-vyper/test/tests.ts
@@ -80,8 +80,9 @@ describe('zkvyper plugin', async function () {
                 const hh = require('hardhat');
                 await hh.run(TASK_COMPILE);
             } catch (e: any) {
-                console.info(e.message);
-                expect(e.message).to.include('Please use versions 1.3.9 to 1.3.14');
+                expect(e.message).to.include(
+                    'The zkvyper compiler version (111.1.77) in the hardhat config file is not within the allowed range.',
+                );
             }
         });
     });


### PR DESCRIPTION
# What :computer: 
* Revert vyper path normalization for windows os

# Why :hand:
* Path normalization is now handled by compiler itself
