### PR TITLE
feat: get release tag from redirect url at node plugin

### DIFF
--- a/packages/hardhat-zksync-node/src/constants.ts
+++ b/packages/hardhat-zksync-node/src/constants.ts
@@ -2,6 +2,7 @@ export const PLUGIN_NAME = '@matterlabs/hardhat-zksync-node';
 
 export const ZKNODE_BIN_OWNER = 'matter-labs';
 export const ZKNODE_BIN_REPOSITORY_NAME = 'era-test-node';
+export const ZKNODE_BIN_REPOSITORY = 'https://github.com/matter-labs/era-test-node';
 // User agent of MacOSX Chrome 120.0.0.0
 export const USER_AGENT =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
@@ -51,6 +52,8 @@ export const NETWORK_GAS_PRICE = {
 export const NETWORK_ETH = {
     LOCALHOST: 'localhost',
 };
+
+export const DEFAULT_TIMEOUT_MILISECONDS = 30000;
 
 // export const TOOLCHAIN_MAP: Record<string, string> = {
 //     linux: '-musl',

--- a/packages/hardhat-zksync-node/src/utils.ts
+++ b/packages/hardhat-zksync-node/src/utils.ts
@@ -151,38 +151,44 @@ export async function getRPCServerBinariesDir(): Promise<string> {
 }
 
 // Get latest release from GitHub of the era-test-node binary
-export async function getRelease(owner: string, repo: string, userAgent: string, tag?: string): Promise<any> {
-    let url = `https://api.github.com/repos/${owner}/${repo}/releases/`;
-    url = tag !== 'latest' ? `${url}tags/${tag}` : `${url}latest`;
+export async function getLatestRelease(owner: string, repo: string, userAgent: string, timeout: number): Promise<any> {
+    const url = `https://github.com/${owner}/${repo}/releases/latest`;
+    const redirectUrlPattern = `https://github.com/${owner}/${repo}/releases/tag/v`;
 
-    try {
-        const response = await axios.get(url, {
-            headers: {
-                'User-Agent': userAgent,
-            },
-        });
+    const { request } = await import('undici');
 
-        return response.data;
-    } catch (error: any) {
-        if (error.response) {
-            // The request was made and the server responded with a status code outside of the range of 2xx
-            throw new ZkSyncNodePluginError(
-                `Failed to get ${tag} release for ${owner}/${repo}. Status: ${
-                    error.response.status
-                }, Data: ${JSON.stringify(error.response.data)}`,
-            );
-        } else if (error.request) {
-            // The request was made but no response was received
-            throw new ZkSyncNodePluginError(`No response received for ${owner}/${repo}. Error: ${error.message}`);
+    const response = await request(url, {
+        headersTimeout: timeout,
+        maxRedirections: 0,
+        method: 'GET',
+        headers: {
+            'User-Agent': `${userAgent}`,
+        },
+    });
+
+    // Check if the response is a redirect
+    if (response.statusCode >= 300 && response.statusCode < 400) {
+        // Get the URL from the 'location' header
+        if (response.headers.location) {
+            // Check if the redirect URL matches the expected pattern
+            if (response.headers.location.startsWith(redirectUrlPattern)) {
+                // Extract the tag from the redirect URL
+                return response.headers.location.substring(redirectUrlPattern.length);
+            }
+
+            throw new ZkSyncNodePluginError(`Unexpected redirect URL: ${response.headers.location} for URL: ${url}`);
         } else {
-            // Something happened in setting up the request that triggered an Error
-            throw new ZkSyncNodePluginError(`Failed to set up the request for ${owner}/${repo}: ${error.message}`);
+            // Throw an error if the 'location' header is missing in a redirect response
+            throw new ZkSyncNodePluginError(`Redirect location not found for URL: ${url}`);
         }
+    } else {
+        // Throw an error for non-redirect responses
+        throw new ZkSyncNodePluginError(`Unexpected response status: ${response.statusCode} for URL: ${url}`);
     }
 }
 
 // Get the asset to download from the latest release of the era-test-node binary
-export async function getAssetToDownload(latestRelease: any): Promise<string> {
+export async function getNodeUrl(repo: string, release: string): Promise<string> {
     const platform = getPlatform();
 
     // TODO: Add support for Windows
@@ -190,10 +196,7 @@ export async function getAssetToDownload(latestRelease: any): Promise<string> {
         throw new ZkSyncNodePluginError(`Unsupported platform: ${platform}`);
     }
 
-    const prefix = `era_test_node-${latestRelease.tag_name}`;
-    const expectedAssetName = `${prefix}-${getArch()}-${platform}.tar.gz`;
-
-    return latestRelease.assets.find((asset: any) => asset.name === expectedAssetName);
+    return `${repo}/releases/download/v${release}/era_test_node-v${release}-${getArch()}-${platform}.tar.gz`;
 }
 
 function isTarGzFile(filePath: string): boolean {

--- a/packages/hardhat-zksync-node/test/tests.ts
+++ b/packages/hardhat-zksync-node/test/tests.ts
@@ -10,9 +10,10 @@ import proxyquire from 'proxyquire';
 import { spawn, ChildProcess } from 'child_process';
 
 import * as utils from '../src/utils';
-import { constructCommandArgs, getRelease, getAssetToDownload } from '../src/utils';
+import { constructCommandArgs } from '../src/utils';
 import { RPCServerDownloader } from '../src/downloader';
 import { TASK_NODE_ZKSYNC, PROCESS_TERMINATION_SIGNALS } from '../src/constants';
+import { USER_AGENT } from '../dist/constants';
 
 chai.use(sinonChai);
 
@@ -30,15 +31,128 @@ async function getPort(): Promise<number> {
 }
 
 describe('node-zksync plugin', async function () {
-    describe('Utils', () => {
-        describe('constructCommandArgs', () => {
-            it('should construct command arguments with minimum args', () => {
+    describe('getLatestRelease', async function () {
+        let mockPool: any;
+        before(() => {
+            const { MockAgent, setGlobalDispatcher } = require('undici');
+            const mockAgent = new MockAgent();
+            mockPool = mockAgent.get('https://github.com');
+
+            setGlobalDispatcher(mockAgent);
+        });
+
+        const mockRelease = '0.1.0';
+
+        it('should fetch the latest release successfully', async function () {
+            mockPool
+                .intercept({
+                    path: '/owner/repo/releases/latest',
+                    timeout: 30000,
+                    'User-Agent': USER_AGENT,
+                    method: 'GET',
+                })
+                .reply(
+                    302,
+                    {},
+                    {
+                        headers: {
+                            location: 'https://github.com/owner/repo/releases/tag/v0.1.0',
+                        },
+                    },
+                );
+
+            const result = await utils.getLatestRelease('owner', 'repo', 'userAgent', 30000);
+            expect(result).to.deep.equal(mockRelease);
+        });
+
+        it('should handle errors when the server responds with a non-2xx status code', async function () {
+            mockPool
+                .intercept({
+                    path: '/owner/repo/releases/latest',
+                    method: 'GET',
+                })
+                .reply(404, {
+                    body: {
+                        status: 404,
+                        data: {
+                            message: 'Not Found',
+                        },
+                    },
+                });
+
+            try {
+                await utils.getLatestRelease('owner', 'repo', 'userAgent', 30000);
+                assert.fail('Expected an error to be thrown');
+            } catch (error: any) {
+                expect(error.message).to.be.equal(
+                    'Unexpected response status: 404 for URL: https://github.com/owner/repo/releases/latest',
+                );
+            }
+        });
+
+        it('should handle errors when no response is received', async function () {
+            mockPool
+                .intercept({
+                    path: '/owner/repo/releases/latest',
+                    timeout: 30000,
+                    'User-Agent': USER_AGENT,
+                    method: 'GET',
+                })
+                .reply(
+                    302,
+                    {},
+                    {
+                        headers: {},
+                    },
+                );
+
+            try {
+                await utils.getLatestRelease('owner', 'repo', 'userAgent', 30000);
+                assert.fail('Expected an error to be thrown');
+            } catch (error: any) {
+                expect(error.message).to.be.equal(
+                    'Redirect location not found for URL: https://github.com/owner/repo/releases/latest',
+                );
+            }
+        });
+
+        it('should handle errors during request setup', async function () {
+            mockPool
+                .intercept({
+                    path: '/owner/repo/releases/latest',
+                    timeout: 30000,
+                    'User-Agent': USER_AGENT,
+                    method: 'GET',
+                })
+                .reply(
+                    302,
+                    {},
+                    {
+                        headers: {
+                            location: 'https://github.com/owner/wrong/',
+                        },
+                    },
+                );
+
+            try {
+                await utils.getLatestRelease('owner', 'repo', 'userAgent', 30000);
+                assert.fail('Expected an error to be thrown');
+            } catch (error: any) {
+                expect(error.message).to.be.equal(
+                    'Unexpected redirect URL: https://github.com/owner/wrong/ for URL: https://github.com/owner/repo/releases/latest',
+                );
+            }
+        });
+    });
+    describe('Utils', async function () {
+        describe('constructCommandArgs', async function () {
+            it('should construct command arguments with minimum args', async function () {
                 const args = {};
                 const result = constructCommandArgs(args);
                 expect(result).to.deep.equal(['run']);
             });
 
-            it('should correctly construct command arguments with all args', () => {
+            it('should correctly construct command arguments with all args', async function () {
                 const args = {
                     port: 8012,
                     log: 'error',
@@ -74,26 +188,26 @@ describe('node-zksync plugin', async function () {
                 ]);
             });
 
-            it('should throw error when both forkBlockNumber and replayTx are specified in all args', () => {
+            it('should throw error when both forkBlockNumber and replayTx are specified in all args', async function () {
                 const args = { fork: 'mainnet', forkBlockNumber: 100, replayTx: '0x1234567890abcdef' };
                 expect(() => constructCommandArgs(args)).to.throw(
                     'Cannot specify both --fork-block-number and --replay-tx. Please specify only one of them.',
                 );
             });
 
-            it('should throw error for invalid log value', () => {
+            it('should throw error for invalid log value', async function () {
                 const args = { log: 'invalid' };
                 expect(() => constructCommandArgs(args)).to.throw('Invalid log value: invalid');
             });
 
-            it('should throw error when there is no fork arg', () => {
+            it('should throw error when there is no fork arg', async function () {
                 const args = { forkBlockNumber: 100 };
                 expect(() => constructCommandArgs(args)).to.throw(
                     'Cannot specify --replay-tx or --fork-block-number parameters without --fork param.',
                 );
             });
 
-            it('should correctly construct command arguments with fork and replayTx', () => {
+            it('should correctly construct command arguments with fork and replayTx', async function () {
                 const args = { fork: 'http://example.com', replayTx: '0x1234567890abcdef' };
                 const result = constructCommandArgs(args);
                 expect(result).to.deep.equal(['replay_tx http://example.com 0x1234567890abcdef']);
@@ -107,266 +221,140 @@ describe('node-zksync plugin', async function () {
                 expect(() => constructCommandArgs(args)).to.throw('Invalid fork network value: invalidURL');
             });
         });
+    });
 
-        describe('getAssetToDownload', () => {
-            let archStub: sinon.SinonStub;
-            let platformStub: sinon.SinonStub;
+    describe.skip('getNodeUrl', async function () {
+        it('should return the node URL for the given repo and release', async function () {
+            const repo = 'example/repo';
+            const release = '1.0.0';
+            const expectedUrl = `${repo}/releases/download/v${release}/era_test_node-v${release}-amd64-linux.tar.gz`;
 
-            const mockRelease = {
-                tag_name: 'v0.1.0',
-                assets: [
-                    { name: 'era_test_node-v0.1.0-aarch64-apple-darwin.tar.gz' },
-                    { name: 'era_test_node-v0.1.0-x86_64-apple-darwin.tar.gz' },
-                    { name: 'era_test_node-v0.1.0-x86_64-unknown-linux-gnu.tar.gz' },
-                ],
-            };
+            const url = await utils.getNodeUrl(repo, release);
 
-            beforeEach(() => {
-                archStub = sinon.stub(process, 'arch');
-                platformStub = sinon.stub(process, 'platform');
-            });
-
-            afterEach(() => {
-                archStub.restore();
-                platformStub.restore();
-            });
-
-            it('should return the correct asset for x64 apple-darwin', async () => {
-                archStub.value('x64');
-                platformStub.value('darwin');
-                expect(await getAssetToDownload(mockRelease)).to.deep.equal(mockRelease.assets[1]);
-            });
-
-            it('should return the correct asset for aarch64 apple-darwin', async () => {
-                archStub.value('arm64');
-                platformStub.value('darwin');
-                expect(await getAssetToDownload(mockRelease)).to.deep.equal(mockRelease.assets[0]);
-            });
-
-            it('should return the correct asset for x64 linux', async () => {
-                archStub.value('x64');
-                platformStub.value('linux');
-                expect(await getAssetToDownload(mockRelease)).to.deep.equal(mockRelease.assets[2]);
-            });
-
-            it('should throw an error for unsupported platform', async () => {
-                archStub.value('x64');
-                platformStub.value('win32');
-                try {
-                    await getAssetToDownload(mockRelease);
-                    throw new Error("Expected an error to be thrown, but it wasn't.");
-                } catch (error: any) {
-                    expect(error.message).to.include('Unsupported platform');
-                }
-            });
+            expect(url).to.equal(expectedUrl);
         });
 
-        describe('getLatestRelease', () => {
-            let axiosGetStub: sinon.SinonStub;
+        it('should throw an error for unsupported platforms', async function () {
+            const repo = 'example/repo';
+            const release = '1.0.0';
+            const platform = 'windows';
 
-            const mockRelease = {
-                assets: [
-                    {
-                        url: 'https://api.github.com/repos/matter-labs/era-test-node/releases/assets/1',
-                        browser_download_url:
-                            'https://github.com/matter-labs/era-test-node/releases/download/v0.1.0/era_test_node-v0.1.0-aarch64-apple-darwin.tar.gz',
-                    },
-                    {
-                        url: 'https://api.github.com/repos/matter-labs/era-test-node/releases/assets/2',
-                        browser_download_url:
-                            'https://github.com/matter-labs/era-test-node/releases/download/v0.1.0/era_test_node-v0.1.0-x86_64-apple-darwin.tar.gz',
-                    },
-                    {
-                        url: 'https://api.github.com/repos/matter-labs/era-test-node/releases/assets/3',
-                        browser_download_url:
-                            'https://github.com/matter-labs/era-test-node/releases/download/v0.1.0/era_test_node-v0.1.0-x86_64-unknown-linux-gnu.tar.gz',
-                    },
-                ],
-            };
-
-            beforeEach(() => {
-                axiosGetStub = sinon.stub(axios, 'get');
-            });
-
-            afterEach(() => {
-                axiosGetStub.restore();
-            });
-
-            it('should fetch the latest release successfully', async () => {
-                axiosGetStub.resolves({ data: mockRelease });
-
-                const result = await getRelease('owner', 'repo', 'userAgent');
-                expect(result).to.deep.equal(mockRelease);
-
-                sinon.assert.calledOnce(axiosGetStub);
-            });
-
-            it('should handle errors when the server responds with a non-2xx status code', async () => {
-                const errorResponse = {
-                    response: {
-                        status: 404,
-                        data: {
-                            message: 'Not Found',
-                        },
-                    },
-                };
-
-                axiosGetStub.rejects(errorResponse);
-
-                try {
-                    await getRelease('owner', 'repo', 'userAgent', 'v0.1.0');
-                    assert.fail('Expected an error to be thrown');
-                } catch (error: any) {
-                    expect(error.message).to.include('Failed to get v0.1.0 release');
-                    expect(error.message).to.include('404');
-                    expect(error.message).to.include('Not Found');
-                }
-            });
-
-            it('should handle errors when no response is received', async () => {
-                const errorNoResponse = {
-                    request: {},
-                    message: 'No response',
-                };
-
-                axiosGetStub.rejects(errorNoResponse);
-
-                try {
-                    await getRelease('owner', 'repo', 'userAgent');
-                    assert.fail('Expected an error to be thrown');
-                } catch (error: any) {
-                    expect(error.message).to.include('No response received');
-                }
-            });
-
-            it('should handle errors during request setup', async () => {
-                const errorSetup = {
-                    message: 'Setup error',
-                };
-
-                axiosGetStub.rejects(errorSetup);
-
-                try {
-                    await getRelease('owner', 'repo', 'userAgent');
-                    assert.fail('Expected an error to be thrown');
-                } catch (error: any) {
-                    expect(error.message).to.include('Failed to set up the request');
-                }
-            });
-        });
-
-        describe('waitForNodeToBeReady', () => {
-            afterEach(() => {
-                sinon.restore();
-            });
-
-            it('should return successfully if the node is ready', async () => {
-                // Mock the axios.post to simulate a node being ready
-                sinon.stub(axios, 'post').resolves({ data: { result: true } });
-
-                const port = 12345; // any port for testing purposes
-                await utils.waitForNodeToBeReady(port);
-
-                expect(axios.post).to.have.been.calledWith(`http://127.0.0.1:${port}`);
-            });
-
-            it("should throw an error if the node isn't ready after maxAttempts", async () => {
-                // Make the stub reject all the time to simulate the node never being ready
-                sinon.stub(axios, 'post').rejects(new Error('Node not ready'));
-
-                try {
-                    await utils.waitForNodeToBeReady(8080, 1);
-                    throw new Error('Expected waitForNodeToBeReady to throw but it did not');
-                } catch (err: any) {
-                    expect(err.message).to.equal("Server didn't respond after multiple attempts");
-                }
-            });
-        });
-
-        describe('adjustTaskArgsForPort', () => {
-            it("should correctly add the --port argument if it's not present", () => {
-                const result = utils.adjustTaskArgsForPort([], 8000);
-                expect(result).to.deep.equal(['--port', '8000']);
-            });
-
-            it("should correctly update the --port argument if it's present", () => {
-                const result = utils.adjustTaskArgsForPort(['--port', '9000'], 8000);
-                expect(result).to.deep.equal(['--port', '8000']);
-            });
-        });
-
-        describe('isPortAvailable', () => {
-            let server: net.Server;
-
-            afterEach(() => {
-                if (server) server.close();
-            });
-
-            it('should correctly identify an available port', async () => {
-                const port = await getPort();
-                const result = await utils.isPortAvailable(port);
-                expect(result).to.equal(true);
-            });
-
-            it('should correctly identify a port that is in use', async () => {
-                const port = await getPort();
-                server = net.createServer().listen(port);
-                const result = await utils.isPortAvailable(port);
-                expect(result).to.equal(false);
-            });
-        });
-
-        describe('getAvailablePort', () => {
-            let isPortAvailableStub: sinon.SinonStub<[number], Promise<boolean>>;
-
-            beforeEach(() => {
-                isPortAvailableStub = sinon.stub(utils, 'isPortAvailable');
-            });
-
-            afterEach(() => {
-                isPortAvailableStub.restore();
-            });
-
-            it('should return the first available port', async () => {
-                isPortAvailableStub.returns(Promise.resolve(true));
-                const port = await utils.getAvailablePort(8080, 10);
-                expect(port).to.equal(8080);
-            });
-
-            // it('should throw an error after checking the maxAttempts number of ports', async () => {
-            //     isPortAvailableStub.returns(Promise.resolve(false));
-
-            //     try {
-            //         await utils.getAvailablePort(8000, 10);
-            //         throw new Error('Expected getAvailablePort to throw but it did not');
-            //     } catch (err: any) {
-            //         expect(err.message).to.equal('Couldn\'t find an available port after several attempts');
-            //     }
-            // });
+            try {
+                await utils.getNodeUrl(repo, release);
+                // Fail the test if no error is thrown
+                expect.fail('Expected an error to be thrown');
+            } catch (error: any) {
+                expect(error.message).to.equal(`Unsupported platform: ${platform}`);
+            }
         });
     });
 
-    describe('RPCServerDownloader', () => {
-        const mockRelease = {
-            url: 'https://api.github.com/repos/matter-labs/era-test-node/releases/assets/latest',
-            tag_name: 'v1.0.0',
-        };
+    describe('waitForNodeToBeReady', async function () {
+        afterEach(() => {
+            sinon.restore();
+        });
 
-        const mockAsset = {
-            browser_download_url:
-                'https://github.com/matter-labs/era-test-node/releases/download/v0.1.0/era_test_node-v0.1.0-aarch64-apple-darwin.tar.gz',
-        };
+        it('should return successfully if the node is ready', async function () {
+            // Mock the axios.post to simulate a node being ready
+            sinon.stub(axios, 'post').resolves({ data: { result: true } });
+
+            const port = 12345; // any port for testing purposes
+            await utils.waitForNodeToBeReady(port);
+
+            expect(axios.post).to.have.been.calledWith(`http://127.0.0.1:${port}`);
+        });
+
+        it("should throw an error if the node isn't ready after maxAttempts", async () => {
+            // Make the stub reject all the time to simulate the node never being ready
+            sinon.stub(axios, 'post').rejects(new Error('Node not ready'));
+
+            try {
+                await utils.waitForNodeToBeReady(8080, 1);
+                throw new Error('Expected waitForNodeToBeReady to throw but it did not');
+            } catch (err: any) {
+                expect(err.message).to.equal("Server didn't respond after multiple attempts");
+            }
+        });
+    });
+
+    describe('adjustTaskArgsForPort', async function () {
+        it("should correctly add the --port argument if it's not present", async function () {
+            const result = utils.adjustTaskArgsForPort([], 8000);
+            expect(result).to.deep.equal(['--port', '8000']);
+        });
+
+        it("should correctly update the --port argument if it's present", async function () {
+            const result = utils.adjustTaskArgsForPort(['--port', '9000'], 8000);
+            expect(result).to.deep.equal(['--port', '8000']);
+        });
+    });
+
+    describe('isPortAvailable', async function () {
+        let server: net.Server;
+
+        afterEach(() => {
+            if (server) server.close();
+        });
+
+        it('should correctly identify an available port', async function () {
+            const port = await getPort();
+            const result = await utils.isPortAvailable(port);
+            expect(result).to.equal(true);
+        });
+
+        it('should correctly identify a port that is in use', async function () {
+            const port = await getPort();
+            server = net.createServer().listen(port);
+            const result = await utils.isPortAvailable(port);
+            expect(result).to.equal(false);
+        });
+    });
+
+    describe('getAvailablePort', () => {
+        let isPortAvailableStub: sinon.SinonStub<[number], Promise<boolean>>;
+
+        beforeEach(() => {
+            isPortAvailableStub = sinon.stub(utils, 'isPortAvailable');
+        });
+
+        afterEach(() => {
+            isPortAvailableStub.restore();
+        });
+
+        it('should return the first available port', async function () {
+            isPortAvailableStub.returns(Promise.resolve(true));
+            const port = await utils.getAvailablePort(8080, 10);
+            expect(port).to.equal(8080);
+        });
+
+        // it('should throw an error after checking the maxAttempts number of ports', async () => {
+        //     isPortAvailableStub.returns(Promise.resolve(false));
+
+        //     try {
+        //         await utils.getAvailablePort(8000, 10);
+        //         throw new Error('Expected getAvailablePort to throw but it did not');
+        //     } catch (err: any) {
+        //         expect(err.message).to.equal('Couldn\'t find an available port after several attempts');
+        //     }
+        // });
+    });
+
+    describe('RPCServerDownloader', async function () {
+        const mockRelease = '1.0.0';
+
+        const mockUrl =
+            'https://github.com/matter-labs/era-test-node/releases/download/v0.1.0/era_test_node-v0.1.0-aarch64-apple-darwin.tar.gz';
 
         let downloadStub: sinon.SinonStub;
         let existsSyncStub: sinon.SinonStub;
         let postProcessDownloadStub: sinon.SinonStub;
         let releaseStub: sinon.SinonStub;
-        let assetToDownloadStub: sinon.SinonStub;
+        let urlStub: sinon.SinonStub;
 
         beforeEach(() => {
             downloadStub = sinon.stub(utils, 'download');
-            releaseStub = sinon.stub(utils, 'getRelease');
-            assetToDownloadStub = sinon.stub(utils, 'getAssetToDownload');
+            releaseStub = sinon.stub(utils, 'getLatestRelease');
+            urlStub = sinon.stub(utils, 'getNodeUrl');
             existsSyncStub = sinon.stub(fs, 'existsSync');
             postProcessDownloadStub = sinon
                 .stub(RPCServerDownloader.prototype as any, '_postProcessDownload')
@@ -378,12 +366,12 @@ describe('node-zksync plugin', async function () {
         });
 
         describe('download', () => {
-            it('should download the binary if not already downloaded', async () => {
+            it('should download the binary if not already downloaded', async function () {
                 const downloader = new RPCServerDownloader('../cache/node', 'latest');
 
                 existsSyncStub.resolves(false);
                 releaseStub.resolves(mockRelease);
-                assetToDownloadStub.resolves(mockAsset);
+                urlStub.resolves(mockUrl);
                 downloadStub.resolves('v1.0.0');
 
                 await downloader.downloadIfNeeded(false);
@@ -393,12 +381,12 @@ describe('node-zksync plugin', async function () {
                 sinon.assert.calledOnce(releaseStub);
             });
 
-            it('should force download the binary', async () => {
+            it('should force download the binary', async function () {
                 const downloader = new RPCServerDownloader('../cache/node', 'latest');
 
                 existsSyncStub.resolves(false);
                 releaseStub.resolves(mockRelease);
-                assetToDownloadStub.resolves(mockAsset);
+                urlStub.resolves(mockUrl);
                 downloadStub.resolves('v1.0.0');
 
                 await downloader.downloadIfNeeded(true);
@@ -408,13 +396,13 @@ describe('node-zksync plugin', async function () {
                 sinon.assert.calledOnce(releaseStub);
             });
 
-            it('should throw an error if download fails', async () => {
+            it('should throw an error if download fails', async function () {
                 const downloader = new RPCServerDownloader('../cache/node', 'latest');
 
                 downloadStub.throws(new Error('Mocked download failure'));
                 existsSyncStub.resolves(false);
                 releaseStub.resolves(mockRelease);
-                assetToDownloadStub.resolves(mockRelease);
+                urlStub.resolves(mockRelease);
 
                 try {
                     await downloader.downloadIfNeeded(false);
@@ -426,7 +414,7 @@ describe('node-zksync plugin', async function () {
         });
     });
 
-    describe('JsonRpcServer', () => {
+    describe('JsonRpcServer', async function () {
         interface SpawnSyncError extends Error {
             signal?: string;
         }
@@ -448,8 +436,8 @@ describe('node-zksync plugin', async function () {
             consoleInfoStub.restore();
         });
 
-        describe('listen', () => {
-            it('should start the JSON-RPC server with the provided arguments', () => {
+        describe('listen', async function () {
+            it('should start the JSON-RPC server with the provided arguments', async function () {
                 const server = new JsonRpcServer('/path/to/binary');
                 const args = ['--arg1=value1', '--arg2=value2'];
 
@@ -465,7 +453,7 @@ describe('node-zksync plugin', async function () {
                 sinon.assert.calledWith(consoleInfoStub, chalk.green('Starting the JSON-RPC server at 127.0.0.1:8011'));
             });
 
-            it.skip('should handle termination signals gracefully', () => {
+            it.skip('should handle termination signals gracefully', async function () {
                 const server = new JsonRpcServer('/path/to/binary');
                 const error = new Error('Mocked error') as SpawnSyncError;
                 error.signal = PROCESS_TERMINATION_SIGNALS[0]; // Let's simulate the first signal, e.g., 'SIGINT'
@@ -484,7 +472,7 @@ describe('node-zksync plugin', async function () {
                 );
             });
 
-            it('should throw an error if the server process exits with an error', () => {
+            it('should throw an error if the server process exits with an error', async function () {
                 const server = new JsonRpcServer('/path/to/binary');
                 const error = new Error('Mocked error');
                 spawnStub.throws(error);
@@ -499,7 +487,7 @@ describe('node-zksync plugin', async function () {
         });
     });
 
-    describe('TASK_NODE_ZKSYNC', function () {
+    describe('TASK_NODE_ZKSYNC', async function () {
         this.timeout(10000); // Increase timeout if needed
 
         let serverProcess: ChildProcess;


### PR DESCRIPTION
# What :computer: 
* Get release tag from redirect url at node plugin

# Why :hand:
* To avoid throttling from github