### PR TITLE
fix: add support for sepolia and zksync era test node

### DIFF
--- a/packages/hardhat-zksync-upgradable/src/core/provider.ts
+++ b/packages/hardhat-zksync-upgradable/src/core/provider.ts
@@ -7,8 +7,8 @@ export async function getChainId(provider: zk.Provider): Promise<number> {
 
 export const networkNames: { [chainId in number]?: string } = Object.freeze({
     324: 'zkSync-era',
-    280: 'zkSync-testnet',
+    280: 'zkSync-testnet-goerli',
     270: 'zkSync-local-setup',
-    300: 'zkSync-sepolia',
+    300: 'zkSync-testnet-sepolia',
     260: 'zkSync-era-test-node'
 });

--- a/packages/hardhat-zksync-upgradable/src/core/provider.ts
+++ b/packages/hardhat-zksync-upgradable/src/core/provider.ts
@@ -9,4 +9,5 @@ export const networkNames: { [chainId in number]?: string } = Object.freeze({
     324: 'zkSync-era',
     280: 'zkSync-testnet',
     270: 'zkSync-local-setup',
+    300: 'zkSync-sepolia'
 });

--- a/packages/hardhat-zksync-upgradable/src/core/provider.ts
+++ b/packages/hardhat-zksync-upgradable/src/core/provider.ts
@@ -9,5 +9,6 @@ export const networkNames: { [chainId in number]?: string } = Object.freeze({
     324: 'zkSync-era',
     280: 'zkSync-testnet',
     270: 'zkSync-local-setup',
-    300: 'zkSync-sepolia'
+    300: 'zkSync-sepolia',
+    260: 'zkSync-era-test-node'
 });


### PR DESCRIPTION
# What :computer: 
Added support for Sepolia and zkSync Era Test node

# Why :hand:
For proper folder naming when deploying upgradable contracts.