### PR TITLE
fix: set zksolc compiler version for specified compiler path

### DIFF
--- a/packages/hardhat-zksync-solc/src/compile/binary.ts
+++ b/packages/hardhat-zksync-solc/src/compile/binary.ts
@@ -7,13 +7,11 @@ export async function compileWithBinary(
     solcPath: string,
     detectMissingLibrariesMode: boolean = false,
 ): Promise<any> {
-    const { compilerPath, isSystem, forceEvmla} = config.settings;
+    const { compilerPath, isSystem, forceEvmla } = config.settings;
 
     const processCommand = `${compilerPath} --standard-json ${isSystem ? '--system-mode' : ''} ${
         forceEvmla ? '--force-evmla' : ''
-    } --solc ${solcPath} ${
-        detectMissingLibrariesMode ? '--detect-missing-libraries' : ''
-    }`;
+    } --solc ${solcPath} ${detectMissingLibrariesMode ? '--detect-missing-libraries' : ''}`;
 
     const output: string = await new Promise((resolve, reject) => {
         const process = exec(

--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -104,7 +104,11 @@ export class ZksolcCompilerDownloader {
             return this._configCompilerPath;
         }
 
-        return path.join(this._compilersDirectory, 'zksolc', `zksolc-${this._configCompilerPath ? 'remote' : 'v' + this._version}${salt ? '-' : ''}${salt}`);
+        return path.join(
+            this._compilersDirectory,
+            'zksolc',
+            `zksolc-${this._configCompilerPath ? 'remote' : `v${this._version}`}${salt ? '-' : ''}${salt}`,
+        );
     }
 
     public async isCompilerDownloaded(): Promise<boolean> {
@@ -114,8 +118,8 @@ export class ZksolcCompilerDownloader {
         }
 
         if (this._configCompilerPath && this._isCompilerPathURL) {
-            const compilerPath = this.getCompilerPath();
-            if (await fsExtra.pathExists(compilerPath)) {
+            const compilerPathFromUrl = this.getCompilerPath();
+            if (await fsExtra.pathExists(compilerPathFromUrl)) {
                 await this._verifyCompilerAndSetVersionIfNeeded();
                 return true;
             }
@@ -164,9 +168,19 @@ export class ZksolcCompilerDownloader {
         }
 
         try {
-            console.info(chalk.yellow(`Downloading zksolc ${!this._configCompilerPath ? this._version : "from the remote origin"}`));
+            console.info(
+                chalk.yellow(
+                    `Downloading zksolc ${!this._configCompilerPath ? this._version : 'from the remote origin'}`,
+                ),
+            );
             await this._downloadCompiler();
-            console.info(chalk.green(`zksolc ${!this._configCompilerPath ? 'version ' + this._version : 'from the remote origin'} successfully downloaded`));
+            console.info(
+                chalk.green(
+                    `zksolc ${
+                        !this._configCompilerPath ? `version ${this._version}` : 'from the remote origin'
+                    } successfully downloaded`,
+                ),
+            );
         } catch (e: any) {
             throw new ZkSyncSolcPluginError(e.message.split('\n')[0]);
         }

--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -24,7 +24,7 @@ import {
     ZKSOLC_BIN_OWNER,
     ZKSOLC_BIN_REPOSITORY_NAME,
     USER_AGENT,
-    ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION,
+    ZKSOLC_COMPILER_PATH_VERSION,
 } from '../constants';
 import { ZkSyncSolcPluginError } from './../errors';
 
@@ -56,23 +56,25 @@ export class ZksolcCompilerDownloader {
                 throw new ZkSyncSolcPluginError(COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR);
             }
 
-            if (version !== ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION && configCompilerPath) {
+            if (version !== ZKSOLC_COMPILER_PATH_VERSION && configCompilerPath) {
                 throw new ZkSyncSolcPluginError(
-                    `The zksolc compiler versions in the hardhat are not supported for remote origin. Please don't specify version or use '${ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION}' as a version.`,
+                    `When a compiler path is provided, specifying a version of the zksolc compiler in Hardhat is not allowed. Please omit the version and try again.`,
                 );
             }
 
