### PR TITLE
fix: add support for regex and forbid unsupported chaining

### DIFF
--- a/examples/upgradable-example/hardhat.config.ts
+++ b/examples/upgradable-example/hardhat.config.ts
@@ -1,6 +1,8 @@
 import '@matterlabs/hardhat-zksync-solc';
 import '@matterlabs/hardhat-zksync-deploy';
+import '@matterlabs/hardhat-zksync-verify';
 import '@matterlabs/hardhat-zksync-upgradable';
+import '@matterlabs/hardhat-zksync-upgradable/dist/src/type-extensions';
 
 import { HardhatUserConfig } from 'hardhat/config';
 

--- a/examples/upgradable-example/scripts/deploy-box-beacon.ts
+++ b/examples/upgradable-example/scripts/deploy-box-beacon.ts
@@ -23,6 +23,11 @@ async function main() {
     box.connect(zkWallet);
     const value = await box.retrieve();
     console.info(chalk.cyan('Box value is: ', value.toNumber()));
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await box.getAddress() });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/deploy-box-proxy.ts
+++ b/examples/upgradable-example/scripts/deploy-box-proxy.ts
@@ -21,6 +21,11 @@ async function main() {
     box.connect(zkWallet);
     const value = await box.retrieve();
     console.info(chalk.cyan('Box value is: ', value.toNumber()));
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await box.getAddress() });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/deploy-box-uups.ts
+++ b/examples/upgradable-example/scripts/deploy-box-uups.ts
@@ -21,6 +21,11 @@ async function main() {
     box.connect(zkWallet);
     const value = await box.retrieve();
     console.info(chalk.cyan('Box value is: ', value.toNumber()));
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await box.getAddress() });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/deploy-factory-beacon.ts
+++ b/examples/upgradable-example/scripts/deploy-factory-beacon.ts
@@ -27,6 +27,11 @@ async function main() {
             'Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.',
         );
     }
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: factory.address });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/deploy-factory-proxy.ts
+++ b/examples/upgradable-example/scripts/deploy-factory-proxy.ts
@@ -24,6 +24,11 @@ async function main() {
             'Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.',
         );
     }
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: factory.address });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/deploy-factory-uups.ts
+++ b/examples/upgradable-example/scripts/deploy-factory-uups.ts
@@ -25,6 +25,11 @@ async function main() {
             'Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.',
         );
     }
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: factory.address });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/upgrade-box-beacon.ts
+++ b/examples/upgradable-example/scripts/upgrade-box-beacon.ts
@@ -39,6 +39,11 @@ async function main() {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     const value = await upgradedBox.retrieve();
     console.info(chalk.cyan('New box value is', value));
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await upgradedBox.getAddress() });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/upgrade-box-uups.ts
+++ b/examples/upgradable-example/scripts/upgrade-box-uups.ts
@@ -26,6 +26,11 @@ async function main() {
     upgradedBox.connect(zkWallet);
     const value = await upgradedBox.retrieve();
     console.info(chalk.cyan('BoxUups value is', value));
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await upgradedBox.getAddress() });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/upgrade-box.ts
+++ b/examples/upgradable-example/scripts/upgrade-box.ts
@@ -26,6 +26,11 @@ async function main() {
     upgradedBox.connect(zkWallet);
     const value = await upgradedBox.retrieve();
     console.info(chalk.cyan('Box value is', value));
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: await upgradedBox.getAddress() });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/upgrade-factory-beacon.ts
+++ b/examples/upgradable-example/scripts/upgrade-factory-beacon.ts
@@ -38,6 +38,11 @@ async function main() {
             'Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.',
         );
     }
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: upgradedFactory.address });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/upgrade-factory-uups.ts
+++ b/examples/upgradable-example/scripts/upgrade-factory-uups.ts
@@ -30,6 +30,11 @@ async function main() {
             'Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.',
         );
     }
