### PR TITLE
fix: support new naming for proxy at forwarder contracts

### DIFF
--- a/packages/hardhat-zksync-vyper/src/index.ts
+++ b/packages/hardhat-zksync-vyper/src/index.ts
@@ -14,7 +14,7 @@ import { Mutex } from 'hardhat/internal/vendor/await-semaphore';
 import './type-extensions';
 import chalk from 'chalk';
 import { CompilationJob } from 'hardhat/types';
-import { ZkArtifacts } from './artifacts';
+import { PROXY_NAME, ProxtContractOutput, ZkArtifacts, proxyNames } from './artifacts';
 import { compile } from './compile';
 import { checkSupportedVyperVersions, pluralize } from './utils';
 import {
@@ -78,10 +78,17 @@ subtask(TASK_COMPILE_VYPER_RUN_BINARY, async (args: { inputPaths: string[]; vype
     delete compilerOutput.zk_version;
     delete compilerOutput.long_version;
 
-    if (compilerOutput.__VYPER_FORWARDER_CONTRACT) {
-        (hre.artifacts as ZkArtifacts).forwarderOutput = compilerOutput.__VYPER_FORWARDER_CONTRACT;
-        delete compilerOutput.__VYPER_FORWARDER_CONTRACT;
-    }
+    proxyNames.forEach((proxyName) => {
+        if (compilerOutput[proxyName]) {
+            const proxyContractOutput: ProxtContractOutput = {
+                proxyName: proxyName as PROXY_NAME,
+                output: compilerOutput[proxyName],
+            };
+
+            (hre.artifacts as ZkArtifacts).proxyContractOutput = proxyContractOutput;
+            delete compilerOutput[proxyName];
+        }
+    });
 
     (hre.artifacts as ZkArtifacts).compilerOutput = compilerOutput;
 

--- a/packages/hardhat-zksync-vyper/test/fixture-projects/factory-with-older-compiler/contracts/CreateForwarder.vy
+++ b/packages/hardhat-zksync-vyper/test/fixture-projects/factory-with-older-compiler/contracts/CreateForwarder.vy
@@ -1,0 +1,12 @@
+# @version ^0.3
+# vim: ft=python
+
+interface DeployMe:
+    def setup(name: String[100]): nonpayable
+
+@external
+def deploy(_masterCopy: address, _name: String[100]) -> address:
+    addr: address = create_forwarder_to(_masterCopy)
+    # DeployMe.__init__ was not called, else this would fail
+    DeployMe(addr).setup(_name)
+    return addr

--- a/packages/hardhat-zksync-vyper/test/fixture-projects/factory-with-older-compiler/contracts/DeployMe.vy
+++ b/packages/hardhat-zksync-vyper/test/fixture-projects/factory-with-older-compiler/contracts/DeployMe.vy
@@ -1,0 +1,18 @@
+# @version ^0.3
+# vim: ft=python
+
+owner: public(address)
+name: public(String[100])
+
+# __init__ is not called when deployed from create_forwarder_to
+@external
+def __init__():
+  self.owner = msg.sender
+  self.name = "Foo"
+
+# call once after create_forwarder_to
+@external
+def setup(_name: String[100]):
+  assert self.owner == ZERO_ADDRESS, "owner != zero address"
+  self.owner = msg.sender
+  self.name = _name

--- a/packages/hardhat-zksync-vyper/test/fixture-projects/factory-with-older-compiler/hardhat.config.ts
+++ b/packages/hardhat-zksync-vyper/test/fixture-projects/factory-with-older-compiler/hardhat.config.ts
@@ -1,0 +1,27 @@
+import '@nomiclabs/hardhat-vyper';
+import '../../../src/index';
+import { HardhatUserConfig } from 'hardhat/config';
+
+const config: HardhatUserConfig = {
+    zkvyper: {
+        version: '1.3.17',
+        compilerSource: 'binary',
+    },
+    networks: {
+        hardhat: {
+            zksync: true,
+        },
+        otherNetwork: {
+            zksync: false,
+            url: 'http://0.0.0.0:3050',
+        },
+    },
+    vyper: {
+        version: '0.3.3',
+    },
+    solidity: {
+        version: '0.8.17',
+    },
+};
+
+export default config;

--- a/packages/hardhat-zksync-vyper/test/tests.ts
+++ b/packages/hardhat-zksync-vyper/test/tests.ts
@@ -122,8 +122,47 @@ describe('zkvyper plugin', async function () {
         });
     });
 
-    describe('Factory', async function () {
+    describe('Factory with compiler version >= 1.4.0', async function () {
         useEnvironment('factory');
+
+        it('Should successfully compile the factory contract', async function () {
+            await this.env.run(TASK_COMPILE);
+
+            const factoryArtifact = this.env.artifacts.readArtifactSync(
+                'contracts/CreateForwarder.vy:CreateForwarder',
+            ) as ZkSyncArtifact;
+            const depArtifact = this.env.artifacts.readArtifactSync('contracts/DeployMe.vy:DeployMe') as ZkSyncArtifact;
+
+            assert.equal(factoryArtifact.contractName, 'CreateForwarder');
+            assert.equal(depArtifact.contractName, 'DeployMe');
+
+            // Check that zkSync-specific artifact information was added.
+
+            // Factory contract should have one dependency.
+            // We do not check for the actual value of the hash, as it depends on the bytecode yielded by the compiler and thus not static.
+            // Instead we only check that it's a hash indeed.
+            const depHash = Object.keys(factoryArtifact.factoryDeps)[0];
+            const expectedLength = 32 * 2 + 2; // 32 bytes in hex + '0x'.
+            assert(depHash.startsWith('0x') && depHash.length === expectedLength, 'Contract hash is malformed');
+            assert.equal(
+                '.__VYPER_MINIMAL_PROXY_CONTRACT:__VYPER_MINIMAL_PROXY_CONTRACT',
+                factoryArtifact.factoryDeps[depHash],
+                'No required dependency in the artifact',
+            );
+
+            // For the dependency contract should be no further dependencies.
+            assert.deepEqual(depArtifact.factoryDeps, {}, 'Unexpected factory-deps for a dependency contract');
+
+            // Check that the forwarder artifact was saved correctly.
+            const forwarderArtifact = this.env.artifacts.readArtifactSync(
+                '.__VYPER_MINIMAL_PROXY_CONTRACT:__VYPER_MINIMAL_PROXY_CONTRACT',
+            ) as ZkSyncArtifact;
+            assert.equal(forwarderArtifact.contractName, '__VYPER_MINIMAL_PROXY_CONTRACT');
+        });
+    });
+
+    describe('Factory with compiler version < 1.4.0', async function () {
+        useEnvironment('factory-with-older-compiler');
 
         it('Should successfully compile the factory contract', async function () {
             await this.env.run(TASK_COMPILE);


### PR DESCRIPTION
# What :computer: 
* Support new naming for proxy at forwarder contracts

# Why :hand:
* With new zkvyper compiler version 1.4.0 proxy contract name is changed.