-            if (version === 'remote' && !configCompilerPath) {
-                throw new ZkSyncSolcPluginError(`The zksolc compiler path is not specified for remote origin.`);
+            if (version === ZKSOLC_COMPILER_PATH_VERSION && !configCompilerPath) {
+                throw new ZkSyncSolcPluginError(
+                    `The zksolc compiler path is not specified for local or remote origin.`,
+                );
             }
 
             if (version === 'latest' || version === compilerVersionInfo.latest) {
                 version = compilerVersionInfo.latest;
-            } else if (version !== 'remote' && !isVersionInRange(version, compilerVersionInfo)) {
+            } else if (version !== ZKSOLC_COMPILER_PATH_VERSION && !isVersionInRange(version, compilerVersionInfo)) {
                 throw new ZkSyncSolcPluginError(
                     COMPILER_VERSION_RANGE_ERROR(version, compilerVersionInfo.minVersion, compilerVersionInfo.latest),
                 );
-            } else if (version !== 'remote') {
+            } else if (version !== ZKSOLC_COMPILER_PATH_VERSION) {
                 console.info(chalk.yellow(COMPILER_VERSION_WARNING(version, compilerVersionInfo.latest)));
             }
 
@@ -118,9 +120,7 @@ export class ZksolcCompilerDownloader {
         return path.join(
             this._compilersDirectory,
             'zksolc',
-            `zksolc-${
-                this._configCompilerPath ? `${ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION}` : `v${this._version}`
-            }${salt ? '-' : ''}${salt}`,
+            `zksolc-${this._configCompilerPath ? `remote` : `v${this._version}`}${salt ? '-' : ''}${salt}`,
         );
     }
 

--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -56,13 +56,23 @@ export class ZksolcCompilerDownloader {
                 throw new ZkSyncSolcPluginError(COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR);
             }
 
+            if (version !== ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION && configCompilerPath) {
+                throw new ZkSyncSolcPluginError(
+                    `The zksolc compiler versions in the hardhat are not supported for remote origin. Please don't specify version or use '${ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION}' as a version.`,
+                );
+            }
+
+            if (version === 'remote' && !configCompilerPath) {
+                throw new ZkSyncSolcPluginError(`The zksolc compiler path is not specified for remote origin.`);
+            }
+
             if (version === 'latest' || version === compilerVersionInfo.latest) {
                 version = compilerVersionInfo.latest;
-            } else if (!configCompilerPath && !isVersionInRange(version, compilerVersionInfo)) {
+            } else if (version !== 'remote' && !isVersionInRange(version, compilerVersionInfo)) {
                 throw new ZkSyncSolcPluginError(
                     COMPILER_VERSION_RANGE_ERROR(version, compilerVersionInfo.minVersion, compilerVersionInfo.latest),
                 );
-            } else if (!configCompilerPath) {
+            } else if (version !== 'remote') {
                 console.info(chalk.yellow(COMPILER_VERSION_WARNING(version, compilerVersionInfo.latest)));
             }
 

--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -24,6 +24,7 @@ import {
     ZKSOLC_BIN_OWNER,
     ZKSOLC_BIN_REPOSITORY_NAME,
     USER_AGENT,
+    ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION,
 } from '../constants';
 import { ZkSyncSolcPluginError } from './../errors';
 
@@ -107,7 +108,9 @@ export class ZksolcCompilerDownloader {
         return path.join(
             this._compilersDirectory,
             'zksolc',
-            `zksolc-${this._configCompilerPath ? 'remote' : `v${this._version}`}${salt ? '-' : ''}${salt}`,
+            `zksolc-${
+                this._configCompilerPath ? `${ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION}` : `v${this._version}`
+            }${salt ? '-' : ''}${salt}`,
         );
     }
 

--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -166,7 +166,7 @@ export class ZksolcCompilerDownloader {
         try {
             console.info(chalk.yellow(`Downloading zksolc ${!this._configCompilerPath ? this._version : "from the remote origin"}`));
             await this._downloadCompiler();
-            console.info(chalk.green(`zksolc ${!this._configCompilerPath ? 'version' + this._version : 'from the remote origin'} successfully downloaded`));
+            console.info(chalk.green(`zksolc ${!this._configCompilerPath ? 'version ' + this._version : 'from the remote origin'} successfully downloaded`));
         } catch (e: any) {
             throw new ZkSyncSolcPluginError(e.message.split('\n')[0]);
         }

--- a/packages/hardhat-zksync-solc/src/constants.ts
+++ b/packages/hardhat-zksync-solc/src/constants.ts
@@ -13,7 +13,7 @@ export const USER_AGENT =
 export const ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION = 'remote';
 
 export const defaultZkSolcConfig: ZkSolcConfig = {
-    version: 'latest',
+    version: 'latest' || ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION,
     compilerSource: 'binary',
     settings: {
         optimizer: {

--- a/packages/hardhat-zksync-solc/src/constants.ts
+++ b/packages/hardhat-zksync-solc/src/constants.ts
@@ -10,10 +10,10 @@ export const DETECT_MISSING_LIBRARY_MODE_COMPILER_VERSION = '1.3.14';
 export const USER_AGENT =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
-export const ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION = 'remote';
+export const ZKSOLC_COMPILER_PATH_VERSION = 'local_or_remote';
 
 export const defaultZkSolcConfig: ZkSolcConfig = {
-    version: 'latest' || ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION,
+    version: 'latest',
     compilerSource: 'binary',
     settings: {
         optimizer: {

--- a/packages/hardhat-zksync-solc/src/constants.ts
+++ b/packages/hardhat-zksync-solc/src/constants.ts
@@ -10,7 +10,7 @@ export const DETECT_MISSING_LIBRARY_MODE_COMPILER_VERSION = '1.3.14';
 export const USER_AGENT =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
-export const ZKSOLC_COMPILER_PATH_VERSION = 'remote';
+export const ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION = 'remote';
 
 export const defaultZkSolcConfig: ZkSolcConfig = {
     version: 'latest',

--- a/packages/hardhat-zksync-solc/src/constants.ts
+++ b/packages/hardhat-zksync-solc/src/constants.ts
@@ -10,6 +10,8 @@ export const DETECT_MISSING_LIBRARY_MODE_COMPILER_VERSION = '1.3.14';
 export const USER_AGENT =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
+export const ZKSOLC_COMPILER_PATH_VERSION = 'remote';
+
 export const defaultZkSolcConfig: ZkSolcConfig = {
     version: 'latest',
     compilerSource: 'binary',

--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -65,6 +65,9 @@ const zkVmSolcCompilerDownloaderMutex = new Mutex();
 const zkSolcCompilerDownloaderMutex = new Mutex();
 
 extendConfig((config, userConfig) => {
+    defaultZkSolcConfig.version = userConfig.zksolc?.settings?.compilerPath
+        ? ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION
+        : 'latest';
     config.zksolc = { ...defaultZkSolcConfig, ...userConfig?.zksolc };
     config.zksolc.settings = { ...defaultZkSolcConfig.settings, ...userConfig?.zksolc?.settings };
     config.zksolc.settings.optimizer = {
@@ -141,10 +144,9 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS, async (args, hre, runSuper) 
     const compilersCache = await getCompilersDir();
 
     await zkSolcCompilerDownloaderMutex.use(async () => {
-        const compilerPath = hre.config.zksolc.settings.compilerPath ?? '';
         const zksolcDownloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-            compilerPath ? ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION : hre.config.zksolc.version,
-            compilerPath,
+            hre.config.zksolc.version,
+            hre.config.zksolc.settings.compilerPath ?? '',
             compilersCache,
         );
 

--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -152,7 +152,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS, async (args, hre, runSuper) 
         if (!isZksolcDownloaded) {
             await zksolcDownloader.downloadCompiler();
         }
-        
+
         hre.config.zksolc.settings.compilerPath = zksolcDownloader.getCompilerPath();
         hre.config.zksolc.version = zksolcDownloader.getVersion();
     });

--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -41,7 +41,7 @@ import {
     COMPILE_AND_DEPLOY_LIBRARIES_INSTRUCTIONS,
     MISSING_LIBRARY_LINK,
     COMPILING_INFO_MESSAGE_ZKVM_SOLC,
-    ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION,
+    ZKSOLC_COMPILER_PATH_VERSION,
 } from './constants';
 import { ZksolcCompilerDownloader } from './compile/downloader';
 import { ZkVmSolcCompilerDownloader } from './compile/zkvm-solc-downloader';
@@ -65,9 +65,7 @@ const zkVmSolcCompilerDownloaderMutex = new Mutex();
 const zkSolcCompilerDownloaderMutex = new Mutex();
 
 extendConfig((config, userConfig) => {
-    defaultZkSolcConfig.version = userConfig.zksolc?.settings?.compilerPath
-        ? ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION
-        : 'latest';
+    defaultZkSolcConfig.version = userConfig.zksolc?.settings?.compilerPath ? ZKSOLC_COMPILER_PATH_VERSION : 'latest';
     config.zksolc = { ...defaultZkSolcConfig, ...userConfig?.zksolc };
     config.zksolc.settings = { ...defaultZkSolcConfig.settings, ...userConfig?.zksolc?.settings };
     config.zksolc.settings.optimizer = {

--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -41,6 +41,7 @@ import {
     COMPILE_AND_DEPLOY_LIBRARIES_INSTRUCTIONS,
     MISSING_LIBRARY_LINK,
     COMPILING_INFO_MESSAGE_ZKVM_SOLC,
+    ZKSOLC_COMPILER_PATH_VERSION,
 } from './constants';
 import { ZksolcCompilerDownloader } from './compile/downloader';
 import { ZkVmSolcCompilerDownloader } from './compile/zkvm-solc-downloader';
@@ -140,9 +141,10 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS, async (args, hre, runSuper) 
     const compilersCache = await getCompilersDir();
 
     await zkSolcCompilerDownloaderMutex.use(async () => {
+        const compilerPath = hre.config.zksolc.settings.compilerPath ?? '';
         const zksolcDownloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-            hre.config.zksolc.version,
-            hre.config.zksolc.settings.compilerPath ?? '',
+            compilerPath ? ZKSOLC_COMPILER_PATH_VERSION : hre.config.zksolc.version,
+            compilerPath,
             compilersCache,
         );
 
@@ -150,6 +152,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS, async (args, hre, runSuper) 
         if (!isZksolcDownloaded) {
             await zksolcDownloader.downloadCompiler();
         }
+        
         hre.config.zksolc.settings.compilerPath = zksolcDownloader.getCompilerPath();
         hre.config.zksolc.version = zksolcDownloader.getVersion();
     });

--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -41,7 +41,7 @@ import {
     COMPILE_AND_DEPLOY_LIBRARIES_INSTRUCTIONS,
     MISSING_LIBRARY_LINK,
     COMPILING_INFO_MESSAGE_ZKVM_SOLC,
-    ZKSOLC_COMPILER_PATH_VERSION,
+    ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION,
 } from './constants';
 import { ZksolcCompilerDownloader } from './compile/downloader';
 import { ZkVmSolcCompilerDownloader } from './compile/zkvm-solc-downloader';
@@ -143,7 +143,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS, async (args, hre, runSuper) 
     await zkSolcCompilerDownloaderMutex.use(async () => {
         const compilerPath = hre.config.zksolc.settings.compilerPath ?? '';
         const zksolcDownloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-            compilerPath ? ZKSOLC_COMPILER_PATH_VERSION : hre.config.zksolc.version,
+            compilerPath ? ZKSOLC_COMPILER_PATH_REMOTE_ORIGIN_VERSION : hre.config.zksolc.version,
             compilerPath,
             compilersCache,
         );

--- a/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
+++ b/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ZksolcCompilerDownloader } from '../../../src/compile/downloader';
+import fse from 'fs-extra';
+import { COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR, COMPILER_VERSION_RANGE_ERROR } from '../../../src/constants';
 
 describe('Downloader', async () => {
     const sandbox = sinon.createSandbox();
@@ -9,16 +11,8 @@ describe('Downloader', async () => {
         return isZksolcDownloaded;
     }
 
-    beforeEach(() => {
-        sandbox.stub(ZksolcCompilerDownloader.prototype, 'downloadCompiler').resolves();
-        sandbox.stub(ZksolcCompilerDownloader.prototype, 'getVersion').returns('0.1.0');
-    });
-
     afterEach(() => {
         sandbox.restore();
-    });
-
-    after(() => {
         (ZksolcCompilerDownloader as any)._instance = undefined;
     });
 
@@ -57,6 +51,223 @@ describe('Downloader', async () => {
             const compilerPath = downloader.getCompilerPath();
 
             expect(compilerPath).to.equal('path/zksolc');
+        });
+
+        it('should return the compiler path when the compiler path is a URL', async () => {
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '0.1.0',
+                'http://example.com/zksolc',
+                'cache/',
+            );
+            sandbox.stub(fse, 'pathExists').resolves(false);
+
+            const result = downloader.getCompilerPath();
+            expect(result).to.be.equal('cache/zksolc/zksolc-remote-b2f43f92a73c853b1c1cd4cd578d3d8489c00d5d');
+        });
+
+        it('should return the compiler path is not provided', async () => {
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '1.3.23',
+                '',
+                'cache/',
+            );
+            sandbox.stub(fse, 'pathExists').resolves(false);
+
+            const result = downloader.getCompilerPath();
+            expect(result).to.be.equal('cache/zksolc/zksolc-v1.3.23');
+        });
+    });
+
+    describe('isCompilerDownloaded', async () => {
+        beforeEach(() => {
+            sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves({ latest: '1.1.0', minVersion: '0.0.1' });
+            sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
+        });
+
+        it('should return true if the compiler is downloaded and verified', async () => {
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '0.1.0',
+                'path/zksolc',
+                'zksolc/0.1.0',
+            );
+            
+            sandbox.stub(downloader as any, '_verifyCompilerAndSetVersionIfNeeded').resolves();
+            sandbox.stub(fse, 'pathExists').resolves(true);
+
+            const result = await downloader.isCompilerDownloaded();
+
+            expect(result).to.be.true;
+        });
+
+        it('should return true if the compiler is downloaded and verified when the compiler path is a URL', async () => {
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '0.1.0',
+                'http://example.com/zksolc',
+                'zksolc/0.1.0',
+            );
+            
+            sandbox.stub(downloader as any, '_verifyCompilerAndSetVersionIfNeeded').resolves();
+            sandbox.stub(fse, 'pathExists').resolves(true);
+
+            const result = await downloader.isCompilerDownloaded();
+
+            expect(result).to.be.true;
+        });
+
+        it('should return false if the compiler is not downloaded', async () => {
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '0.1.0',
+                'path/zksolc',
+                'zksolc/0.1.0',
+            );
+            
+            sandbox.stub(fse, 'pathExists').resolves(false);
+
+            try {
+            const _ = await downloader.isCompilerDownloaded();
+            } catch (e: any) {
+                expect(e.message).to.equal('The zksolc binary at path path/zksolc is corrupted. Please delete it and try again.');
+            }
+        });
+
+        it('should return false if the compiler is not downloaded when the compiler path is a URL', async () => {
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '0.1.0',
+                'http://example.com/zksolc',
+                'zksolc/',
+            );
+        
+            sandbox.stub(fse, 'pathExists').resolves(false);
+
+            const result = await downloader.isCompilerDownloaded();
+            expect(result).to.be.false;
+        });
+    });
+
+    describe('downloadCompiler', function() {
+        it('should download the compiler if the version info is not available', async function() {
+
+            const compilerStub = sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves(undefined);
+            sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(true);
+            sandbox.stub(ZksolcCompilerDownloader as any, '_downloadCompilerVersionInfo').resolves();
+            compilerStub.resolves({ latest: '1.3.50', minVersion: '1.3.16' });
+
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '1.3.17',
+                '',
+                'zksolc/',
+            );
+
+            sandbox.stub(downloader as any, '_downloadCompiler').resolves();
+            sandbox.stub(downloader as any, '_postProcessCompilerDownload').resolves();
+            sandbox.stub(downloader as any, '_verifyCompilerAndSetVersionIfNeeded').resolves();
+
+            await downloader.downloadCompiler();
+
+            sinon.assert.callCount((ZksolcCompilerDownloader as any)._getCompilerVersionInfo, 4);
+            sinon.assert.calledTwice((ZksolcCompilerDownloader as any)._shouldDownloadCompilerVersionInfo);
+            sinon.assert.calledTwice((ZksolcCompilerDownloader as any)._downloadCompilerVersionInfo);
+            sinon.assert.calledOnce((downloader as any)._downloadCompiler);
+            sinon.assert.calledOnce((downloader as any)._postProcessCompilerDownload);
+            sinon.assert.calledOnce((downloader as any)._verifyCompilerAndSetVersionIfNeeded);
+        });
+
+        it('should throw an error if the version info file is not found', async function() {
+            const compilerInfoStub = sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves({ latest: '1.3.50', minVersion: '1.3.16' });
+            sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
+            
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '1.3.21',
+                '',
+                'zksolc/',
+            );
+
+            try {
+                compilerInfoStub.resolves(undefined);
+                sandbox.stub(ZksolcCompilerDownloader as any, '_downloadCompilerVersionInfo').resolves();
+                await downloader.downloadCompiler();
+            }
+            catch (e: any) {
+                expect(e.message).to.equal(COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR);
+            }
+        });
+
+        it('should throw an error if the compiler version is not in the specified range', async function() {
+            const compilerVersionInfoStub = sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves({ latest: '1.3.25', minVersion: '1.3.18' });
+            sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
+
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '1.3.19',
+                '',
+                'zksolc/',
+            );
+
+            try{
+                compilerVersionInfoStub.resolves({ latest: '1.3.26', minVersion: '1.3.20' });
+                await downloader.downloadCompiler();
+            } catch (e: any) {
+                expect(e.message).to.equal(COMPILER_VERSION_RANGE_ERROR('1.3.19', '1.3.20', '1.3.26'));
+            }
+        });
+
+        it('should download the compiler and perform post-processing and verification', async function() {
+            sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves({ latest: '1.3.25', minVersion: '1.3.0' });
+            sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
+
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '1.3.21',
+                '',
+                'zksolc/',
+            );
+            
+            sandbox.stub(downloader as any, '_downloadCompiler').resolves();
+            sandbox.stub(downloader as any, '_postProcessCompilerDownload').resolves();
+            sandbox.stub(downloader as any, '_verifyCompilerAndSetVersionIfNeeded').resolves();
+            const consoleInfoSpy = sandbox.spy(console, 'info');
+
+            await downloader.downloadCompiler();
+
+            sinon.assert.calledOnce((downloader as any)._postProcessCompilerDownload);
+            sinon.assert.calledOnce((downloader as any)._verifyCompilerAndSetVersionIfNeeded);
+            sinon.assert.calledWithExactly(
+                consoleInfoSpy,
+                '\u001b[33mDownloading zksolc 1.3.21\u001b[39m',
+            );
+
+            sinon.assert.calledWithExactly(
+                consoleInfoSpy,
+                '\u001b[32mzksolc version 1.3.21 successfully downloaded\u001b[39m',
+            );
+        });
+
+        it('should download the compiler and perform post-processing and verification when compiler is provided with URL', async function() {
+            sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves({ latest: '1.3.25', minVersion: '1.3.0' });
+            sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
+
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                '',
+                'http://example.com/zksolc',
+                'cache/',
+            );
+
+            sandbox.stub(downloader as any, '_downloadCompiler').resolves();
+            sandbox.stub(downloader as any, '_postProcessCompilerDownload').resolves();
+            sandbox.stub(downloader as any, '_verifyCompilerAndSetVersionIfNeeded').resolves();
+            const consoleInfoSpy = sandbox.spy(console, 'info');
+
+            await downloader.downloadCompiler();
+
+            sinon.assert.calledOnce((downloader as any)._postProcessCompilerDownload);
+            sinon.assert.calledOnce((downloader as any)._verifyCompilerAndSetVersionIfNeeded);
+            sinon.assert.calledWithExactly(
+                consoleInfoSpy,
+                '\u001b[33mDownloading zksolc from the remote origin\u001b[39m',
+            );
+
+            sinon.assert.calledWithExactly(
+                consoleInfoSpy,
+                '\u001b[32mzksolc from the remote origin successfully downloaded\u001b[39m',
+            );
         });
     });
 });

--- a/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
+++ b/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
@@ -259,13 +259,13 @@ describe('Downloader', async () => {
 
             sinon.assert.calledOnce((downloader as any)._postProcessCompilerDownload);
             sinon.assert.calledOnce((downloader as any)._verifyCompilerAndSetVersionIfNeeded);
-            sinon.assert.calledWithExactly(
-                consoleInfoSpy,
+            sinon.assert.calledWith(
+                consoleInfoSpy.firstCall,
                 '\u001b[33mDownloading zksolc from the remote origin\u001b[39m',
             );
 
             sinon.assert.calledWithExactly(
-                consoleInfoSpy,
+                consoleInfoSpy.secondCall,
                 '\u001b[32mzksolc from the remote origin successfully downloaded\u001b[39m',
             );
         });

--- a/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
+++ b/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { ZksolcCompilerDownloader } from '../../../src/compile/downloader';
 import fse from 'fs-extra';
+import { ZksolcCompilerDownloader } from '../../../src/compile/downloader';
 import { COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR, COMPILER_VERSION_RANGE_ERROR } from '../../../src/constants';
 
 describe('Downloader', async () => {
@@ -66,11 +66,7 @@ describe('Downloader', async () => {
         });
 
         it('should return the compiler path is not provided', async () => {
-            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-                '1.3.23',
-                '',
-                'cache/',
-            );
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated('1.3.23', '', 'cache/');
             sandbox.stub(fse, 'pathExists').resolves(false);
 
             const result = downloader.getCompilerPath();
@@ -80,7 +76,9 @@ describe('Downloader', async () => {
 
     describe('isCompilerDownloaded', async () => {
         beforeEach(() => {
-            sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves({ latest: '1.1.0', minVersion: '0.0.1' });
+            sandbox
+                .stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo')
+                .resolves({ latest: '1.1.0', minVersion: '0.0.1' });
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
         });
 
@@ -90,13 +88,13 @@ describe('Downloader', async () => {
                 'path/zksolc',
                 'zksolc/0.1.0',
             );
-            
+
             sandbox.stub(downloader as any, '_verifyCompilerAndSetVersionIfNeeded').resolves();
             sandbox.stub(fse, 'pathExists').resolves(true);
 
             const result = await downloader.isCompilerDownloaded();
 
-            expect(result).to.be.true;
+            expect(result).to.be.equal(true);
         });
 
         it('should return true if the compiler is downloaded and verified when the compiler path is a URL', async () => {
@@ -105,13 +103,13 @@ describe('Downloader', async () => {
                 'http://example.com/zksolc',
                 'zksolc/0.1.0',
             );
-            
+
             sandbox.stub(downloader as any, '_verifyCompilerAndSetVersionIfNeeded').resolves();
             sandbox.stub(fse, 'pathExists').resolves(true);
 
             const result = await downloader.isCompilerDownloaded();
 
-            expect(result).to.be.true;
+            expect(result).to.be.equal(true);
         });
 
         it('should return false if the compiler is not downloaded', async () => {
@@ -120,13 +118,15 @@ describe('Downloader', async () => {
                 'path/zksolc',
                 'zksolc/0.1.0',
             );
-            
+
             sandbox.stub(fse, 'pathExists').resolves(false);
 
             try {
-            const _ = await downloader.isCompilerDownloaded();
+                const _ = await downloader.isCompilerDownloaded();
             } catch (e: any) {
-                expect(e.message).to.equal('The zksolc binary at path path/zksolc is corrupted. Please delete it and try again.');
+                expect(e.message).to.equal(
+                    'The zksolc binary at path path/zksolc is corrupted. Please delete it and try again.',
+                );
             }
         });
 
@@ -136,18 +136,19 @@ describe('Downloader', async () => {
                 'http://example.com/zksolc',
                 'zksolc/',
             );
-        
+
             sandbox.stub(fse, 'pathExists').resolves(false);
 
             const result = await downloader.isCompilerDownloaded();
-            expect(result).to.be.false;
+            expect(result).to.be.equal(false);
         });
     });
 
-    describe('downloadCompiler', function() {
-        it('should download the compiler if the version info is not available', async function() {
-
-            const compilerStub = sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves(undefined);
+    describe('downloadCompiler', function () {
+        it('should download the compiler if the version info is not available', async function () {
+            const compilerStub = sandbox
+                .stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo')
+                .resolves(undefined);
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(true);
             sandbox.stub(ZksolcCompilerDownloader as any, '_downloadCompilerVersionInfo').resolves();
             compilerStub.resolves({ latest: '1.3.50', minVersion: '1.3.16' });
@@ -172,10 +173,12 @@ describe('Downloader', async () => {
             sinon.assert.calledOnce((downloader as any)._verifyCompilerAndSetVersionIfNeeded);
         });
 
-        it('should throw an error if the version info file is not found', async function() {
-            const compilerInfoStub = sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves({ latest: '1.3.50', minVersion: '1.3.16' });
+        it('should throw an error if the version info file is not found', async function () {
+            const compilerInfoStub = sandbox
+                .stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo')
+                .resolves({ latest: '1.3.50', minVersion: '1.3.16' });
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
-            
+
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
                 '1.3.21',
                 '',
@@ -186,14 +189,15 @@ describe('Downloader', async () => {
                 compilerInfoStub.resolves(undefined);
                 sandbox.stub(ZksolcCompilerDownloader as any, '_downloadCompilerVersionInfo').resolves();
                 await downloader.downloadCompiler();
-            }
-            catch (e: any) {
+            } catch (e: any) {
                 expect(e.message).to.equal(COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR);
             }
         });
 
-        it('should throw an error if the compiler version is not in the specified range', async function() {
-            const compilerVersionInfoStub = sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves({ latest: '1.3.25', minVersion: '1.3.18' });
+        it('should throw an error if the compiler version is not in the specified range', async function () {
+            const compilerVersionInfoStub = sandbox
+                .stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo')
+                .resolves({ latest: '1.3.25', minVersion: '1.3.18' });
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
 
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
@@ -202,7 +206,7 @@ describe('Downloader', async () => {
                 'zksolc/',
             );
 
-            try{
+            try {
                 compilerVersionInfoStub.resolves({ latest: '1.3.26', minVersion: '1.3.20' });
                 await downloader.downloadCompiler();
             } catch (e: any) {
@@ -210,8 +214,10 @@ describe('Downloader', async () => {
             }
         });
 
-        it('should download the compiler and perform post-processing and verification', async function() {
-            sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves({ latest: '1.3.25', minVersion: '1.3.0' });
+        it('should download the compiler and perform post-processing and verification', async function () {
+            sandbox
+                .stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo')
+                .resolves({ latest: '1.3.25', minVersion: '1.3.0' });
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
 
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
@@ -219,7 +225,7 @@ describe('Downloader', async () => {
                 '',
                 'zksolc/',
             );
-            
+
             sandbox.stub(downloader as any, '_downloadCompiler').resolves();
             sandbox.stub(downloader as any, '_postProcessCompilerDownload').resolves();
             sandbox.stub(downloader as any, '_verifyCompilerAndSetVersionIfNeeded').resolves();
@@ -229,19 +235,18 @@ describe('Downloader', async () => {
 
             sinon.assert.calledOnce((downloader as any)._postProcessCompilerDownload);
             sinon.assert.calledOnce((downloader as any)._verifyCompilerAndSetVersionIfNeeded);
-            sinon.assert.calledWithExactly(
-                consoleInfoSpy,
-                '\u001b[33mDownloading zksolc 1.3.21\u001b[39m',
-            );
+            sinon.assert.calledWith(consoleInfoSpy.firstCall, sinon.match('Downloading zksolc 1.3.21'));
 
-            sinon.assert.calledWithExactly(
-                consoleInfoSpy,
-                '\u001b[32mzksolc version 1.3.21 successfully downloaded\u001b[39m',
+            sinon.assert.calledWith(
+                consoleInfoSpy.secondCall,
+                sinon.match('zksolc version 1.3.21 successfully downloaded'),
             );
         });
 
-        it('should download the compiler and perform post-processing and verification when compiler is provided with URL', async function() {
-            sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo').resolves({ latest: '1.3.25', minVersion: '1.3.0' });
+        it('should download the compiler and perform post-processing and verification when compiler is provided with URL', async function () {
+            sandbox
+                .stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo')
+                .resolves({ latest: '1.3.25', minVersion: '1.3.0' });
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
 
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
@@ -259,14 +264,11 @@ describe('Downloader', async () => {
 
             sinon.assert.calledOnce((downloader as any)._postProcessCompilerDownload);
             sinon.assert.calledOnce((downloader as any)._verifyCompilerAndSetVersionIfNeeded);
-            sinon.assert.calledWith(
-                consoleInfoSpy.firstCall,
-                '\u001b[33mDownloading zksolc from the remote origin\u001b[39m',
-            );
+            sinon.assert.calledWith(consoleInfoSpy.firstCall, sinon.match('Downloading zksolc from the remote origin'));
 
-            sinon.assert.calledWithExactly(
+            sinon.assert.calledWith(
                 consoleInfoSpy.secondCall,
-                '\u001b[32mzksolc from the remote origin successfully downloaded\u001b[39m',
+                sinon.match('zksolc from the remote origin successfully downloaded'),
             );
         });
     });

--- a/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
+++ b/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
@@ -2,7 +2,11 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import fse from 'fs-extra';
 import { ZksolcCompilerDownloader } from '../../../src/compile/downloader';
-import { COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR, COMPILER_VERSION_RANGE_ERROR } from '../../../src/constants';
+import {
+    COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR,
+    COMPILER_VERSION_RANGE_ERROR,
+    ZKSOLC_COMPILER_PATH_VERSION,
+} from '../../../src/constants';
 
 describe('Downloader', async () => {
     const sandbox = sinon.createSandbox();
@@ -78,7 +82,7 @@ describe('Downloader', async () => {
             compilerInfoStub.resolves({ latest: '0.1.0', minVersion: '0.0.1' });
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-                'remote',
+                ZKSOLC_COMPILER_PATH_VERSION,
                 'zksolc/zksolc-custom',
                 'cache/',
             );
@@ -86,7 +90,7 @@ describe('Downloader', async () => {
             const version = downloader.getVersion();
 
             expect(compilerPath).to.equal('zksolc/zksolc-custom');
-            expect(version).to.equal('remote');
+            expect(version).to.equal(ZKSOLC_COMPILER_PATH_VERSION);
         });
 
         it('create downloader with remote version with URL compiler path', async () => {
@@ -94,7 +98,7 @@ describe('Downloader', async () => {
             compilerInfoStub.resolves({ latest: '0.1.0', minVersion: '0.0.1' });
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-                'remote',
+                ZKSOLC_COMPILER_PATH_VERSION,
                 'http://example.com/zksolc',
                 'cache/',
             );
@@ -102,7 +106,7 @@ describe('Downloader', async () => {
             const version = downloader.getVersion();
 
             expect(compilerPath).to.equal('cache/zksolc/zksolc-remote-b2f43f92a73c853b1c1cd4cd578d3d8489c00d5d');
-            expect(version).to.equal('remote');
+            expect(version).to.equal(ZKSOLC_COMPILER_PATH_VERSION);
         });
 
         it('create downloader with remote version and with without compiler path', async () => {
@@ -111,9 +115,13 @@ describe('Downloader', async () => {
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
 
             try {
-                await ZksolcCompilerDownloader.getDownloaderWithVersionValidated('remote', '', 'cache/');
+                await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                    ZKSOLC_COMPILER_PATH_VERSION,
+                    '',
+                    'cache/',
+                );
             } catch (e: any) {
-                expect(e.message).to.equal('The zksolc compiler path is not specified for remote origin.');
+                expect(e.message).to.equal('The zksolc compiler path is not specified for local or remote origin.');
             }
         });
 
@@ -130,7 +138,7 @@ describe('Downloader', async () => {
                 );
             } catch (e: any) {
                 expect(e.message).to.equal(
-                    `The zksolc compiler versions in the hardhat are not supported for remote origin. Please don't specify version or use 'remote' as a version.`,
+                    `When a compiler path is provided, specifying a version of the zksolc compiler in Hardhat is not allowed. Please omit the version and try again.`,
                 );
             }
 
@@ -142,7 +150,7 @@ describe('Downloader', async () => {
                 );
             } catch (e: any) {
                 expect(e.message).to.equal(
-                    `The zksolc compiler versions in the hardhat are not supported for remote origin. Please don't specify version or use 'remote' as a version.`,
+                    `When a compiler path is provided, specifying a version of the zksolc compiler in Hardhat is not allowed. Please omit the version and try again.`,
                 );
             }
         });
@@ -172,7 +180,7 @@ describe('Downloader', async () => {
                 .returns(isCompilerDownloaded(false));
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-                'remote',
+                ZKSOLC_COMPILER_PATH_VERSION,
                 'path/zksolc/zksolc-custom',
                 'cache/',
             );
@@ -183,7 +191,7 @@ describe('Downloader', async () => {
 
         it('should return the compiler path when the compiler path is a URL', async () => {
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-                'remote',
+                ZKSOLC_COMPILER_PATH_VERSION,
                 'http://example.com/zksolc',
                 'cache/',
             );
@@ -204,7 +212,7 @@ describe('Downloader', async () => {
 
         it('should return true if the compiler is downloaded and verified', async () => {
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-                'remote',
+                ZKSOLC_COMPILER_PATH_VERSION,
                 'path/zksolc',
                 'zksolc/0.1.0',
             );
@@ -219,7 +227,7 @@ describe('Downloader', async () => {
 
         it('should return true if the compiler is downloaded and verified when the compiler path is a URL', async () => {
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-                'remote',
+                ZKSOLC_COMPILER_PATH_VERSION,
                 'http://example.com/zksolc',
                 'zksolc/0.1.0',
             );
@@ -248,7 +256,7 @@ describe('Downloader', async () => {
 
         it('should return false if the compiler is not downloaded when the compiler path is a URL', async () => {
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-                'remote',
+                ZKSOLC_COMPILER_PATH_VERSION,
                 'http://example.com/zksolc',
                 'cache/',
             );
@@ -362,7 +370,7 @@ describe('Downloader', async () => {
             sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
 
             const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
-                'remote',
+                ZKSOLC_COMPILER_PATH_VERSION,
                 'http://example.com/zksolc',
                 'cache/',
             );

--- a/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
+++ b/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
@@ -89,6 +89,22 @@ describe('Downloader', async () => {
             expect(version).to.equal('remote');
         });
 
+        it('create downloader with remote version with URL compiler path', async () => {
+            const compilerInfoStub = sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo');
+            compilerInfoStub.resolves({ latest: '0.1.0', minVersion: '0.0.1' });
+            sandbox.stub(ZksolcCompilerDownloader as any, '_shouldDownloadCompilerVersionInfo').resolves(false);
+            const downloader = await ZksolcCompilerDownloader.getDownloaderWithVersionValidated(
+                'remote',
+                'http://example.com/zksolc',
+                'cache/',
+            );
+            const compilerPath = downloader.getCompilerPath();
+            const version = downloader.getVersion();
+
+            expect(compilerPath).to.equal('cache/zksolc/zksolc-remote-b2f43f92a73c853b1c1cd4cd578d3d8489c00d5d');
+            expect(version).to.equal('remote');
+        });
+
         it('create downloader with remote version and with without compiler path', async () => {
             const compilerInfoStub = sandbox.stub(ZksolcCompilerDownloader as any, '_getCompilerVersionInfo');
             compilerInfoStub.resolves({ latest: '0.1.0', minVersion: '0.0.1' });


### PR DESCRIPTION
# What :computer: 
* Set zksolc compiler version for specified compiler path

# Why :hand:
* Handle real zksolc compilers versions when we download  them from remote origins or if we provide a path to our local path.