### PR TITLE
fix: add smart contract verification to upgradable examples

### DIFF
--- a/examples/upgradable-example/hardhat.config.ts
+++ b/examples/upgradable-example/hardhat.config.ts
@@ -1,5 +1,6 @@
 import '@matterlabs/hardhat-zksync-solc';
 import '@matterlabs/hardhat-zksync-deploy';
+import '@matterlabs/hardhat-zksync-verify';
 import '@matterlabs/hardhat-zksync-upgradable';
 
 import { HardhatUserConfig } from 'hardhat/config';

--- a/examples/upgradable-example/scripts/deploy-box-beacon.ts
+++ b/examples/upgradable-example/scripts/deploy-box-beacon.ts
@@ -24,9 +24,9 @@ async function main() {
     const value = await box.retrieve();
     console.info(chalk.cyan('Box value is: ', value));
 
-    const chainId = await hre.network.provider.send('eth_chainId',[]) 
-    if (chainId==="0x12c"){
-        hre.run("verify:verify",{address:await box.getAddress()})
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await box.getAddress() });
     }
 }
 

--- a/examples/upgradable-example/scripts/deploy-box-beacon.ts
+++ b/examples/upgradable-example/scripts/deploy-box-beacon.ts
@@ -23,6 +23,11 @@ async function main() {
     box.connect(zkWallet);
     const value = await box.retrieve();
     console.info(chalk.cyan('Box value is: ', value));
+
+    const chainId = await hre.network.provider.send('eth_chainId',[]) 
+    if (chainId==="0x12c"){
+        hre.run("verify:verify",{address:await box.getAddress()})
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/deploy-box-proxy.ts
+++ b/examples/upgradable-example/scripts/deploy-box-proxy.ts
@@ -22,9 +22,9 @@ async function main() {
     const value = await box.retrieve();
     console.info(chalk.cyan('Box value is: ', value));
 
-    const chainId = await hre.network.provider.send('eth_chainId',[]) 
-    if (chainId==="0x12c"){
-        hre.run("verify:verify",{address:await box.getAddress()})
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await box.getAddress() });
     }
 }
 

--- a/examples/upgradable-example/scripts/deploy-box-proxy.ts
+++ b/examples/upgradable-example/scripts/deploy-box-proxy.ts
@@ -21,6 +21,11 @@ async function main() {
     box.connect(zkWallet);
     const value = await box.retrieve();
     console.info(chalk.cyan('Box value is: ', value));
+
+    const chainId = await hre.network.provider.send('eth_chainId',[]) 
+    if (chainId==="0x12c"){
+        hre.run("verify:verify",{address:await box.getAddress()})
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/deploy-box-uups.ts
+++ b/examples/upgradable-example/scripts/deploy-box-uups.ts
@@ -22,9 +22,9 @@ async function main() {
     const value = await box.retrieve();
     console.info(chalk.cyan('Box value is: ', value));
 
-    const chainId = await hre.network.provider.send('eth_chainId',[]) 
-    if (chainId==="0x12c"){
-        hre.run("verify:verify",{address:await box.getAddress()})
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await box.getAddress() });
     }
 }
 

--- a/examples/upgradable-example/scripts/deploy-box-uups.ts
+++ b/examples/upgradable-example/scripts/deploy-box-uups.ts
@@ -21,6 +21,11 @@ async function main() {
     box.connect(zkWallet);
     const value = await box.retrieve();
     console.info(chalk.cyan('Box value is: ', value));
+
+    const chainId = await hre.network.provider.send('eth_chainId',[]) 
+    if (chainId==="0x12c"){
+        hre.run("verify:verify",{address:await box.getAddress()})
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/upgrade-box-beacon.ts
+++ b/examples/upgradable-example/scripts/upgrade-box-beacon.ts
@@ -42,9 +42,9 @@ async function main() {
     const value = await upgradedBox.retrieve();
     console.info(chalk.cyan('New box value is', value));
 
-    const chainId = await hre.network.provider.send('eth_chainId',[]) 
-    if (chainId==="0x12c"){
-        hre.run("verify:verify",{address:await upgradedBox.getAddress()})
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await upgradedBox.getAddress() });
     }
 }
 

--- a/examples/upgradable-example/scripts/upgrade-box-beacon.ts
+++ b/examples/upgradable-example/scripts/upgrade-box-beacon.ts
@@ -41,6 +41,11 @@ async function main() {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     const value = await upgradedBox.retrieve();
     console.info(chalk.cyan('New box value is', value));
+
+    const chainId = await hre.network.provider.send('eth_chainId',[]) 
+    if (chainId==="0x12c"){
+        hre.run("verify:verify",{address:await upgradedBox.getAddress()})
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/upgrade-box-uups.ts
+++ b/examples/upgradable-example/scripts/upgrade-box-uups.ts
@@ -28,6 +28,11 @@ async function main() {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     const value = await upgradedBox.retrieve();
     console.info(chalk.cyan('BoxUups value is', value));
+
+    const chainId = await hre.network.provider.send('eth_chainId',[]) 
+    if (chainId==="0x12c"){
+        hre.run("verify:verify",{address:await upgradedBox.getAddress()})
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/upgrade-box-uups.ts
+++ b/examples/upgradable-example/scripts/upgrade-box-uups.ts
@@ -29,9 +29,9 @@ async function main() {
     const value = await upgradedBox.retrieve();
     console.info(chalk.cyan('BoxUups value is', value));
 
-    const chainId = await hre.network.provider.send('eth_chainId',[]) 
-    if (chainId==="0x12c"){
-        hre.run("verify:verify",{address:await upgradedBox.getAddress()})
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await upgradedBox.getAddress() });
     }
 }
 

--- a/examples/upgradable-example/scripts/upgrade-box.ts
+++ b/examples/upgradable-example/scripts/upgrade-box.ts
@@ -27,10 +27,10 @@ async function main() {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     const value = await upgradedBox.retrieve();
     console.info(chalk.cyan('Box value is', value));
-    
-    const chainId = await hre.network.provider.send('eth_chainId',[]) 
-    if (chainId==="0x12c"){
-        hre.run("verify:verify",{address:await upgradedBox.getAddress()})
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await upgradedBox.getAddress() });
     }
 }
 

--- a/examples/upgradable-example/scripts/upgrade-box.ts
+++ b/examples/upgradable-example/scripts/upgrade-box.ts
@@ -27,6 +27,11 @@ async function main() {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     const value = await upgradedBox.retrieve();
     console.info(chalk.cyan('Box value is', value));
+    
+    const chainId = await hre.network.provider.send('eth_chainId',[]) 
+    if (chainId==="0x12c"){
+        hre.run("verify:verify",{address:await upgradedBox.getAddress()})
+    }
 }
 
 main().catch((error) => {


### PR DESCRIPTION
# What :computer: 
Added smart contract verification to upgradable examples

# Why :hand:
To ensure the proper operation of the hardhat-zksync-upgradable plugin in combination with hardhat-zksync-verify on zkSync Sepolia Testnet.

