### PR TITLE
fix: windows path normalize with compiler

### DIFF
--- a/packages/hardhat-zksync-vyper/package.json
+++ b/packages/hardhat-zksync-vyper/package.json
@@ -41,7 +41,8 @@
     "sinon": "^9.0.0",
     "chai": "^4.3.6",
     "undici": "^5.14.0",
-    "semver": "^7.5.4"
+    "semver": "^7.5.4",
+    "sinon-chai": "^3.7.0" 
   },
   "devDependencies": {
     "@nomiclabs/hardhat-vyper": "^3.0.5",

--- a/packages/hardhat-zksync-vyper/src/compile/index.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/index.ts
@@ -50,7 +50,7 @@ export async function compile(
     return output;
 }
 
-function getWindowsOutput(output: CompilerOutput, path: string) {
+export function getWindowsOutput(output: CompilerOutput, path: string) {
     const { version, ...contracts } = output;
     const changedOutput = {} as CompilerOutput;
 

--- a/packages/hardhat-zksync-vyper/src/compile/index.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/index.ts
@@ -1,6 +1,8 @@
 import { HardhatDocker, Image } from '@nomiclabs/hardhat-docker';
+import semver from 'semver';
 import { ZkVyperConfig, CompilerOptions, CompilerOutput } from '../types';
 import { ZkSyncVyperPluginError } from '../errors';
+import { ZKVYPER_COMPILER_MIN_VERSION_WITH_WINDOWS_PATH_NORMALIZE } from '../constants';
 import { compileWithBinary } from './binary';
 import {
     validateDockerIsInstalled,
@@ -38,11 +40,14 @@ export async function compile(
         zkvyperConfig,
     );
 
-    if (process.platform !== 'win32') {
-        return output;
+    if (
+        process.platform === 'win32' &&
+        semver.lt(zkvyperConfig.version, ZKVYPER_COMPILER_MIN_VERSION_WITH_WINDOWS_PATH_NORMALIZE)
+    ) {
+        return getWindowsOutput(output, rootPath);
     }
 
-    return getWindowsOutput(output, rootPath);
+    return output;
 }
 
 function getWindowsOutput(output: CompilerOutput, path: string) {

--- a/packages/hardhat-zksync-vyper/src/compile/index.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/index.ts
@@ -57,7 +57,7 @@ function getWindowsOutput(output: CompilerOutput, path: string) {
     const specificPath = path.replaceAll('\\', '/');
     for (const [originalSourceName, _output] of Object.entries(contracts)) {
         const sourceName = originalSourceName.replace(`//?/${specificPath}/`, '');
-        changedOutput[sourceName] = output;
+        changedOutput[sourceName] = _output;
     }
 
     changedOutput.version = version;

--- a/packages/hardhat-zksync-vyper/src/constants.ts
+++ b/packages/hardhat-zksync-vyper/src/constants.ts
@@ -26,6 +26,7 @@ export const defaultZkVyperConfig: ZkVyperConfig = {
 export const UNSUPPORTED_VYPER_VERSIONS = ['0.3.4', '0.3.5', '0.3.6', '0.3.7'];
 
 export const ZKVYPER_COMPILER_VERSION_MIN_VERSION = '1.3.9';
+export const ZKVYPER_COMPILER_MIN_VERSION_WITH_WINDOWS_PATH_NORMALIZE = '1.3.16';
 
 export const ZKVYPER_BIN_OWNER = 'matter-labs';
 export const ZKVYPER_BIN_REPOSITORY_NAME = 'zkvyper-bin';

--- a/packages/hardhat-zksync-vyper/test/tests.ts
+++ b/packages/hardhat-zksync-vyper/test/tests.ts
@@ -80,8 +80,9 @@ describe('zkvyper plugin', async function () {
                 const hh = require('hardhat');
                 await hh.run(TASK_COMPILE);
             } catch (e: any) {
-                console.info(e.message);
-                expect(e.message).to.include('Please use versions 1.3.9 to 1.3.14');
+                expect(e.message).to.include(
+                    'The zkvyper compiler version (111.1.77) in the hardhat config file is not within the allowed range.',
+                );
             }
         });
     });


### PR DESCRIPTION
# What :computer: 
* Windows path normalize with compiler

# Why :hand:
* From compiler version 1.3.16 windows path are resolved and plugin don't need to do that.
