### PR TITLE
fix: add no compile flag propagation for ethers-v5

### DIFF
--- a/packages/hardhat-zksync-upgradable/src/verify/verify-beacon.ts
+++ b/packages/hardhat-zksync-upgradable/src/verify/verify-beacon.ts
@@ -12,6 +12,7 @@ export async function fullVerifyBeacon(
     beaconAddress: any,
     hardhatVerify: (address: string) => Promise<any>,
     runSuper: RunSuperFunction<any>,
+    noCompile: boolean = false,
     quiet: boolean = false
 ) {
     const networkConfig: any = hre.network.config;
@@ -25,7 +26,7 @@ export async function fullVerifyBeacon(
         if (!quiet) {
             console.info(chalk.cyan(`Verifying beacon: ${beaconAddress}`));
         }
-        await verifyWithArtifact(hre, beaconAddress, [verifiableContracts.upgradeableBeacon], runSuper);
+        await verifyWithArtifact(hre, beaconAddress, [verifiableContracts.upgradeableBeacon], runSuper, noCompile);
     }
 }
 
@@ -34,19 +35,20 @@ export async function fullVerifyBeaconProxy(
     proxyAddress: any,
     hardhatVerify: (address: string) => Promise<any>,
     runSuper: RunSuperFunction<any>,
+    noCompile: boolean = false,
     quiet: boolean = false
 ) {
     const networkConfig: any = hre.network.config;
     const provider = new Provider(networkConfig.url);
     const beaconAddress = await getBeaconAddress(provider, proxyAddress);
 
-    await fullVerifyBeacon(hre, beaconAddress, hardhatVerify, runSuper);
+    await fullVerifyBeacon(hre, beaconAddress, hardhatVerify, runSuper, noCompile);
     await verifyBeaconProxy();
 
     async function verifyBeaconProxy() {
         if (!quiet) {
             console.info(chalk.cyan(`Verifying beacon proxy: ${proxyAddress}`));
         }
-        await verifyWithArtifact(hre, proxyAddress, [verifiableContracts.beaconProxy], runSuper);
+        await verifyWithArtifact(hre, proxyAddress, [verifiableContracts.beaconProxy], runSuper, noCompile);
     }
 }

--- a/packages/hardhat-zksync-upgradable/src/verify/verify-proxy.ts
+++ b/packages/hardhat-zksync-upgradable/src/verify/verify-proxy.ts
@@ -29,11 +29,11 @@ export async function verify(args: any, hre: HardhatRuntimeEnvironment, runSuper
     const proxyAddress = args.address;
 
     if (await isTransparentOrUUPSProxy(provider, proxyAddress)) {
-        await fullVerifyTransparentOrUUPS(hre, proxyAddress, hardhatZkSyncVerify, runSuper);
+        await fullVerifyTransparentOrUUPS(hre, proxyAddress, hardhatZkSyncVerify, runSuper, args.noCompile);
     } else if (await isBeaconProxy(provider, proxyAddress)) {
-        await fullVerifyBeaconProxy(hre, proxyAddress, hardhatZkSyncVerify, runSuper);
+        await fullVerifyBeaconProxy(hre, proxyAddress, hardhatZkSyncVerify, runSuper, args.noCompile);
     } else if (await isBeacon(provider, proxyAddress)) {
-        await fullVerifyBeacon(hre, proxyAddress, hardhatZkSyncVerify, runSuper);
+        await fullVerifyBeacon(hre, proxyAddress, hardhatZkSyncVerify, runSuper, args.noCompile);
     } else {
         return hardhatZkSyncVerify(proxyAddress);
     }
@@ -70,10 +70,11 @@ export async function verifyWithArtifact(
     hre: HardhatRuntimeEnvironment,
     address: string,
     possibleContractInfo: VerifiableContractInfo[],
-    runSuper: RunSuperFunction<any>
+    runSuper: RunSuperFunction<any>,
+    noCompile: boolean,
 ) {
     try {
-        await attemptVerifyWithCreationEvent(hre, address, possibleContractInfo, runSuper);
+        await attemptVerifyWithCreationEvent(hre, address, possibleContractInfo, runSuper, noCompile);
         return true;
     } catch (fallbackError: any) {
         if (fallbackError.message.toLowerCase().includes('already verified')) {
@@ -101,7 +102,8 @@ async function attemptVerifyWithCreationEvent(
     hre: HardhatRuntimeEnvironment,
     address: string,
     possibleContractInfo: VerifiableContractInfo[],
-    runSuper: RunSuperFunction<any>
+    runSuper: RunSuperFunction<any>,
+    noCompile: boolean,
 ) {
     const networkConfig: any = hre.network.config;
     const provider = new zk.Provider(networkConfig.url);
@@ -120,5 +122,5 @@ async function attemptVerifyWithCreationEvent(
     );
     const constructorArgs = decodedInputData[2];
 
-    await runSuper({ address: address, constructorArguments: constructorArgs, libraries: {} });
+    await runSuper({ address: address, constructorArguments: constructorArgs, libraries: {}, noCompile });
 }

--- a/packages/hardhat-zksync-upgradable/src/verify/verify-transparent-uups.ts
+++ b/packages/hardhat-zksync-upgradable/src/verify/verify-transparent-uups.ts
@@ -27,6 +27,7 @@ export async function fullVerifyTransparentOrUUPS(
     proxyAddress: any,
     hardhatVerify: (address: string) => Promise<any>,
     runSuper: RunSuperFunction<any>,
+    noCompile: boolean = false,
     quiet: boolean = false
 ) {
     const networkConfig: any = hre.network.config;
@@ -44,7 +45,7 @@ export async function fullVerifyTransparentOrUUPS(
                 console.info(chalk.cyan(`Verifying proxy admin: ${adminAddress}`));
             }
             try {
-                await verifyWithArtifact(hre, adminAddress, [verifiableContracts.proxyAdmin], runSuper);
+                await verifyWithArtifact(hre, adminAddress, [verifiableContracts.proxyAdmin], runSuper, noCompile);
             } catch (e: any) {
                 console.error(chalk.red(`Error verifying proxy admin: ${e.message}`));
             }
@@ -59,7 +60,8 @@ export async function fullVerifyTransparentOrUUPS(
             hre,
             proxyAddress,
             [verifiableContracts.transparentUpgradeableProxy, verifiableContracts.erc1967proxy],
-            runSuper
+            runSuper,
+            noCompile
         );
     }
 }


### PR DESCRIPTION
# What :computer: 
* Add no compile flag propagation for ethers-v5

# Why :hand:
* To support older verification of contracts compiled with currently unsupported zksolc versions.