### PR TITLE
chore: send notifications after github release is created

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -19,9 +19,17 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: google-github-actions/release-please-action@v3
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
+            command: manifest
             config-file: .github/release-please/config.json
             manifest-file: .github/release-please/manifest.json
-            target-branch: ${{ github.ref_name }}
+            monorepo-tags: true
+
+      - name: Send release info to the matter-labs slack channel
+        if: ${{ steps.release.outputs.releases_created }}
+        uses: matter-labs/format-release-please-for-slack-action@69e6fe9e4ec531b7b5fb0d826f73c190db83cf42 # v2.1.0
+        with:
+          release-please-output: ${{ toJSON(steps.release.outputs) }}
+          slack-webhook-url: ${{ secrets.MATTERMOST_URL }}


### PR DESCRIPTION
# What :computer: 
* Send notifications after github release is created

# Why :hand:
* So code owners are aware that new package release is present