### PR TITLE
chore: add codeowners for the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# This CODEOWNERS file sets the individuals responsible for code in the hardhat-zksync repository.
+
+# These users are the default owners for everything in the repo.
+# They will be requested for review when someone opens a pull request.
+
+* @matter-labs/external-txfusion-hardhat-team


### PR DESCRIPTION
# What :computer: 
* add CODEOWNERS for the repo

# Why :hand:
* Add organization that is responsible for external PRs