### PR TITLE
fix: get release tag from redirect url at node plugin

### DIFF
--- a/packages/hardhat-zksync-node/src/constants.ts
+++ b/packages/hardhat-zksync-node/src/constants.ts
@@ -2,6 +2,10 @@ export const PLUGIN_NAME = '@matterlabs/hardhat-zksync-node';
 
 export const ZKNODE_BIN_OWNER = 'matter-labs';
 export const ZKNODE_BIN_REPOSITORY_NAME = 'era-test-node';
+export const ZKNODE_BIN_REPOSITORY = 'https://github.com/matter-labs/era-test-node';
+
+export const USER_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
 export const TASK_NODE_ZKSYNC = 'node-zksync';
 export const TASK_NODE_ZKSYNC_CREATE_SERVER = 'node-zksync:create-server';
@@ -48,6 +52,8 @@ export const NETWORK_GAS_PRICE = {
 export const NETWORK_ETH = {
     LOCALHOST: 'localhost',
 };
+
+export const DEFAULT_TIMEOUT_MILISECONDS = 30000;
 
 // export const TOOLCHAIN_MAP: Record<string, string> = {
 //     linux: '-musl',

--- a/packages/hardhat-zksync-node/src/downloader.ts
+++ b/packages/hardhat-zksync-node/src/downloader.ts
@@ -1,12 +1,15 @@
 import path from 'path';
 import fse from 'fs-extra';
-import { download, getAssetToDownload, getRelease } from './utils';
+import { download, getLatestRelease, getNodeUrl } from './utils';
 import { ZkSyncNodePluginError } from './errors';
 import {
     DEFAULT_RELEASE_CACHE_FILE_NAME,
     DEFAULT_RELEASE_VERSION_INFO_CACHE_PERIOD,
+    DEFAULT_TIMEOUT_MILISECONDS,
     PLUGIN_NAME,
+    USER_AGENT,
     ZKNODE_BIN_OWNER,
+    ZKNODE_BIN_REPOSITORY,
     ZKNODE_BIN_REPOSITORY_NAME,
 } from './constants';
 import chalk from 'chalk';
@@ -25,63 +28,70 @@ export class RPCServerDownloader {
 
     public async downloadIfNeeded(force: boolean): Promise<void> {
         if (force) {
-            await this._download(await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, PLUGIN_NAME, this._tag));
+            const releaseTag = this.isLatestTag()
+                ? await getLatestRelease(
+                    ZKNODE_BIN_OWNER,
+                    ZKNODE_BIN_REPOSITORY_NAME,
+                    USER_AGENT,
+                    DEFAULT_TIMEOUT_MILISECONDS,
+                )
+                : this._tag;
+            await this._download(releaseTag);
             return;
         }
 
         if (this.isLatestTag()) {
             if (!(await this._isLatestReleaseInfoValid())) {
-                const release = await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, PLUGIN_NAME, this._tag);
+                const latestTag = await getLatestRelease(
+                    ZKNODE_BIN_OWNER,
+                    ZKNODE_BIN_REPOSITORY_NAME,
+                    USER_AGENT,
+                    DEFAULT_TIMEOUT_MILISECONDS,
+                );
 
-                if (await this._isBinaryPathExists(release.tag_name)) {
-                    await this._postProcessDownload(release.tag_name);
+                if (await this._isBinaryPathExists(latestTag)) {
+                    await this._postProcessDownload(latestTag);
                     return;
                 }
 
-                await this._download(release);
+                await this._download(latestTag);
                 return;
             }
 
             const info = await this._getLatestReleaseInfo();
-            if (info && await this._isBinaryPathExists(info.latest)) {
+            if (info && (await this._isBinaryPathExists(info.latest))) {
                 return;
             }
 
-            const release = await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, PLUGIN_NAME, this._tag);
+            const latestTag = await getLatestRelease(
+                ZKNODE_BIN_OWNER,
+                ZKNODE_BIN_REPOSITORY_NAME,
+                USER_AGENT,
+                DEFAULT_TIMEOUT_MILISECONDS,
+            );
 
-            if (info
-                && info.latest === release.tag_name
-                && await this._isBinaryPathExists(release.tag_name)) {
-
-                await this._postProcessDownload(release.tag_name);
+            if (info && info.latest === latestTag && (await this._isBinaryPathExists(latestTag))) {
+                await this._postProcessDownload(latestTag);
                 return;
             }
-            await this._download(release);
+            await this._download(latestTag);
             return;
         }
 
         if (!(await this._isBinaryPathExists(this._tag))) {
-            await this._download(await getRelease(ZKNODE_BIN_OWNER, ZKNODE_BIN_REPOSITORY_NAME, PLUGIN_NAME, this._tag));
+            await this._download(this._tag);
         }
     }
 
-    private async _download(release: any): Promise<void> {
-        const assetToDownload: any = await getAssetToDownload(release);
+    private async _download(tag: any): Promise<void> {
+        const url: any = await getNodeUrl(ZKNODE_BIN_REPOSITORY, tag);
         try {
-            console.info(chalk.yellow(`Downloading era-test-node binary, release: ${release.tag_name}`));
-            await download(
-                assetToDownload.browser_download_url,
-                await this._createBinaryPath(release.tag_name),
-                PLUGIN_NAME,
-                release.tag_name,
-                30000
-            );
-            await this._postProcessDownload(release.tag_name);
+            console.info(chalk.yellow(`Downloading era-test-node binary, release: ${tag}`));
+            await download(url, await this._createBinaryPath(tag), PLUGIN_NAME, tag, 30000);
+            await this._postProcessDownload(tag);
             console.info(chalk.green('era-test-node binary downloaded successfully'));
         } catch (error: any) {
-            throw new ZkSyncNodePluginError(
-                `Error downloading binary from URL ${assetToDownload.browser_download_url}: ${error.message}`
-            );
+            throw new ZkSyncNodePluginError(`Error downloading binary from URL ${url}: ${error.message}`);
         }
     }
 

--- a/packages/hardhat-zksync-node/test/tests.ts
+++ b/packages/hardhat-zksync-node/test/tests.ts
@@ -1,5 +1,4 @@
-import { expect, assert } from 'chai';
-import chai from 'chai';
+import chai, { expect, assert } from 'chai';
 import sinonChai from 'sinon-chai';
 import chalk from 'chalk';
 import sinon from 'sinon';
@@ -11,9 +10,10 @@ import proxyquire from 'proxyquire';
 import { spawn, ChildProcess } from 'child_process';
 
 import * as utils from '../src/utils';
-import { constructCommandArgs, getRelease, getAssetToDownload } from '../src/utils';
+import { constructCommandArgs } from '../src/utils';
 import { RPCServerDownloader } from '../src/downloader';
 import { TASK_NODE_ZKSYNC, PROCESS_TERMINATION_SIGNALS } from '../src/constants';
+import { USER_AGENT } from '../dist/constants';
 
 chai.use(sinonChai);
 
@@ -31,15 +31,128 @@ async function getPort(): Promise<number> {
 }
 
 describe('node-zksync plugin', async function () {
-    describe('Utils', () => {
-        describe('constructCommandArgs', () => {
-            it('should construct command arguments with minimum args', () => {
+    describe('getLatestRelease', async function () {
+        let mockPool: any;
+        before(() => {
+            const { MockAgent, setGlobalDispatcher } = require('undici');
+            const mockAgent = new MockAgent();
+            mockPool = mockAgent.get('https://github.com');
+
+            setGlobalDispatcher(mockAgent);
+        });
+
+        const mockRelease = '0.1.0';
+
+        it('should fetch the latest release successfully', async function () {
+            mockPool
+                .intercept({
+                    path: '/owner/repo/releases/latest',
+                    timeout: 30000,
+                    'User-Agent': USER_AGENT,
+                    method: 'GET',
+                })
+                .reply(
+                    302,
+                    {},
+                    {
+                        headers: {
+                            location: 'https://github.com/owner/repo/releases/tag/v0.1.0',
+                        },
+                    },
+                );
+
+            const result = await utils.getLatestRelease('owner', 'repo', 'userAgent', 30000);
+            expect(result).to.deep.equal(mockRelease);
+        });
+
+        it('should handle errors when the server responds with a non-2xx status code', async function () {
+            mockPool
+                .intercept({
+                    path: '/owner/repo/releases/latest',
+                    method: 'GET',
+                })
+                .reply(404, {
+                    body: {
+                        status: 404,
+                        data: {
+                            message: 'Not Found',
+                        },
+                    },
+                });
+
+            try {
+                await utils.getLatestRelease('owner', 'repo', 'userAgent', 30000);
+                assert.fail('Expected an error to be thrown');
+            } catch (error: any) {
+                expect(error.message).to.be.equal(
+                    'Unexpected response status: 404 for URL: https://github.com/owner/repo/releases/latest',
+                );
+            }
+        });
+
+        it('should handle errors when no response is received', async function () {
+            mockPool
+                .intercept({
+                    path: '/owner/repo/releases/latest',
+                    timeout: 30000,
+                    'User-Agent': USER_AGENT,
+                    method: 'GET',
+                })
+                .reply(
+                    302,
+                    {},
+                    {
+                        headers: {},
+                    },
+                );
+
+            try {
+                await utils.getLatestRelease('owner', 'repo', 'userAgent', 30000);
+                assert.fail('Expected an error to be thrown');
+            } catch (error: any) {
+                expect(error.message).to.be.equal(
+                    'Redirect location not found for URL: https://github.com/owner/repo/releases/latest',
+                );
+            }
+        });
+
+        it('should handle errors during request setup', async function () {
+            mockPool
+                .intercept({
+                    path: '/owner/repo/releases/latest',
+                    timeout: 30000,
+                    'User-Agent': USER_AGENT,
+                    method: 'GET',
+                })
+                .reply(
+                    302,
+                    {},
+                    {
+                        headers: {
+                            location: 'https://github.com/owner/wrong/',
+                        },
+                    },
+                );
+
+            try {
+                await utils.getLatestRelease('owner', 'repo', 'userAgent', 30000);
+                assert.fail('Expected an error to be thrown');
+            } catch (error: any) {
+                expect(error.message).to.be.equal(
+                    'Unexpected redirect URL: https://github.com/owner/wrong/ for URL: https://github.com/owner/repo/releases/latest',
+                );
+            }
+        });
+    });
+    describe('Utils', async function () {
+        describe('constructCommandArgs', async function () {
+            it('should construct command arguments with minimum args', async function () {
                 const args = {};
                 const result = constructCommandArgs(args);
                 expect(result).to.deep.equal(['run']);
             });
 
-            it('should correctly construct command arguments with all args', () => {
+            it('should correctly construct command arguments with all args', async function () {
                 const args = {
                     port: 8012,
                     log: 'error',
@@ -75,26 +188,26 @@ describe('node-zksync plugin', async function () {
                 ]);
             });
 
-            it('should throw error when both forkBlockNumber and replayTx are specified in all args', () => {
+            it('should throw error when both forkBlockNumber and replayTx are specified in all args', async function () {
                 const args = { fork: 'mainnet', forkBlockNumber: 100, replayTx: '0x1234567890abcdef' };
                 expect(() => constructCommandArgs(args)).to.throw(
-                    'Cannot specify both --fork-block-number and --replay-tx. Please specify only one of them.'
+                    'Cannot specify both --fork-block-number and --replay-tx. Please specify only one of them.',
                 );
             });
 
-            it('should throw error for invalid log value', () => {
+            it('should throw error for invalid log value', async function () {
                 const args = { log: 'invalid' };
                 expect(() => constructCommandArgs(args)).to.throw('Invalid log value: invalid');
             });
 
-            it('should throw error when there is no fork arg', () => {
+            it('should throw error when there is no fork arg', async function () {
                 const args = { forkBlockNumber: 100 };
                 expect(() => constructCommandArgs(args)).to.throw(
-                    'Cannot specify --replay-tx or --fork-block-number parameters without --fork param.'
+                    'Cannot specify --replay-tx or --fork-block-number parameters without --fork param.',
                 );
             });
 
-            it('should correctly construct command arguments with fork and replayTx', () => {
+            it('should correctly construct command arguments with fork and replayTx', async function () {
                 const args = { fork: 'http://example.com', replayTx: '0x1234567890abcdef' };
                 const result = constructCommandArgs(args);
                 expect(result).to.deep.equal(['replay_tx http://example.com 0x1234567890abcdef']);
@@ -108,267 +221,140 @@ describe('node-zksync plugin', async function () {
                 expect(() => constructCommandArgs(args)).to.throw('Invalid fork network value: invalidURL');
             });
         });
+    });
 
-        describe('getAssetToDownload', () => {
-            let archStub: sinon.SinonStub;
-            let platformStub: sinon.SinonStub;
+    describe.skip('getNodeUrl', async function () {
+        it('should return the node URL for the given repo and release', async function () {
+            const repo = 'example/repo';
+            const release = '1.0.0';
+            const expectedUrl = `${repo}/releases/download/v${release}/era_test_node-v${release}-amd64-linux.tar.gz`;
 
-            const mockRelease = {
-                tag_name: 'v0.1.0',
-                assets: [
-                    { name: 'era_test_node-v0.1.0-aarch64-apple-darwin.tar.gz' },
-                    { name: 'era_test_node-v0.1.0-x86_64-apple-darwin.tar.gz' },
-                    { name: 'era_test_node-v0.1.0-x86_64-unknown-linux-gnu.tar.gz' },
-                ],
-            };
+            const url = await utils.getNodeUrl(repo, release);
 
-            beforeEach(() => {
-                archStub = sinon.stub(process, 'arch');
-                platformStub = sinon.stub(process, 'platform');
-            });
-
-            afterEach(() => {
-                archStub.restore();
-                platformStub.restore();
-            });
-
-            it('should return the correct asset for x64 apple-darwin', async () => {
-                archStub.value('x64');
-                platformStub.value('darwin');
-                expect(await getAssetToDownload(mockRelease)).to.deep.equal(mockRelease.assets[1]);
-            });
-
-            it('should return the correct asset for aarch64 apple-darwin', async () => {
-                archStub.value('arm64');
-                platformStub.value('darwin');
-                expect(await getAssetToDownload(mockRelease)).to.deep.equal(mockRelease.assets[0]);
-            });
-
-            it('should return the correct asset for x64 linux', async () => {
-                archStub.value('x64');
-                platformStub.value('linux');
-                expect(await getAssetToDownload(mockRelease)).to.deep.equal(mockRelease.assets[2]);
-            });
-
-            it('should throw an error for unsupported platform', async () => {
-                archStub.value('x64');
-                platformStub.value('win32');
-                try {
-                    await getAssetToDownload(mockRelease);
-                    throw new Error("Expected an error to be thrown, but it wasn't.");
-                } catch (error: any) {
-                    expect(error.message).to.include('Unsupported platform');
-                }
-            });
+            expect(url).to.equal(expectedUrl);
         });
 
-        describe('getLatestRelease', () => {
-            let axiosGetStub: sinon.SinonStub;
+        it('should throw an error for unsupported platforms', async function () {
+            const repo = 'example/repo';
+            const release = '1.0.0';
+            const platform = 'windows';
 
-            const mockRelease = {
-                assets: [
-                    {
-                        url: 'https://api.github.com/repos/matter-labs/era-test-node/releases/assets/1',
-                        browser_download_url:
-                            'https://github.com/matter-labs/era-test-node/releases/download/v0.1.0/era_test_node-v0.1.0-aarch64-apple-darwin.tar.gz',
-                    },
-                    {
-                        url: 'https://api.github.com/repos/matter-labs/era-test-node/releases/assets/2',
-                        browser_download_url:
-                            'https://github.com/matter-labs/era-test-node/releases/download/v0.1.0/era_test_node-v0.1.0-x86_64-apple-darwin.tar.gz',
-                    },
-                    {
-                        url: 'https://api.github.com/repos/matter-labs/era-test-node/releases/assets/3',
-                        browser_download_url:
-                            'https://github.com/matter-labs/era-test-node/releases/download/v0.1.0/era_test_node-v0.1.0-x86_64-unknown-linux-gnu.tar.gz',
-                    },
-                ],
-            };
-
-            beforeEach(() => {
-                axiosGetStub = sinon.stub(axios, 'get');
-            });
-
-            afterEach(() => {
-                axiosGetStub.restore();
-            });
-
-            it('should fetch the latest release successfully', async () => {
-                axiosGetStub.resolves({ data: mockRelease });
-
-                const result = await getRelease('owner', 'repo', 'userAgent');
-                expect(result).to.deep.equal(mockRelease);
-
-                sinon.assert.calledOnce(axiosGetStub);
-            });
-
-            it('should handle errors when the server responds with a non-2xx status code', async () => {
-                const errorResponse = {
-                    response: {
-                        status: 404,
-                        data: {
-                            message: 'Not Found',
-                        },
-                    },
-                };
-
-                axiosGetStub.rejects(errorResponse);
-
-                try {
-                    await getRelease('owner', 'repo', 'userAgent', 'v0.1.0');
-                    assert.fail('Expected an error to be thrown');
-                } catch (error: any) {
-                    expect(error.message).to.include('Failed to get v0.1.0 release');
-                    expect(error.message).to.include('404');
-                    expect(error.message).to.include('Not Found');
-                }
-            });
-
-            it('should handle errors when no response is received', async () => {
-                const errorNoResponse = {
-                    request: {},
-                    message: 'No response',
-                };
-
-                axiosGetStub.rejects(errorNoResponse);
-
-                try {
-                    await getRelease('owner', 'repo', 'userAgent');
-                    assert.fail('Expected an error to be thrown');
-                } catch (error: any) {
-                    expect(error.message).to.include('No response received');
-                }
-            });
-
-            it('should handle errors during request setup', async () => {
-                const errorSetup = {
-                    message: 'Setup error',
-                };
-
-                axiosGetStub.rejects(errorSetup);
-
-                try {
-                    await getRelease('owner', 'repo', 'userAgent');
-                    assert.fail('Expected an error to be thrown');
-                } catch (error: any) {
-                    expect(error.message).to.include('Failed to set up the request');
-                }
-            });
-        });
-
-        describe('waitForNodeToBeReady', () => {
-            afterEach(() => {
-                sinon.restore();
-            });
-
-            it('should return successfully if the node is ready', async () => {
-                // Mock the axios.post to simulate a node being ready
-                sinon.stub(axios, 'post').resolves({ data: { result: true } });
-
-                const port = 12345; // any port for testing purposes
-                await utils.waitForNodeToBeReady(port);
-
-                expect(axios.post).to.have.been.calledWith(`http://127.0.0.1:${port}`);
-            });
-
-            it("should throw an error if the node isn't ready after maxAttempts", async () => {
-                // Make the stub reject all the time to simulate the node never being ready
-                sinon.stub(axios, 'post').rejects(new Error('Node not ready'));
-
-                try {
-                    await utils.waitForNodeToBeReady(8080, 1);
-                    throw new Error('Expected waitForNodeToBeReady to throw but it did not');
-                } catch (err: any) {
-                    expect(err.message).to.equal("Server didn't respond after multiple attempts");
-                }
-            });
-        });
-
-        describe('adjustTaskArgsForPort', () => {
-            it("should correctly add the --port argument if it's not present", () => {
-                const result = utils.adjustTaskArgsForPort([], 8000);
-                expect(result).to.deep.equal(['--port', '8000']);
-            });
-
-            it("should correctly update the --port argument if it's present", () => {
-                const result = utils.adjustTaskArgsForPort(['--port', '9000'], 8000);
-                expect(result).to.deep.equal(['--port', '8000']);
-            });
-        });
-
-        describe('isPortAvailable', () => {
-            let server: net.Server;
-
-            afterEach(() => {
-                if (server) server.close();
-            });
-
-            it('should correctly identify an available port', async () => {
-                const port = await getPort();
-                const result = await utils.isPortAvailable(port);
-                expect(result).to.be.true;
-            });
-
-            it('should correctly identify a port that is in use', async () => {
-                const port = await getPort();
-                server = net.createServer().listen(port);
-                const result = await utils.isPortAvailable(port);
-                expect(result).to.be.false;
-            });
-        });
-
-        describe('getAvailablePort', () => {
-            let isPortAvailableStub: sinon.SinonStub<[number], Promise<boolean>>;
-
-            beforeEach(() => {
-                isPortAvailableStub = sinon.stub(utils, 'isPortAvailable');
-            });
-
-            afterEach(() => {
-                isPortAvailableStub.restore();
-            });
-
-            it('should return the first available port', async () => {
-                isPortAvailableStub.returns(Promise.resolve(true));
-                const port = await utils.getAvailablePort(8080, 10);
-                expect(port).to.equal(8080);
-            });
-
-            // it('should throw an error after checking the maxAttempts number of ports', async () => {
-            //     isPortAvailableStub.returns(Promise.resolve(false));
-
-            //     try {
-            //         await utils.getAvailablePort(8000, 10);
-            //         throw new Error('Expected getAvailablePort to throw but it did not');
-            //     } catch (err: any) {
-            //         expect(err.message).to.equal('Couldn\'t find an available port after several attempts');
-            //     }
-            // });
+            try {
+                await utils.getNodeUrl(repo, release);
+                // Fail the test if no error is thrown
+                expect.fail('Expected an error to be thrown');
+            } catch (error: any) {
+                expect(error.message).to.equal(`Unsupported platform: ${platform}`);
+            }
         });
     });
 
-    describe('RPCServerDownloader', () => {
+    describe('waitForNodeToBeReady', async function () {
+        afterEach(() => {
+            sinon.restore();
+        });
 
-        const mockRelease = {
-            url: 'https://api.github.com/repos/matter-labs/era-test-node/releases/assets/latest',
-            tag_name: 'v1.0.0',
-        };
+        it('should return successfully if the node is ready', async function () {
+            // Mock the axios.post to simulate a node being ready
+            sinon.stub(axios, 'post').resolves({ data: { result: true } });
 
-        const mockAsset = {
-            browser_download_url:
-            'https://github.com/matter-labs/era-test-node/releases/download/v0.1.0/era_test_node-v0.1.0-aarch64-apple-darwin.tar.gz',
-        }
-    
+            const port = 12345; // any port for testing purposes
+            await utils.waitForNodeToBeReady(port);
+
+            expect(axios.post).to.have.been.calledWith(`http://127.0.0.1:${port}`);
+        });
+
+        it("should throw an error if the node isn't ready after maxAttempts", async () => {
+            // Make the stub reject all the time to simulate the node never being ready
+            sinon.stub(axios, 'post').rejects(new Error('Node not ready'));
+
+            try {
+                await utils.waitForNodeToBeReady(8080, 1);
+                throw new Error('Expected waitForNodeToBeReady to throw but it did not');
+            } catch (err: any) {
+                expect(err.message).to.equal("Server didn't respond after multiple attempts");
+            }
+        });
+    });
+
+    describe('adjustTaskArgsForPort', async function () {
+        it("should correctly add the --port argument if it's not present", async function () {
+            const result = utils.adjustTaskArgsForPort([], 8000);
+            expect(result).to.deep.equal(['--port', '8000']);
+        });
+
+        it("should correctly update the --port argument if it's present", async function () {
+            const result = utils.adjustTaskArgsForPort(['--port', '9000'], 8000);
+            expect(result).to.deep.equal(['--port', '8000']);
+        });
+    });
+
+    describe('isPortAvailable', async function () {
+        let server: net.Server;
+
+        afterEach(() => {
+            if (server) server.close();
+        });
+
+        it('should correctly identify an available port', async function () {
+            const port = await getPort();
+            const result = await utils.isPortAvailable(port);
+            expect(result).to.equal(true);
+        });
+
+        it('should correctly identify a port that is in use', async function () {
+            const port = await getPort();
+            server = net.createServer().listen(port);
+            const result = await utils.isPortAvailable(port);
+            expect(result).to.equal(false);
+        });
+    });
+
+    describe('getAvailablePort', () => {
+        let isPortAvailableStub: sinon.SinonStub<[number], Promise<boolean>>;
+
+        beforeEach(() => {
+            isPortAvailableStub = sinon.stub(utils, 'isPortAvailable');
+        });
+
+        afterEach(() => {
+            isPortAvailableStub.restore();
+        });
+
+        it('should return the first available port', async function () {
+            isPortAvailableStub.returns(Promise.resolve(true));
+            const port = await utils.getAvailablePort(8080, 10);
+            expect(port).to.equal(8080);
+        });
+
+        // it('should throw an error after checking the maxAttempts number of ports', async () => {
+        //     isPortAvailableStub.returns(Promise.resolve(false));
+
+        //     try {
+        //         await utils.getAvailablePort(8000, 10);
+        //         throw new Error('Expected getAvailablePort to throw but it did not');
+        //     } catch (err: any) {
+        //         expect(err.message).to.equal('Couldn\'t find an available port after several attempts');
+        //     }
+        // });
+    });
+
+    describe('RPCServerDownloader', async function () {
+        const mockRelease = '1.0.0';
+
+        const mockUrl =
+            'https://github.com/matter-labs/era-test-node/releases/download/v0.1.0/era_test_node-v0.1.0-aarch64-apple-darwin.tar.gz';
+
         let downloadStub: sinon.SinonStub;
         let existsSyncStub: sinon.SinonStub;
         let postProcessDownloadStub: sinon.SinonStub;
         let releaseStub: sinon.SinonStub;
-        let assetToDownloadStub: sinon.SinonStub;
+        let urlStub: sinon.SinonStub;
 
         beforeEach(() => {
             downloadStub = sinon.stub(utils, 'download');
-            releaseStub = sinon.stub(utils, 'getRelease');
-            assetToDownloadStub = sinon.stub(utils, 'getAssetToDownload');
+            releaseStub = sinon.stub(utils, 'getLatestRelease');
+            urlStub = sinon.stub(utils, 'getNodeUrl');
             existsSyncStub = sinon.stub(fs, 'existsSync');
             postProcessDownloadStub = sinon
                 .stub(RPCServerDownloader.prototype as any, '_postProcessDownload')
@@ -380,12 +366,12 @@ describe('node-zksync plugin', async function () {
         });
 
         describe('download', () => {
-            it('should download the binary if not already downloaded', async () => {
+            it('should download the binary if not already downloaded', async function () {
                 const downloader = new RPCServerDownloader('../cache/node', 'latest');
 
                 existsSyncStub.resolves(false);
                 releaseStub.resolves(mockRelease);
-                assetToDownloadStub.resolves(mockAsset);
+                urlStub.resolves(mockUrl);
                 downloadStub.resolves('v1.0.0');
 
                 await downloader.downloadIfNeeded(false);
@@ -395,12 +381,12 @@ describe('node-zksync plugin', async function () {
                 sinon.assert.calledOnce(releaseStub);
             });
 
-            it('should force download the binary', async () => {
+            it('should force download the binary', async function () {
                 const downloader = new RPCServerDownloader('../cache/node', 'latest');
 
                 existsSyncStub.resolves(false);
                 releaseStub.resolves(mockRelease);
-                assetToDownloadStub.resolves(mockAsset);
+                urlStub.resolves(mockUrl);
                 downloadStub.resolves('v1.0.0');
 
                 await downloader.downloadIfNeeded(true);
@@ -410,13 +396,13 @@ describe('node-zksync plugin', async function () {
                 sinon.assert.calledOnce(releaseStub);
             });
 
-            it('should throw an error if download fails', async () => {
+            it('should throw an error if download fails', async function () {
                 const downloader = new RPCServerDownloader('../cache/node', 'latest');
 
                 downloadStub.throws(new Error('Mocked download failure'));
                 existsSyncStub.resolves(false);
                 releaseStub.resolves(mockRelease);
-                assetToDownloadStub.resolves(mockRelease);
+                urlStub.resolves(mockRelease);
 
                 try {
                     await downloader.downloadIfNeeded(false);
@@ -428,17 +414,17 @@ describe('node-zksync plugin', async function () {
         });
     });
 
-    describe('JsonRpcServer', () => {
+    describe('JsonRpcServer', async function () {
         interface SpawnSyncError extends Error {
             signal?: string;
         }
 
-        let spawnStub = sinon.stub();
+        const spawnStub = sinon.stub();
         let consoleInfoStub: sinon.SinonStub;
 
         // Because we cannot stub the execSync method directly, we use proxyquire to stub the entire 'child_process' module
         const { JsonRpcServer } = proxyquire('../src/server', {
-            'child_process': { spawn: spawnStub },
+            child_process: { spawn: spawnStub },
         });
 
         beforeEach(() => {
@@ -450,8 +436,8 @@ describe('node-zksync plugin', async function () {
             consoleInfoStub.restore();
         });
 
-        describe('listen', () => {
-            it('should start the JSON-RPC server with the provided arguments', () => {
+        describe('listen', async function () {
+            it('should start the JSON-RPC server with the provided arguments', async function () {
                 const server = new JsonRpcServer('/path/to/binary');
                 const args = ['--arg1=value1', '--arg2=value2'];
 
@@ -467,7 +453,7 @@ describe('node-zksync plugin', async function () {
                 sinon.assert.calledWith(consoleInfoStub, chalk.green('Starting the JSON-RPC server at 127.0.0.1:8011'));
             });
 
-            it.skip('should handle termination signals gracefully', () => {
+            it.skip('should handle termination signals gracefully', async function () {
                 const server = new JsonRpcServer('/path/to/binary');
                 const error = new Error('Mocked error') as SpawnSyncError;
                 error.signal = PROCESS_TERMINATION_SIGNALS[0]; // Let's simulate the first signal, e.g., 'SIGINT'
@@ -482,11 +468,11 @@ describe('node-zksync plugin', async function () {
 
                 sinon.assert.calledWithMatch(
                     consoleInfoStub,
-                    chalk.yellow(`Received ${PROCESS_TERMINATION_SIGNALS[0]} signal. The server process has exited.`)
+                    chalk.yellow(`Received ${PROCESS_TERMINATION_SIGNALS[0]} signal. The server process has exited.`),
                 );
             });
 
-            it('should throw an error if the server process exits with an error', () => {
+            it('should throw an error if the server process exits with an error', async function () {
                 const server = new JsonRpcServer('/path/to/binary');
                 const error = new Error('Mocked error');
                 spawnStub.throws(error);
@@ -494,19 +480,19 @@ describe('node-zksync plugin', async function () {
                 try {
                     server.listen();
                     expect.fail('Expected an error to be thrown');
-                } catch (error: any) {
-                    expect(error.message).to.equal('Expected an error to be thrown');
+                } catch (err: any) {
+                    expect(err.message).to.equal('Expected an error to be thrown');
                 }
             });
         });
     });
 
-    describe('TASK_NODE_ZKSYNC', function () {
+    describe('TASK_NODE_ZKSYNC', async function () {
         this.timeout(10000); // Increase timeout if needed
 
         let serverProcess: ChildProcess;
 
-        function delay(ms: number): Promise<void> {
+        function _delay(ms: number): Promise<void> {
             return new Promise((resolve) => setTimeout(resolve, ms));
         }
 


### PR DESCRIPTION
# What :computer: 
* Get release tag from redirect url at node plugin

# Why :hand:
* To avoid throttling from github
