### PR TITLE
fix: move fallback optimizing for size to optimizer section

### DIFF
--- a/packages/hardhat-zksync-chai-matchers/tsconfig.json
+++ b/packages/hardhat-zksync-chai-matchers/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist",
     "esModuleInterop": true,
-    "skipLibCheck": true
   },
   "exclude": ["./dist", "./node_modules"]
 }

--- a/packages/hardhat-zksync-solc/src/compile/binary.ts
+++ b/packages/hardhat-zksync-solc/src/compile/binary.ts
@@ -7,11 +7,11 @@ export async function compileWithBinary(
     solcPath: string,
     detectMissingLibrariesMode: boolean = false,
 ): Promise<any> {
-    const { compilerPath, isSystem, forceEvmla, fallbackOz } = config.settings;
+    const { compilerPath, isSystem, forceEvmla} = config.settings;
 
     const processCommand = `${compilerPath} --standard-json ${isSystem ? '--system-mode' : ''} ${
         forceEvmla ? '--force-evmla' : ''
-    } ${fallbackOz ? '--fallback-Oz' : ''} --solc ${solcPath} ${
+    } --solc ${solcPath} ${
         detectMissingLibrariesMode ? '--detect-missing-libraries' : ''
     }`;
 

--- a/packages/hardhat-zksync-solc/src/compile/docker.ts
+++ b/packages/hardhat-zksync-solc/src/compile/docker.ts
@@ -128,9 +128,6 @@ export async function compileWithDocker(
     if (zksolcConfig.settings.forceEvmla) {
         command.push('--force-evmla');
     }
-    if (zksolcConfig.settings.fallbackOz) {
-        command.push('--fallback-Oz');
-    }
 
     // @ts-ignore
     const dockerInstance: Docker = docker._docker;

--- a/packages/hardhat-zksync-solc/src/compile/index.ts
+++ b/packages/hardhat-zksync-solc/src/compile/index.ts
@@ -21,11 +21,11 @@ import { compileWithBinary } from './binary';
 export async function compile(zksolcConfig: ZkSolcConfig, input: CompilerInput, solcPath?: string) {
     let compiler: ICompiler;
     if (
-        zksolcConfig.settings.fallbackOz &&
+        zksolcConfig.settings.optimizer?.fallback_to_optimizing_for_size &&
         semver.lt(zksolcConfig.version, ZKSOLC_COMPILER_MIN_VERSION_WITH_FALLBACK_OZ)
     ) {
         throw new ZkSyncSolcPluginError(
-            `FallbackOz option is not supported for zksolc compiler version ${zksolcConfig.version}. Please use version ${ZKSOLC_COMPILER_MIN_VERSION_WITH_FALLBACK_OZ} or higher.`,
+            `fallback_to_optimizing_for_size option in optimizer is not supported for zksolc compiler version ${zksolcConfig.version}. Please use version ${ZKSOLC_COMPILER_MIN_VERSION_WITH_FALLBACK_OZ} or higher.`,
         );
     }
     if (zksolcConfig.compilerSource === 'binary') {

--- a/packages/hardhat-zksync-solc/src/types.ts
+++ b/packages/hardhat-zksync-solc/src/types.ts
@@ -17,8 +17,6 @@ export interface ZkSolcConfig {
             enabled?: boolean;
             [key: string]: any;
         };
-        // Try to recompile with -Oz if the bytecode is too large.
-        fallbackOz?: boolean;
         // Remove metadata hash from bytecode. If the option is ommited, the metadata hash will be appended by default.
         metadata?: {
             bytecodeHash?: 'none';

--- a/packages/hardhat-zksync-solc/test/tests/compile/index.test.ts
+++ b/packages/hardhat-zksync-solc/test/tests/compile/index.test.ts
@@ -92,7 +92,7 @@ describe('compile', () => {
         }
     });
 
-    it.only('should throw an error for unsupported zksolc compiler version with fallback_to_optimizing_for_size', async () => {
+    it('should throw an error for unsupported zksolc compiler version with fallback_to_optimizing_for_size', async () => {
         const zksolcConfig: ZkSolcConfig = {
             compilerSource: 'binary',
             version: '1.3.16',
@@ -114,7 +114,7 @@ describe('compile', () => {
         }
     });
 
-    it.only('should zksolc compiler compile with fallback_to_optimizing_for_size', async () => {
+    it('should zksolc compiler compile with fallback_to_optimizing_for_size', async () => {
         const zksolcConfig: ZkSolcConfig = {
             compilerSource: 'binary',
             version: '1.3.21',

--- a/packages/hardhat-zksync-solc/test/tests/compile/index.test.ts
+++ b/packages/hardhat-zksync-solc/test/tests/compile/index.test.ts
@@ -92,12 +92,14 @@ describe('compile', () => {
         }
     });
 
-    it('should throw an error for unsupported zksolc compiler version with fallbackOz', async () => {
+    it.only('should throw an error for unsupported zksolc compiler version with fallback_to_optimizing_for_size', async () => {
         const zksolcConfig: ZkSolcConfig = {
             compilerSource: 'binary',
             version: '1.3.16',
             settings: {
-                fallbackOz: true,
+                optimizer: {
+                    fallback_to_optimizing_for_size: true,
+                },
             },
         };
 
@@ -107,17 +109,19 @@ describe('compile', () => {
             expect.fail('Expected ZkSyncSolcPluginError to be thrown');
         } catch (error: any) {
             expect(error.message).to.equal(
-                'FallbackOz option is not supported for zksolc compiler version 1.3.16. Please use version 1.3.21 or higher.',
+                'fallback_to_optimizing_for_size option in optimizer is not supported for zksolc compiler version 1.3.16. Please use version 1.3.21 or higher.',
             );
         }
     });
 
-    it('should zksolc compiler compile with fallbackOz', async () => {
+    it.only('should zksolc compiler compile with fallback_to_optimizing_for_size', async () => {
         const zksolcConfig: ZkSolcConfig = {
             compilerSource: 'binary',
             version: '1.3.21',
             settings: {
-                fallbackOz: true,
+                optimizer: {
+                    fallback_to_optimizing_for_size: true,
+                },
             },
         };
 


### PR DESCRIPTION
# What :computer: 
* Move fallback optimizing for size to optimizer section

# Why :hand:
* Guard for standard JSON is introduced which blocks --fallbackOz flag in zksolc compiler 