### PR TITLE
fix: add factory deps for implementation deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,12 @@ jobs:
           yarn hardhat run scripts/upgrade-box-beacon.ts 
           yarn hardhat run scripts/upgrade-box-uups.ts 
           yarn hardhat run scripts/upgrade-box.ts 
+          yarn hardhat run scripts/deploy-factory-beacon.ts 
+          yarn hardhat run scripts/deploy-factory-proxy.ts 
+          yarn hardhat run scripts/deploy-factory-uups.ts 
+          yarn hardhat run scripts/upgrade-factory-beacon.ts 
+          yarn hardhat run scripts/upgrade-factory-uups.ts 
+          yarn hardhat run scripts/upgrade-factory.ts 
       - name: Show logs
         if: always()
         run: |

--- a/examples/upgradable-example/contracts/Empty.sol
+++ b/examples/upgradable-example/contracts/Empty.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract EmptyContract {
+}

--- a/examples/upgradable-example/contracts/Factory.sol
+++ b/examples/upgradable-example/contracts/Factory.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract EmptyContract {
-}
+import "./Empty.sol";
 
 contract Factory {
     address[] public deployedContracts;

--- a/examples/upgradable-example/contracts/Factory.sol
+++ b/examples/upgradable-example/contracts/Factory.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract EmptyContract {
+}
+
+contract Factory {
+    address[] public deployedContracts;
+
+    function initialize() public{
+        deployEmptyContract();
+    }
+
+    function deployEmptyContract() public {
+        EmptyContract newContract = new EmptyContract();
+        deployedContracts.push(address(newContract));
+    }
+
+    function getNumberOfDeployedContracts() public view returns (uint) {
+        return deployedContracts.length;
+    }
+}

--- a/examples/upgradable-example/contracts/FactoryUups.sol
+++ b/examples/upgradable-example/contracts/FactoryUups.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+
+contract EmptyContract {
+}
+
+contract FactoryUups is Initializable, UUPSUpgradeable, OwnableUpgradeable  {
+    address[] public deployedContracts;
+
+    function initialize() public initializer{
+        __Ownable_init();
+        __UUPSUpgradeable_init();
+        deployEmptyContract();
+    }
+
+    function deployEmptyContract() public {
+        EmptyContract newContract = new EmptyContract();
+        deployedContracts.push(address(newContract));
+    }
+
+    function getNumberOfDeployedContracts() public view returns (uint) {
+        return deployedContracts.length;
+    }
+
+    function storeNothing() public pure {
+        
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+}

--- a/examples/upgradable-example/contracts/FactoryUups.sol
+++ b/examples/upgradable-example/contracts/FactoryUups.sol
@@ -4,9 +4,8 @@ pragma solidity ^0.8.0;
 import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import "./Empty.sol";
 
-contract EmptyContract {
-}
 
 contract FactoryUups is Initializable, UUPSUpgradeable, OwnableUpgradeable  {
     address[] public deployedContracts;

--- a/examples/upgradable-example/contracts/FactoryUupsV2.sol
+++ b/examples/upgradable-example/contracts/FactoryUupsV2.sol
@@ -4,9 +4,8 @@ pragma solidity ^0.8.0;
 import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import "./Empty.sol";
 
-contract EmptyContract {
-}
 
 contract FactoryUupsV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable  {
     address[] public deployedContracts;

--- a/examples/upgradable-example/contracts/FactoryUupsV2.sol
+++ b/examples/upgradable-example/contracts/FactoryUupsV2.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+
+contract EmptyContract {
+}
+
+contract FactoryUupsV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable  {
+    address[] public deployedContracts;
+
+    function initialize() public initializer{
+        deployEmptyContract();
+    }
+
+    function deployEmptyContract() public {
+        EmptyContract newContract = new EmptyContract();
+        deployedContracts.push(address(newContract));
+    }
+
+    function getNumberOfDeployedContracts() public view returns (uint) {
+        return deployedContracts.length;
+    }
+    
+    function storeNothing() public pure {
+        
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    function uint2str(uint _i) internal pure returns (string memory) {
+        if (_i == 0) {
+            return '0';
+        }
+        uint j = _i;
+        uint len;
+        while (j != 0) {
+            len++;
+            j /= 10;
+        }
+        bytes memory bstr = new bytes(len);
+        uint k = len;
+        while (_i != 0) {
+            k = k - 1;
+            uint8 temp = (48 + uint8(_i - (_i / 10) * 10));
+            bytes1 b1 = bytes1(temp);
+            bstr[k] = b1;
+            _i /= 10;
+        }
+        return string(bstr);
+    }
+}

--- a/examples/upgradable-example/contracts/FactoryV2.sol
+++ b/examples/upgradable-example/contracts/FactoryV2.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract EmptyContract {
-}
+import "./Empty.sol";
+
 
 contract FactoryV2 {
     address[] public deployedContracts;

--- a/examples/upgradable-example/contracts/FactoryV2.sol
+++ b/examples/upgradable-example/contracts/FactoryV2.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract EmptyContract {
+}
+
+contract FactoryV2 {
+    address[] public deployedContracts;
+
+    function initialize() public{
+        deployEmptyContract();
+    }
+
+    function deployEmptyContract() public {
+        EmptyContract newContract = new EmptyContract();
+        deployedContracts.push(address(newContract));
+    }
+
+    function getNumberOfDeployedContracts() public view returns (uint) {
+        return deployedContracts.length;
+    }
+
+    function uint2str(uint _i) internal pure returns (string memory) {
+        if (_i == 0) {
+            return "0";
+        }
+        uint j = _i;
+        uint len;
+        while (j != 0) {
+            len++;
+            j /= 10;
+        }
+        bytes memory bstr = new bytes(len);
+        uint k = len;
+        while (_i != 0) {
+            k = k - 1;
+            uint8 temp = (48 + uint8(_i - (_i / 10) * 10));
+            bytes1 b1 = bytes1(temp);
+            bstr[k] = b1;
+            _i /= 10;
+        }
+        return string(bstr);
+    }
+}

--- a/examples/upgradable-example/scripts/deploy-factory-beacon.ts
+++ b/examples/upgradable-example/scripts/deploy-factory-beacon.ts
@@ -1,0 +1,34 @@
+import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
+import { Wallet } from 'zksync-ethers';
+import chalk from 'chalk';
+
+import * as hre from 'hardhat';
+
+async function main() {
+    const contractName = 'Factory';
+    console.info(chalk.yellow('Deploying ' + contractName + '...'));
+
+    const testMnemonic = 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
+    const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+
+    const deployer = new Deployer(hre, zkWallet);
+
+    const factoryContract = await deployer.loadArtifact(contractName);
+    const beacon = await hre.zkUpgrades.deployBeacon(deployer.zkWallet, factoryContract);
+    await beacon.deployed();
+
+    const factory = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, beacon, factoryContract, []);
+    await factory.deployed();
+    
+    factory.connect(zkWallet);
+    const number = await factory.getNumberOfDeployedContracts();
+    if(number===0){
+        throw new Error("Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.")
+    }
+
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/examples/upgradable-example/scripts/deploy-factory-proxy.ts
+++ b/examples/upgradable-example/scripts/deploy-factory-proxy.ts
@@ -1,0 +1,31 @@
+import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
+import { Wallet } from 'zksync-ethers';
+import chalk from 'chalk';
+
+import * as hre from 'hardhat';
+
+async function main() {
+    const contractName = 'Factory';
+    console.info(chalk.yellow('Deploying ' + contractName + '...'));
+
+    const testMnemonic = 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
+    const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+
+    const deployer = new Deployer(hre, zkWallet);
+
+    const contract = await deployer.loadArtifact(contractName);
+    const factory = await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [], { initializer: 'initialize' });
+    await factory.deployed();
+    
+    factory.connect(zkWallet);
+    const number = await factory.getNumberOfDeployedContracts();
+    if(number===0){
+        throw new Error("Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.")
+    }
+
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/examples/upgradable-example/scripts/deploy-factory-uups.ts
+++ b/examples/upgradable-example/scripts/deploy-factory-uups.ts
@@ -1,0 +1,31 @@
+import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
+import { Wallet } from 'zksync-ethers';
+import chalk from 'chalk';
+
+import * as hre from 'hardhat';
+
+async function main() {
+    const contractName = 'FactoryUups';
+    console.info(chalk.yellow('Deploying ' + contractName + '...'));
+
+    const testMnemonic = 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
+    const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+
+    const deployer = new Deployer(hre, zkWallet);
+
+    const contract = await deployer.loadArtifact(contractName);
+    const factory = await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [], { initializer: 'initialize' });
+
+    await factory.deployed();
+
+    factory.connect(zkWallet);
+    const number = await factory.getNumberOfDeployedContracts();
+    if(number===0){
+        throw new Error("Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.")
+    }
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/examples/upgradable-example/scripts/upgrade-box-beacon.ts
+++ b/examples/upgradable-example/scripts/upgrade-box-beacon.ts
@@ -32,7 +32,7 @@ async function main() {
         deployer.zkWallet,
         deployer.deploymentType
     );
-    const upgradedBox = await attachTo.attach(boxBeaconProxy.address);
+    const upgradedBox = attachTo.attach(boxBeaconProxy.address);
 
     upgradedBox.connect(zkWallet);
     // wait some time before the next call

--- a/examples/upgradable-example/scripts/upgrade-factory-beacon.ts
+++ b/examples/upgradable-example/scripts/upgrade-factory-beacon.ts
@@ -1,0 +1,45 @@
+import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
+import { Wallet } from 'zksync-ethers';
+import chalk from 'chalk';
+import * as zk from 'zksync-ethers';
+
+import * as hre from 'hardhat';
+
+async function main() {
+    const testMnemonic = 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
+    const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+    const deployer = new Deployer(hre, zkWallet);
+
+
+    const contractName = 'Factory';
+    const contract = await deployer.loadArtifact(contractName);
+    const beacon = await hre.zkUpgrades.deployBeacon(deployer.zkWallet, contract);
+    await beacon.deployed();
+
+    const factoryBeaconProxy = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, beacon, contract, []);
+    await factoryBeaconProxy.deployed();
+
+    // upgrade beacon
+
+    const factoryV2Implementation = await deployer.loadArtifact('FactoryV2');
+    await hre.zkUpgrades.upgradeBeacon(deployer.zkWallet, beacon.address, factoryV2Implementation);
+    console.info(chalk.green('Successfully upgraded beacon Factory to FactoryV2 on address: ', beacon.address));
+
+    const attachTo = new zk.ContractFactory(
+        factoryV2Implementation.abi,
+        factoryV2Implementation.bytecode,
+        deployer.zkWallet,
+        deployer.deploymentType
+    );
+    const upgradedFactory = attachTo.attach(factoryBeaconProxy.address);
+    upgradedFactory.connect(zkWallet);
+    const number = await upgradedFactory.getNumberOfDeployedContracts();
+    if(number===0){
+        throw new Error("Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.")
+    }
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/examples/upgradable-example/scripts/upgrade-factory-uups.ts
+++ b/examples/upgradable-example/scripts/upgrade-factory-uups.ts
@@ -1,0 +1,36 @@
+import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
+import { Wallet } from 'zksync-ethers';
+import chalk from 'chalk';
+
+import * as hre from 'hardhat';
+
+async function main() {
+    const testMnemonic = 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
+    const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+    const deployer = new Deployer(hre, zkWallet);
+
+    // deploy proxy
+    const contractName = 'FactoryUups';
+
+    const contract = await deployer.loadArtifact(contractName);
+    const factory = await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [], { initializer: 'initialize' });
+
+    await factory.deployed();
+
+    // upgrade proxy implementation
+
+    const FactoryUupsV2 = await deployer.loadArtifact('FactoryUupsV2');
+    const upgradedFactory = await hre.zkUpgrades.upgradeProxy(deployer.zkWallet, factory.address, FactoryUupsV2);
+    console.info(chalk.green('Successfully upgraded FactoryUups to FactoryUupsV2'));
+    
+    upgradedFactory.connect(zkWallet)
+    const number = await upgradedFactory.getNumberOfDeployedContracts();
+    if(number===0){
+        throw new Error("Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.")
+    }
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/examples/upgradable-example/scripts/upgrade-factory.ts
+++ b/examples/upgradable-example/scripts/upgrade-factory.ts
@@ -17,10 +17,10 @@ async function main() {
     await factory.deployed();
 
     const FactoryV2 = await deployer.loadArtifact('FactoryV2');
-    const upgradedBox = await hre.zkUpgrades.upgradeProxy(deployer.zkWallet, factory.address, FactoryV2);
+    const upgradedFactory = await hre.zkUpgrades.upgradeProxy(deployer.zkWallet, factory.address, FactoryV2);
     console.info(chalk.green('Successfully upgraded Factory to FactoryV2'));
 
-    upgradedBox.connect(zkWallet);
+    upgradedFactory.connect(zkWallet);
     const number = await factory.getNumberOfDeployedContracts();
     if(number===0){
         throw new Error("Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.")

--- a/examples/upgradable-example/scripts/upgrade-factory.ts
+++ b/examples/upgradable-example/scripts/upgrade-factory.ts
@@ -1,0 +1,33 @@
+import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
+import { Wallet } from 'zksync-ethers';
+import chalk from 'chalk';
+
+import * as hre from 'hardhat';
+
+async function main() {
+    const testMnemonic = 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
+    const zkWallet = Wallet.fromMnemonic(testMnemonic, "m/44'/60'/0'/0/0");
+    const deployer = new Deployer(hre, zkWallet);
+
+    const contractName = 'Factory';
+
+    const contract = await deployer.loadArtifact(contractName);
+    const factory = await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [], { initializer: 'initialize' });
+
+    await factory.deployed();
+
+    const FactoryV2 = await deployer.loadArtifact('FactoryV2');
+    const upgradedBox = await hre.zkUpgrades.upgradeProxy(deployer.zkWallet, factory.address, FactoryV2);
+    console.info(chalk.green('Successfully upgraded Factory to FactoryV2'));
+
+    upgradedBox.connect(zkWallet);
+    const number = await factory.getNumberOfDeployedContracts();
+    if(number===0){
+        throw new Error("Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.")
+    }
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/packages/hardhat-zksync-upgradable/src/constants.ts
+++ b/packages/hardhat-zksync-upgradable/src/constants.ts
@@ -10,6 +10,9 @@ export const LOCAL_SETUP_ZKSYNC_NETWORK = 'http://localhost:3050';
 export const FORMAT_TYPE_MINIMAL = 'minimal';
 export const MANIFEST_DEFAULT_DIR = '.upgradable';
 
+export const ZKSOLC_ARTIFACT_FORMAT_VERSION = 'hh-zksolc-artifact-1';
+export const ZKVYPER_ARTIFACT_FORMAT_VERSION = 'hh-zkvyper-artifact-1';
+
 export const PROXY_SOURCE_NAMES = [
     '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol',
     '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol',

--- a/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-beacon.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-beacon.ts
@@ -5,6 +5,7 @@ import { Deployment } from '@openzeppelin/upgrades-core';
 import { ZkSyncArtifact } from '@matterlabs/hardhat-zksync-deploy/src/types';
 
 import { DeployBeaconOptions } from '../utils/options';
+import { extractFactoryDeps } from '../utils/utils-general';
 import { deploy, DeployTransaction } from './deploy';
 import * as zk from 'zksync-ethers';
 import { deployBeaconImpl } from './deploy-impl';
@@ -27,6 +28,7 @@ export function makeDeployBeacon(hre: HardhatRuntimeEnvironment): DeployBeaconFu
         const beaconImplFactory = new zk.ContractFactory(artifact.abi, artifact.bytecode, wallet);
 
         opts.provider = wallet.provider;
+        opts.factoryDeps = await extractFactoryDeps(hre,artifact);
         const { impl } = await deployBeaconImpl(hre, beaconImplFactory, opts);
         if (!quiet) {
             console.info(chalk.green('Beacon impl deployed at', impl));

--- a/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-impl.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-impl.ts
@@ -42,7 +42,15 @@ export async function getDeployData(
     const version = getVersion(unlinkedBytecode, contractFactory.bytecode, encodedArgs);
     const layout = getStorageLayout(validations, version);
     const fullOpts = withDefaults(opts);
-    return { provider, validations, unlinkedBytecode, encodedArgs, version, layout, fullOpts };
+    return {
+        provider,
+        validations,
+        unlinkedBytecode,
+        encodedArgs,
+        version,
+        layout,
+        fullOpts,
+    };
 }
 
 export async function deployProxyImpl(
@@ -73,7 +81,13 @@ async function deployImpl(
                 if (opts.useDeployedImplementation) {
                     throw new ZkSyncUpgradablePluginError(IMPL_CONTRACT_NOT_DEPLOYED_ERROR);
                 } else {
-                    const deployed = await deploy(factory, deployData.fullOpts.constructorArgs);
+                    const deployed = await deploy(
+                        factory,
+                        ...[
+                            ...deployData.fullOpts.constructorArgs,
+                            { customData: { factoryDeps: deployData.fullOpts.factoryDeps } },
+                        ],
+                    );
 
                     return deployed;
                 }

--- a/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-proxy.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-proxy.ts
@@ -8,7 +8,7 @@ import { ZkSyncArtifact } from '@matterlabs/hardhat-zksync-deploy/src/types';
 
 import { DeployTransaction, deploy } from './deploy';
 import { deployProxyImpl } from './deploy-impl';
-import { getInitializerData } from '../utils/utils-general';
+import { extractFactoryDeps, getInitializerData } from '../utils/utils-general';
 import { ERC1967_PROXY_JSON, TUP_JSON } from '../constants';
 import { Manifest, ProxyDeployment } from '../core/manifest';
 import { DeployProxyOptions } from '../utils/options';
@@ -32,10 +32,12 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
             args = [];
         }
         opts.provider = wallet.provider;
+        opts.factoryDeps = await extractFactoryDeps(hre, artifact);
 
         const manifest = await Manifest.forNetwork(wallet.provider);
 
         const factory = new zk.ContractFactory(artifact.abi, artifact.bytecode, wallet);
+        
         const { impl, kind } = await deployProxyImpl(hre, factory, opts);
         if (!quiet) {
             console.info(chalk.green('Implementation contract was deployed to ' + impl));

--- a/packages/hardhat-zksync-upgradable/src/proxy-upgrade/upgrade-beacon.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-upgrade/upgrade-beacon.ts
@@ -3,7 +3,7 @@ import * as zk from 'zksync-ethers';
 import path from 'path';
 import { ZkSyncArtifact } from '@matterlabs/hardhat-zksync-deploy/src/types';
 
-import { ContractAddressOrInstance } from '../utils/utils-general';
+import { ContractAddressOrInstance,extractFactoryDeps } from '../utils/utils-general';
 import { UpgradeBeaconOptions } from '../utils/options';
 import { deployBeaconImpl } from '../proxy-deployment/deploy-impl';
 import { getContractAddress } from '../utils/utils-general';
@@ -34,6 +34,8 @@ export function makeUpgradeBeacon(hre: HardhatRuntimeEnvironment): UpgradeBeacon
         );
 
         opts.provider = wallet.provider;
+        opts.factoryDeps = await extractFactoryDeps(hre, newImplementationArtifact);
+        
         const beaconImplementationAddress = getContractAddress(beaconImplementation);
         const { impl: nextImpl } = await deployBeaconImpl(hre, factory, opts, beaconImplementationAddress);
         if (!quiet) {

--- a/packages/hardhat-zksync-upgradable/src/proxy-upgrade/upgrade-proxy.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-upgrade/upgrade-proxy.ts
@@ -8,7 +8,7 @@ import { ZkSyncArtifact } from '@matterlabs/hardhat-zksync-deploy/src/types';
 
 import { ContractAddressOrInstance } from '../interfaces';
 import { UpgradeProxyOptions } from '../utils/options';
-import { getContractAddress } from '../utils/utils-general';
+import { extractFactoryDeps,getContractAddress } from '../utils/utils-general';
 import { deployProxyImpl } from '../proxy-deployment/deploy-impl';
 import { Manifest } from '../core/manifest';
 import { ITUP_JSON, PROXY_ADMIN_JSON } from '../constants';
@@ -33,7 +33,8 @@ export function makeUpgradeProxy(hre: HardhatRuntimeEnvironment): UpgradeFunctio
     ) {
         const proxyAddress = getContractAddress(proxy);
         opts.provider = wallet.provider;
-
+        opts.factoryDeps = await extractFactoryDeps(hre, newImplementationArtifact);
+        
         const newImplementationFactory = new zk.ContractFactory(
             newImplementationArtifact.abi,
             newImplementationArtifact.bytecode,

--- a/packages/hardhat-zksync-upgradable/src/utils/options.ts
+++ b/packages/hardhat-zksync-upgradable/src/utils/options.ts
@@ -14,6 +14,7 @@ export type StandaloneOptions = StandaloneValidationOptions &
         constructorArgs?: unknown[];
         useDeployedImplementation?: boolean;
         provider?: any;
+        factoryDeps?: string[];
     };
 
 export type UpgradeOptions = ValidationOptions & StandaloneOptions;
@@ -25,6 +26,7 @@ export function withDefaults(opts: UpgradeOptions = {}): Required<UpgradeOptions
         provider: opts.provider ?? new zk.Provider(LOCAL_SETUP_ZKSYNC_NETWORK),
         pollingInterval: opts.pollingInterval ?? 5e3,
         useDeployedImplementation: opts.useDeployedImplementation ?? true,
+        factoryDeps: opts.factoryDeps ?? [],
         ...withValidationDefaults(opts),
     };
 }

--- a/packages/hardhat-zksync-upgradable/src/utils/utils-general.ts
+++ b/packages/hardhat-zksync-upgradable/src/utils/utils-general.ts
@@ -1,11 +1,17 @@
 import { MaybeSolcOutput } from '../interfaces';
-import { TOPIC_LOGS_NOT_FOUND_ERROR } from '../constants';
 import { keccak256 } from 'ethereumjs-util';
 import { Interface } from '@ethersproject/abi';
 import chalk from 'chalk';
 import * as zk from 'zksync-ethers';
-import { SolcConfig } from 'hardhat/types';
+import { HardhatRuntimeEnvironment, SolcConfig } from 'hardhat/types';
 import { ethers } from 'ethers';
+import {
+    TOPIC_LOGS_NOT_FOUND_ERROR,
+    ZKSOLC_ARTIFACT_FORMAT_VERSION,
+    ZKVYPER_ARTIFACT_FORMAT_VERSION,
+} from '../constants';
+import { ZkSyncUpgradablePluginError } from '../errors';
+import { ZkSyncArtifact } from '@matterlabs/hardhat-zksync-deploy/src/types';
 
 export type ContractAddressOrInstance = string | { address: string };
 
@@ -129,4 +135,49 @@ export function extendCompilerOutputSelection(compiler: SolcConfig) {
 
 export function convertGasPriceToEth(gasPrice: ethers.BigNumber): string {
     return ethers.utils.formatEther(gasPrice.toString());
+}
+
+
+export async function loadArtifact(
+    hre: HardhatRuntimeEnvironment,
+    contractNameOrFullyQualifiedName: string,
+): Promise<ZkSyncArtifact> {
+    const artifact = await hre.artifacts.readArtifact(contractNameOrFullyQualifiedName);
+
+    // Verify that this artifact was compiled by the zkSync compiler, and not `solc` or `vyper`.
+    if (artifact._format !== ZKSOLC_ARTIFACT_FORMAT_VERSION && artifact._format !== ZKVYPER_ARTIFACT_FORMAT_VERSION) {
+        throw new ZkSyncUpgradablePluginError(
+            `Artifact ${contractNameOrFullyQualifiedName} was not compiled by zksolc or zkvyper`,
+        );
+    }
+    return artifact as ZkSyncArtifact;
+}
+
+export async function extractFactoryDeps(hre: HardhatRuntimeEnvironment, artifact: ZkSyncArtifact): Promise<string[]> {
+    const visited = new Set<string>();
+    visited.add(`${artifact.sourceName}:${artifact.contractName}`);
+    return await extractFactoryDepsRecursive(hre, artifact, visited);
+}
+
+export async function extractFactoryDepsRecursive(
+    hre: HardhatRuntimeEnvironment,
+    artifact: ZkSyncArtifact,
+    visited: Set<string>,
+): Promise<string[]> {
+    // Load all the dependency bytecodes.
+    // We transform it into an array of bytecodes.
+    const factoryDeps: string[] = [];
+    for (const dependencyHash in artifact.factoryDeps) {
+        if (!dependencyHash) continue;
+        const dependencyContract = artifact.factoryDeps[dependencyHash];
+        if (!visited.has(dependencyContract)) {
+            const dependencyArtifact = await loadArtifact(hre, dependencyContract);
+            factoryDeps.push(dependencyArtifact.bytecode);
+            visited.add(dependencyContract);
+            const transitiveDeps = await extractFactoryDepsRecursive(hre, dependencyArtifact, visited);
+            factoryDeps.push(...transitiveDeps);
+        }
+    }
+
+    return factoryDeps;
 }


### PR DESCRIPTION
# What :computer: 
Add factory deps for implementation deployment
# Why :hand:
In a proxy implementation, a factory might rely on certain dependencies. If these dependencies aren't properly provided or transmitted, transactions might fail, which happen with code "The code hash is not known" returned from ContractDeployer.