+    
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: upgradedFactory.address });
+    }
 }
 
 main().catch((error) => {

--- a/examples/upgradable-example/scripts/upgrade-factory.ts
+++ b/examples/upgradable-example/scripts/upgrade-factory.ts
@@ -27,6 +27,11 @@ async function main() {
             'Something went wrong during deployment of a Factory contract. Initialize functions is probably not called.',
         );
     }
+
+    const chainId = await hre.network.provider.send('eth_chainId', []);
+    if (chainId === '0x12c') {
+        let _ = hre.run('verify:verify', { address: upgradedFactory.address });
+    }
 }
 
 main().catch((error) => {

--- a/packages/hardhat-zksync-chai-matchers/src/constants.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/constants.ts
@@ -1,1 +1,13 @@
 export const PLUGIN_NAME = '@matterlabs/hardhat-zksync-chai-matchers';
+
+export const ASYNC_MATCHER_CALLED = 'asyncMatcherCalled';
+export const CHANGE_ETHER_BALANCE_MATCHER = 'changeEtherBalance';
+export const CHANGE_ETHER_BALANCES_MATCHER = 'changeEtherBalances';
+export const CHANGE_TOKEN_BALANCE_MATCHER = 'changeTokenBalance';
+export const CHANGE_TOKEN_BALANCES_MATCHER = 'changeTokenBalances';
+export const EMIT_MATCHER = 'emit';
+export const REVERTED_MATCHER = 'reverted';
+export const REVERTED_WITH_MATCHER = 'revertedWith';
+export const REVERTED_WITH_CUSTOM_ERROR_MATCHER = 'revertedWithCustomError';
+export const REVERTED_WITH_PANIC_MATCHER = 'revertedWithPanic';
+export const REVERTED_WITHOUT_REASON_MATCHER = 'revertedWithoutReason';

--- a/packages/hardhat-zksync-chai-matchers/src/errors.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/errors.ts
@@ -21,3 +21,9 @@ export class ZkSyncChaiMatchersPluginAssertionError extends HardhatPluginError {
         super(PLUGIN_NAME, `Assertion error: ${message}`);
     }
 }
+
+export class ZkSyncChaiMatchersNonChainableMatcherError extends HardhatPluginError {
+    constructor(matcherName: string) {
+        super(PLUGIN_NAME, `${matcherName} is not chainable.`);
+    }
+}

--- a/packages/hardhat-zksync-chai-matchers/src/internal/changeEtherBalance.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/internal/changeEtherBalance.ts
@@ -4,12 +4,16 @@ import * as zk from 'zksync-ethers';
 import { buildAssert } from '@nomicfoundation/hardhat-chai-matchers/utils';
 import { ensure } from '@nomicfoundation/hardhat-chai-matchers/internal/calledOnContract/utils';
 
+import { CHANGE_ETHER_BALANCE_MATCHER } from '../constants';
 import { Account, getAddressOf } from './misc/account';
-import { BalanceChangeOptions } from './misc/balance';
 
-export function supportChangeEtherBalance(Assertion: Chai.AssertionStatic) {
+import type { BalanceChangeOptions } from './misc/balance';
+
+import { preventAsyncMatcherChaining } from './utils';
+
+export function supportChangeEtherBalance(Assertion: Chai.AssertionStatic, chaiUtils: Chai.ChaiUtils) {
     Assertion.addMethod(
-        'changeEtherBalance',
+        CHANGE_ETHER_BALANCE_MATCHER,
         function (
             this: any,
             account: Account | string,
@@ -23,6 +27,8 @@ export function supportChangeEtherBalance(Assertion: Chai.AssertionStatic) {
 
             const negated = this.__flags.negate;
             const subject = this._obj;
+
+            preventAsyncMatcherChaining(this, CHANGE_ETHER_BALANCE_MATCHER, chaiUtils);
 
             const checkBalanceChange = ([actualChange, address]: [typeof BigNumber, string]) => {
                 const assert = buildAssert(negated, checkBalanceChange);

--- a/packages/hardhat-zksync-chai-matchers/src/internal/changeEtherBalances.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/internal/changeEtherBalances.ts
@@ -4,12 +4,15 @@ import ordinal from 'ordinal';
 
 import { buildAssert } from '@nomicfoundation/hardhat-chai-matchers/utils';
 
+import { CHANGE_ETHER_BALANCES_MATCHER } from '../constants';
 import { getAddressOf, Account } from './misc/account';
 import { BalanceChangeOptions, getAddresses, getBalances } from './misc/balance';
 
-export function supportChangeEtherBalances(Assertion: Chai.AssertionStatic) {
+import { preventAsyncMatcherChaining } from './utils';
+
+export function supportChangeEtherBalances(Assertion: Chai.AssertionStatic, chaiUtils: Chai.ChaiUtils) {
     Assertion.addMethod(
-        'changeEtherBalances',
+        CHANGE_ETHER_BALANCES_MATCHER,
         function (
             this: any,
             accounts: Array<Account | string>,
@@ -22,6 +25,8 @@ export function supportChangeEtherBalances(Assertion: Chai.AssertionStatic) {
             const { BigNumber } = require('ethers');
 
             const negated = this.__flags.negate;
+
+            preventAsyncMatcherChaining(this, CHANGE_ETHER_BALANCES_MATCHER, chaiUtils);
 
             let subject = this._obj;
             if (typeof subject === 'function') {

--- a/packages/hardhat-zksync-chai-matchers/src/internal/changeTokenBalance.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/internal/changeTokenBalance.ts
@@ -4,15 +4,18 @@ import * as zk from 'zksync-ethers';
 import { buildAssert } from '@nomicfoundation/hardhat-chai-matchers/utils';
 import { ensure } from '@nomicfoundation/hardhat-chai-matchers/internal/calledOnContract/utils';
 
+import { CHANGE_TOKEN_BALANCES_MATCHER, CHANGE_TOKEN_BALANCE_MATCHER } from '../constants';
 import { Account, getAddressOf } from './misc/account';
+
+import { preventAsyncMatcherChaining } from './utils';
 
 interface Token extends zk.Contract {
     balanceOf(address: string, overrides?: any): Promise<BigNumber>;
 }
 
-export function supportChangeTokenBalance(Assertion: Chai.AssertionStatic) {
+export function supportChangeTokenBalance(Assertion: Chai.AssertionStatic, chaiUtils: Chai.ChaiUtils) {
     Assertion.addMethod(
-        'changeTokenBalance',
+        CHANGE_TOKEN_BALANCE_MATCHER,
         function (this: any, token: Token, account: Account | string, balanceChange: BigNumberish) {
             const { BigNumber } = require('ethers');
 
@@ -23,7 +26,9 @@ export function supportChangeTokenBalance(Assertion: Chai.AssertionStatic) {
                 subject = subject();
             }
 
-            checkToken(token, 'changeTokenBalance');
+            preventAsyncMatcherChaining(this, CHANGE_TOKEN_BALANCE_MATCHER, chaiUtils);
+
+            checkToken(token, CHANGE_TOKEN_BALANCE_MATCHER);
 
             const checkBalanceChange = ([actualChange, address, tokenDescription]: [BigNumber, string, string]) => {
                 const assert = buildAssert(negated, checkBalanceChange);
@@ -49,7 +54,7 @@ export function supportChangeTokenBalance(Assertion: Chai.AssertionStatic) {
     );
 
     Assertion.addMethod(
-        'changeTokenBalances',
+        CHANGE_TOKEN_BALANCES_MATCHER,
         function (this: any, token: Token, accounts: Array<Account | string>, balanceChanges: BigNumberish[]) {
             const { BigNumber } = require('ethers');
 
@@ -60,7 +65,9 @@ export function supportChangeTokenBalance(Assertion: Chai.AssertionStatic) {
                 subject = subject();
             }
 
-            checkToken(token, 'changeTokenBalances');
+            preventAsyncMatcherChaining(this, CHANGE_TOKEN_BALANCES_MATCHER, chaiUtils);
+
+            checkToken(token, CHANGE_TOKEN_BALANCES_MATCHER);
 
             if (accounts.length !== balanceChanges.length) {
                 throw new Error(

--- a/packages/hardhat-zksync-chai-matchers/src/internal/hardhatChaiMatchers.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/internal/hardhatChaiMatchers.ts
@@ -15,20 +15,20 @@ import { supportRevertedWithCustomError } from './reverted/revertedWithCustomErr
 import { supportRevertedWithoutReason } from './reverted/revertedWithoutReason';
 import { supportRevertedWithPanic } from './reverted/revertedWithPanic';
 
-export function hardhatChaiMatchers(chai: Chai.ChaiStatic, utils: Chai.ChaiUtils) {
-    supportBigNumber(chai.Assertion, utils);
-    supportEmit(chai.Assertion, utils);
+export function hardhatChaiMatchers(chai: Chai.ChaiStatic, chaiUtils: Chai.ChaiUtils) {
+    supportBigNumber(chai.Assertion, chaiUtils);
+    supportEmit(chai.Assertion, chaiUtils);
     supportHexEqual(chai.Assertion);
     supportProperAddress(chai.Assertion);
     supportProperHex(chai.Assertion);
     supportProperPrivateKey(chai.Assertion);
-    supportChangeEtherBalance(chai.Assertion);
-    supportChangeEtherBalances(chai.Assertion);
-    supportChangeTokenBalance(chai.Assertion);
-    supportReverted(chai.Assertion);
-    supportRevertedWith(chai.Assertion);
-    supportRevertedWithCustomError(chai.Assertion, utils);
-    supportRevertedWithPanic(chai.Assertion);
-    supportRevertedWithoutReason(chai.Assertion);
-    supportWithArgs(chai.Assertion, utils);
+    supportChangeEtherBalance(chai.Assertion, chaiUtils);
+    supportChangeEtherBalances(chai.Assertion, chaiUtils);
+    supportChangeTokenBalance(chai.Assertion, chaiUtils);
+    supportReverted(chai.Assertion, chaiUtils);
+    supportRevertedWith(chai.Assertion, chaiUtils);
+    supportRevertedWithCustomError(chai.Assertion, chaiUtils);
+    supportRevertedWithPanic(chai.Assertion, chaiUtils);
+    supportRevertedWithoutReason(chai.Assertion, chaiUtils);
+    supportWithArgs(chai.Assertion, chaiUtils);
 }

--- a/packages/hardhat-zksync-chai-matchers/src/internal/reverted/reverted.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/internal/reverted/reverted.ts
@@ -1,13 +1,16 @@
 import { buildAssert } from '@nomicfoundation/hardhat-chai-matchers/utils';
 import * as zk from 'zksync-ethers';
-
+import { REVERTED_MATCHER } from '../../constants';
+import { preventAsyncMatcherChaining } from '../utils';
 import { decodeReturnData, getReturnDataFromError } from './utils';
 
-export function supportReverted(Assertion: Chai.AssertionStatic) {
-    Assertion.addProperty('reverted', function (this: any) {
+export function supportReverted(Assertion: Chai.AssertionStatic, chaiUtils: Chai.ChaiUtils) {
+    Assertion.addProperty(REVERTED_MATCHER, function (this: any) {
         const negated = this.__flags.negate;
 
         const subject: unknown = this._obj;
+
+        preventAsyncMatcherChaining(this, REVERTED_MATCHER, chaiUtils);
 
         const onSuccess = async (value: unknown) => {
             const assert = buildAssert(negated, onSuccess);

--- a/packages/hardhat-zksync-chai-matchers/src/internal/reverted/revertedWith.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/internal/reverted/revertedWith.ts
@@ -1,19 +1,27 @@
 import { buildAssert } from '@nomicfoundation/hardhat-chai-matchers/utils';
-
+import { REVERTED_WITH_MATCHER } from '../../constants';
+import { preventAsyncMatcherChaining } from '../utils';
 import { decodeReturnData, getReturnDataFromError } from './utils';
 
-export function supportRevertedWith(Assertion: Chai.AssertionStatic) {
-    Assertion.addMethod('revertedWith', function (this: any, expectedReason: unknown) {
+export function supportRevertedWith(Assertion: Chai.AssertionStatic, chaiUtils: Chai.ChaiUtils) {
+    Assertion.addMethod(REVERTED_WITH_MATCHER, function (this: any, expectedReason: string | RegExp) {
         const negated = this.__flags.negate;
 
-        if (typeof expectedReason !== 'string') {
-            throw new TypeError('Expected the revert reason to be a string');
+        if (!(expectedReason instanceof RegExp) && typeof expectedReason !== 'string') {
+            throw new TypeError('Expected the revert reason to be a string or a regular expression');
         }
+
+        const expectedReasonString = expectedReason instanceof RegExp ? expectedReason.source : expectedReason;
+
+        preventAsyncMatcherChaining(this, REVERTED_WITH_MATCHER, chaiUtils);
 
         const onSuccess = () => {
             const assert = buildAssert(negated, onSuccess);
 
-            assert(false, `Expected transaction to be reverted with reason '${expectedReason}', but it didn't revert`);
+            assert(
+                false,
+                `Expected transaction to be reverted with reason '${expectedReasonString}', but it didn't revert`,
+            );
         };
 
         const onError = (error: any) => {
@@ -25,31 +33,34 @@ export function supportRevertedWith(Assertion: Chai.AssertionStatic) {
             if (decodedReturnData.kind === 'Empty') {
                 assert(
                     false,
-                    `Expected transaction to be reverted with reason '${expectedReason}', but it reverted without a reason`,
+                    `Expected transaction to be reverted with reason '${expectedReasonString}', but it reverted without a reason`,
                 );
             } else if (decodedReturnData.kind === 'Error') {
+                const isReverted =
+                    expectedReason instanceof RegExp
+                        ? expectedReason.test(decodedReturnData.reason)
+                        : decodedReturnData.reason === expectedReasonString;
                 assert(
-                    decodedReturnData.reason === expectedReason,
-                    `Expected transaction to be reverted with reason '${expectedReason}', but it reverted with reason '${decodedReturnData.reason}'`,
-                    `Expected transaction NOT to be reverted with reason '${expectedReason}', but it was`,
+                    isReverted,
+                    `Expected transaction to be reverted with reason '${expectedReasonString}', but it reverted with reason '${decodedReturnData.reason}'`,
+                    `Expected transaction NOT to be reverted with reason '${expectedReasonString}', but it was`,
                 );
             } else if (decodedReturnData.kind === 'Panic') {
                 assert(
                     false,
-                    `Expected transaction to be reverted with reason '${expectedReason}', but it reverted with panic code ${decodedReturnData.code.toHexString()} (${
+                    `Expected transaction to be reverted with reason '${expectedReasonString}', but it reverted with panic code ${decodedReturnData.code.toHexString()} (${
                         decodedReturnData.description
                     })`,
                 );
             } else if (decodedReturnData.kind === 'Custom') {
                 assert(
                     false,
-                    `Expected transaction to be reverted with reason '${expectedReason}', but it reverted with a custom error`,
+                    `Expected transaction to be reverted with reason '${expectedReasonString}', but it reverted with a custom error`,
                 );
             } else {
                 const _exhaustiveCheck: never = decodedReturnData;
             }
         };
-
         const derivedPromise = Promise.resolve(this._obj).then(onSuccess, onError);
 
         this.then = derivedPromise.then.bind(derivedPromise);

--- a/packages/hardhat-zksync-chai-matchers/src/internal/reverted/revertedWithPanic.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/internal/reverted/revertedWithPanic.ts
@@ -4,10 +4,12 @@ import { normalizeToBigInt } from 'hardhat/common';
 import { panicErrorCodeToReason } from '@nomicfoundation/hardhat-chai-matchers/internal/reverted/panic';
 import { buildAssert } from '@nomicfoundation/hardhat-chai-matchers/utils';
 
+import { REVERTED_WITH_PANIC_MATCHER } from '../../constants';
+import { preventAsyncMatcherChaining } from '../utils';
 import { decodeReturnData, getReturnDataFromError } from './utils';
 
-export function supportRevertedWithPanic(Assertion: Chai.AssertionStatic) {
-    Assertion.addMethod('revertedWithPanic', function (this: any, expectedCodeArg: any) {
+export function supportRevertedWithPanic(Assertion: Chai.AssertionStatic, chaiUtils: Chai.ChaiUtils) {
+    Assertion.addMethod(REVERTED_WITH_PANIC_MATCHER, function (this: any, expectedCodeArg: any) {
         const ethers = require('ethers');
 
         const negated = this.__flags.negate;
@@ -35,6 +37,8 @@ export function supportRevertedWithPanic(Assertion: Chai.AssertionStatic) {
             description = panicErrorCodeToReason(codeBN) ?? 'unknown panic code';
             formattedPanicCode = `panic code ${codeBN.toHexString()} (${description})`;
         }
+
+        preventAsyncMatcherChaining(this, REVERTED_WITH_PANIC_MATCHER, chaiUtils);
 
         const onSuccess = () => {
             const assert = buildAssert(negated, onSuccess);

--- a/packages/hardhat-zksync-chai-matchers/src/internal/reverted/revertedWithoutReason.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/internal/reverted/revertedWithoutReason.ts
@@ -1,11 +1,14 @@
 import { buildAssert } from '@nomicfoundation/hardhat-chai-matchers/utils';
 
+import { REVERTED_WITHOUT_REASON_MATCHER } from '../../constants';
+import { preventAsyncMatcherChaining } from '../utils';
 import { decodeReturnData, getReturnDataFromError } from './utils';
 
-export function supportRevertedWithoutReason(Assertion: Chai.AssertionStatic) {
-    Assertion.addMethod('revertedWithoutReason', function (this: any) {
+export function supportRevertedWithoutReason(Assertion: Chai.AssertionStatic, chaiUtils: Chai.ChaiUtils) {
+    Assertion.addMethod(REVERTED_WITHOUT_REASON_MATCHER, function (this: any) {
         const negated = this.__flags.negate;
 
+        preventAsyncMatcherChaining(this, REVERTED_WITHOUT_REASON_MATCHER, chaiUtils);
         const onSuccess = () => {
             const assert = buildAssert(negated, onSuccess);
 

--- a/packages/hardhat-zksync-chai-matchers/src/internal/reverted/utils.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/internal/reverted/utils.ts
@@ -1,4 +1,4 @@
-import type { BigNumber } from 'ethers';
+import { BigNumber } from 'ethers';
 import { AssertionError } from 'chai';
 
 import { panicErrorCodeToReason } from '@nomicfoundation/hardhat-chai-matchers/internal/reverted/panic';

--- a/packages/hardhat-zksync-chai-matchers/src/internal/utils.ts
+++ b/packages/hardhat-zksync-chai-matchers/src/internal/utils.ts
@@ -1,7 +1,15 @@
-import { ZkSyncChaiMatchersPluginDefaultError } from '../errors';
+import { ASYNC_MATCHER_CALLED } from '../constants';
+import { ZkSyncChaiMatchersNonChainableMatcherError, ZkSyncChaiMatchersPluginDefaultError } from '../errors';
 
 export function assertIsNotNull<T>(value: T, valueName: string): asserts value is Exclude<T, null> {
     if (value === null) {
         throw new ZkSyncChaiMatchersPluginDefaultError(`${valueName} should not be null`);
     }
+}
+
+export function preventAsyncMatcherChaining(context: object, matcherName: string, chaiUtils: Chai.ChaiUtils) {
+    if (chaiUtils.flag(context, ASYNC_MATCHER_CALLED) === true) {
+        throw new ZkSyncChaiMatchersNonChainableMatcherError(matcherName);
+    }
+    chaiUtils.flag(context, ASYNC_MATCHER_CALLED, true);
 }

--- a/packages/hardhat-zksync-chai-matchers/test/changeEtherBalance.ts
+++ b/packages/hardhat-zksync-chai-matchers/test/changeEtherBalance.ts
@@ -900,6 +900,34 @@ describe('INTEGRATION: changeEtherBalance matcher', function () {
 
                 expect.fail('Expected an exception but none was thrown');
             });
+
+            it('changeEtherBalance: should throw if chained to another non-chainable method', async function () {
+                const transferPromise = sender.transfer({
+                    to: receiver.address,
+                    amount: 200,
+                });
+                expect(() =>
+                    expect(transferPromise).to.be.a.nonChainableMatcher().and.to.changeEtherBalance(receiver, '200'),
+                ).to.throw(/changeEtherBalance is not chainable./);
+                await transferPromise;
+            });
+
+            it('changeEtherBalance: should throw if chained to another non-chainable method', async function () {
+                try {
+                    // eslint-disable-next-line
+                    expect(
+                        await sender.sendTransaction({
+                            to: receiver.address,
+                            value: 200,
+                        }),
+                    )
+                        .to.nonChainableMatcher()
+                        .and.to.changeEtherBalance(sender, '-200');
+                } catch (e: any) {
+                    expect(e.message).to.match(/changeEtherBalance is not chainable./);
+                    return;
+                }
+            });
         });
     }
 });

--- a/packages/hardhat-zksync-chai-matchers/test/changeEtherBalances.ts
+++ b/packages/hardhat-zksync-chai-matchers/test/changeEtherBalances.ts
@@ -44,6 +44,23 @@ describe('INTEGRATION: changeEtherBalances matcher', function () {
             txGasFees = gasPrice * gasUsed;
         });
 
+        it('changeEtherBalances: should throw if chained to another non-chainable method', async function () {
+            try {
+                // eslint-disable-next-line
+                expect(
+                    await sender.transfer({
+                        to: receiver.address,
+                        amount: 200,
+                    }),
+                )
+                    .to.nonChainableMatcher()
+                    .and.to.changeEtherBalances([sender, receiver], [-200, '200']);
+            } catch (e: any) {
+                expect(e.message).to.match(/changeEtherBalances is not chainable./);
+                return;
+            }
+        });
+
         describe('Transaction Callback', () => {
             describe('Change balances, one account, one contract', () => {
                 it('Should pass when all expected balance changes are equal to actual values', async () => {

--- a/packages/hardhat-zksync-chai-matchers/test/changeTokenBalance.ts
+++ b/packages/hardhat-zksync-chai-matchers/test/changeTokenBalance.ts
@@ -43,6 +43,16 @@ describe('INTEGRATION: changeTokenBalance and changeTokenBalances matchers', fun
             mockToken = await deployer.deploy(artifact);
         });
 
+        it('changeTokenBalance: should throw if chained to another non-chainable method', async function () {
+            const transferPromise = mockToken.transfer(receiver.address, 50);
+            expect(() =>
+                expect(transferPromise)
+                    .to.be.a.nonChainableMatcher()
+                    .and.to.changeTokenBalance(mockToken, [sender, receiver], [-200, '200']),
+            ).to.throw(/changeTokenBalance is not chainable./);
+            await transferPromise;
+        });
+
         describe("transaction that doesn't move tokens", () => {
             it('with a promise of a TxResponse', async function () {
                 await runAllAsserts(

--- a/packages/hardhat-zksync-chai-matchers/test/helpers.ts
+++ b/packages/hardhat-zksync-chai-matchers/test/helpers.ts
@@ -1,8 +1,9 @@
-import { AssertionError, expect } from 'chai';
+import { AssertionError, expect, use } from 'chai';
 import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names';
 import { resetHardhatContext } from 'hardhat/plugins-testing';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import path from 'path';
+import { preventAsyncMatcherChaining } from '../src/internal/utils';
 
 declare module 'mocha' {
     interface Context {
@@ -83,3 +84,17 @@ export async function runFailedAsserts({
         failedAssertReason,
     );
 }
+
+/**
+ * Used to test that non-chainable matchers like changeEtherBalance,
+ * changeTokenBalance and reverted throw an error when used along with other
+ * non-chainable matchers.
+ */
+function supportNonChainableMatcher(chai: Chai.ChaiStatic, chaiUtils: Chai.ChaiUtils) {
+    chai.Assertion.addMethod('nonChainableMatcher', function (this: any) {
+        preventAsyncMatcherChaining(this, 'nonChainableMatcher', chaiUtils);
+        this.assert(true);
+    });
+}
+
+use(supportNonChainableMatcher);

--- a/packages/hardhat-zksync-chai-matchers/test/reverted/misc.ts
+++ b/packages/hardhat-zksync-chai-matchers/test/reverted/misc.ts
@@ -5,7 +5,7 @@ import { getAddressOf, isWalletOrContract } from '../../src/internal/misc/accoun
 import { assertIsNotNull } from '../../src/internal/utils';
 
 class TestError extends Error {
-    private _data?: any;
+    public _data?: any;
 
     constructor(message: string, data?: any) {
         super(message);

--- a/packages/hardhat-zksync-chai-matchers/test/reverted/reverted.ts
+++ b/packages/hardhat-zksync-chai-matchers/test/reverted/reverted.ts
@@ -210,5 +210,43 @@ describe('INTEGRATION: Reverted', function () {
                 await expect(provider.sendTransaction(zk.utils.serialize(aaTx))).to.be.reverted;
             });
         });
+
+        describe('it throws because of non chainable methods', async function () {
+            it('reverted: should throw if chained to another non-chainable method', async function () {
+                const txPromise = matchers.revertsWith('Should revert here');
+                expect(() => expect(txPromise).to.be.a.nonChainableMatcher().and.to.be.reverted).to.throw(
+                    /reverted is not chainable./,
+                );
+            });
+            it('revertedWith: should throw if chained to another non-chainable method', async function () {
+                const txPromise = matchers.revertsWith('Should revert here');
+                expect(() =>
+                    expect(txPromise).to.be.a.nonChainableMatcher().and.to.be.revertedWith('an error message'),
+                ).to.throw(/revertedWith is not chainable./);
+            });
+
+            it('revertedWithCustomError: should throw if chained to another non-chainable method', async function () {
+                const txPromise = matchers.revertWithSomeCustomError();
+                expect(() =>
+                    expect(txPromise)
+                        .to.be.a.nonChainableMatcher()
+                        .and.to.be.revertedWithCustomError(matchers, 'SomeCustomError'),
+                ).to.throw(/revertedWithCustomError is not chainable./);
+            });
+
+            it('revertedWithoutReason: should throw if chained to another non-chainable method', async function () {
+                const txPromise = matchers.revertsWithoutReason();
+                expect(() =>
+                    expect(txPromise).to.be.a.nonChainableMatcher().and.to.be.revertedWithoutReason(),
+                ).to.throw(/revertedWithoutReason is not chainable./);
+            });
+
+            it('revertedWithPanic: should throw if chained to another non-chainable method', async function () {
+                const txPromise = matchers.panicAssert();
+                expect(() => expect(txPromise).to.be.a.nonChainableMatcher().and.to.be.revertedWithPanic()).to.throw(
+                    /revertedWithPanic is not chainable./,
+                );
+            });
+        });
     }
 });

--- a/packages/hardhat-zksync-chai-matchers/test/reverted/revertedWith.ts
+++ b/packages/hardhat-zksync-chai-matchers/test/reverted/revertedWith.ts
@@ -80,6 +80,13 @@ describe('INTEGRATION: Reverted with', function () {
                     args: ['some reason'],
                     successfulAssert: (x) => expect(x).to.not.be.revertedWith('another reason'),
                 });
+
+                await runSuccessfulAsserts({
+                    matchers,
+                    method: 'revertsWith',
+                    args: ['regular expression reason'],
+                    successfulAssert: (x) => expect(x).to.be.revertedWith(/regular .* reason/),
+                });
             });
 
             it('failed asserts: expected reason not to match', async function () {
@@ -100,6 +107,17 @@ describe('INTEGRATION: Reverted with', function () {
                     failedAssert: (x) => expect(x).to.be.revertedWith('some reason'),
                     failedAssertReason:
                         "Expected transaction to be reverted with reason 'some reason', but it reverted with reason 'another reason'",
+                });
+            });
+
+            it('failed asserts: expected a different regular expression reason ', async function () {
+                await runFailedAsserts({
+                    matchers,
+                    method: 'revertsWith',
+                    args: ['another regular expression reason'],
+                    failedAssert: (x) => expect(x).to.be.revertedWith(/some regular .* reason/),
+                    failedAssertReason:
+                        "Expected transaction to be reverted with reason 'some regular .* reason', but it reverted with reason 'another regular expression reason'",
                 });
             });
         });

--- a/packages/hardhat-zksync-chai-matchers/test/reverted/revertedWithPanic.ts
+++ b/packages/hardhat-zksync-chai-matchers/test/reverted/revertedWithPanic.ts
@@ -232,6 +232,25 @@ describe('INTEGRATION: Reverted with panic', function () {
                     successfulAssert: (x) => expect(x).not.to.be.revertedWithPanic(BigNumber.from(1)),
                 });
             });
+
+            it('invalid string', async function () {
+                try {
+                    await runFailedAsserts({
+                        matchers,
+                        method: 'panicAssert',
+                        failedAssert: (x) => expect(x).not.to.be.revertedWithPanic('invalid'),
+                        failedAssertReason:
+                            "Expected the given panic code to be a number-like value, but got 'invalid'",
+                    });
+                } catch (e: any) {
+                    expect(
+                        e.message.includes(
+                            "Expected the given panic code to be a number-like value, but got 'invalid'",
+                        ),
+                        'should have failed with the invalid string',
+                    );
+                }
+            });
         });
 
         describe('invalid values', function () {

--- a/packages/hardhat-zksync-chai-matchers/test/types.ts
+++ b/packages/hardhat-zksync-chai-matchers/test/types.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-namespace, @typescript-eslint/no-unused-vars
+declare namespace Chai {
+    interface Assertion extends LanguageChains, NumericComparison, TypeComparison {
+        nonChainableMatcher(): Assertion;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -833,7 +833,7 @@
   uid ""
 
 "@matterlabs/hardhat-zksync-upgradable@link:packages/hardhat-zksync-upgradable":
-  version "0.2.2"
+  version "0.2.3"
   dependencies:
     "@ethersproject/abi" "^5.1.2"
     "@matterlabs/hardhat-zksync-deploy" "^0.7.0"


### PR DESCRIPTION
# What :computer: 
Add support for regex and forbid async matchers from being chained.

# Why :hand:
In order to extend testing capabilities of the plugin and prevent false positive tests by forbidding chaining matchers that should not be chained. 
