### PR TITLE
fix: add era test node and sepolia to supported networks

### DIFF
--- a/packages/hardhat-zksync-upgradable/src/core/provider.ts
+++ b/packages/hardhat-zksync-upgradable/src/core/provider.ts
@@ -7,6 +7,8 @@ export async function getChainId(provider: zk.Provider): Promise<number> {
 
 export const networkNames: { [chainId in number]?: string } = Object.freeze({
     324: 'zkSync-era',
-    280: 'zkSync-testnet',
+    280: 'zkSync-testnet-goerli',
     270: 'zkSync-local-setup',
+    300: 'zkSync-testnet-sepolia',
+    260: 'zkSync-era-test-node'
 });


### PR DESCRIPTION
# What :computer: 
Added support for Sepolia and zkSync Era Test node.



# Why :hand:
For proper folder naming when deploying upgradable contracts.

