### PR TITLE
fix: set zkvyper compiler version for specified compiler path

### DIFF
--- a/packages/hardhat-zksync-vyper/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/downloader.ts
@@ -121,7 +121,7 @@ export class ZkVyperCompilerDownloader {
             return this._configCompilerPath;
         }
 
-        //Add mock extension '0' to the path so windows can execute it
+        // Add mock extension '0' to the path so windows can execute it
         return path.join(
             this._compilersDirectory,
             'zkvyper',

--- a/packages/hardhat-zksync-vyper/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/downloader.ts
@@ -125,7 +125,9 @@ export class ZkVyperCompilerDownloader {
         return path.join(
             this._compilersDirectory,
             'zkvyper',
-            `zkvyper-${this._configCompilerPath ? `remote` : `v${this._version}`}${salt ? '-' : ''}${salt}.0`,
+            `zkvyper-${this._configCompilerPath ? `remote` : `v${this._version}`}${salt ? '-' : ''}${salt}${
+                this._configCompilerPath ? '.0' : ''
+            }`,
         );
     }
 

--- a/packages/hardhat-zksync-vyper/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/downloader.ts
@@ -121,10 +121,11 @@ export class ZkVyperCompilerDownloader {
             return this._configCompilerPath;
         }
 
+        //Add mock extension '0' to the path so windows can execute it
         return path.join(
             this._compilersDirectory,
             'zkvyper',
-            `zkvyper-${this._configCompilerPath ? `remote` : `v${this._version}`}${salt ? '-' : ''}${salt}`,
+            `zkvyper-${this._configCompilerPath ? `remote` : `v${this._version}`}${salt ? '-' : ''}${salt}.0`,
         );
     }
 

--- a/packages/hardhat-zksync-vyper/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/downloader.ts
@@ -3,7 +3,15 @@ import fsExtra from 'fs-extra';
 import chalk from 'chalk';
 import { spawnSync } from 'child_process';
 
-import { download, getLatestRelease, getZkvyperUrl, isURL, isVersionInRange, saveDataToFile } from '../utils';
+import {
+    download,
+    getLatestRelease,
+    getZkvyperUrl,
+    isURL,
+    isVersionInRange,
+    saltFromUrl,
+    saveDataToFile,
+} from '../utils';
 import {
     COMPILER_BINARY_CORRUPTION_ERROR,
     COMPILER_VERSION_INFO_FILE_DOWNLOAD_ERROR,
@@ -16,6 +24,7 @@ import {
     ZKVYPER_BIN_OWNER,
     ZKVYPER_BIN_REPOSITORY,
     ZKVYPER_BIN_REPOSITORY_NAME,
+    ZKVYPER_COMPILER_PATH_VERSION,
     ZKVYPER_COMPILER_VERSION_MIN_VERSION,
 } from '../constants';
 import { ZkSyncVyperPluginError } from '../errors';
@@ -52,13 +61,25 @@ export class ZkVyperCompilerDownloader {
                 throw new ZkSyncVyperPluginError(COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR);
             }
 
+            if (version !== ZKVYPER_COMPILER_PATH_VERSION && configCompilerPath) {
+                throw new ZkSyncVyperPluginError(
+                    `When a compiler path is provided, specifying a version of the zkvyper compiler in Hardhat is not allowed. Please omit the version and try again.`,
+                );
+            }
+
+            if (version === ZKVYPER_COMPILER_PATH_VERSION && !configCompilerPath) {
+                throw new ZkSyncVyperPluginError(
+                    `The zkvyper compiler path is not specified for local or remote origin.`,
+                );
+            }
+
             if (version === 'latest' || version === compilerVersionInfo.latest) {
                 version = compilerVersionInfo.latest;
-            } else if (!isVersionInRange(version, compilerVersionInfo)) {
+            } else if (version !== ZKVYPER_COMPILER_PATH_VERSION && !isVersionInRange(version, compilerVersionInfo)) {
                 throw new ZkSyncVyperPluginError(
                     COMPILER_VERSION_RANGE_ERROR(version, compilerVersionInfo.minVersion, compilerVersionInfo.latest),
                 );
-            } else {
+            } else if (version !== ZKVYPER_COMPILER_PATH_VERSION) {
                 console.info(chalk.yellow(COMPILER_VERSION_WARNING(version, compilerVersionInfo.latest)));
             }
 
@@ -74,7 +95,7 @@ export class ZkVyperCompilerDownloader {
 
     private static _instance: ZkVyperCompilerDownloader;
     public static compilerVersionInfoCachePeriodMs = DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD;
-
+    private _isCompilerPathURL: boolean;
     /**
      * Use `getDownloaderWithVersionValidated` to create an instance of this class.
      */
@@ -82,24 +103,44 @@ export class ZkVyperCompilerDownloader {
         private _version: string,
         private readonly _configCompilerPath: string,
         private readonly _compilersDirectory: string,
-    ) {}
+    ) {
+        this._isCompilerPathURL = isURL(_configCompilerPath);
+    }
 
     public getVersion(): string {
         return this._version;
     }
 
     public getCompilerPath(): string {
-        if (this._configCompilerPath) {
+        let salt = '';
+
+        if (this._isCompilerPathURL) {
+            // hashed url used as a salt to avoid name collisions
+            salt = saltFromUrl(this._configCompilerPath);
+        } else if (this._configCompilerPath) {
             return this._configCompilerPath;
         }
 
-        return path.join(this._compilersDirectory, 'zkvyper', `zkvyper-v${this._version}`);
+        return path.join(
+            this._compilersDirectory,
+            'zkvyper',
+            `zkvyper-${this._configCompilerPath ? `remote` : `v${this._version}`}${salt ? '-' : ''}${salt}`,
+        );
     }
 
     public async isCompilerDownloaded(): Promise<boolean> {
-        if (this._configCompilerPath) {
-            await this._verifyCompiler();
+        if (this._configCompilerPath && !this._isCompilerPathURL) {
+            await this._verifyCompilerAndSetVersionIfNeeded();
             return true;
+        }
+
+        if (this._configCompilerPath && this._isCompilerPathURL) {
+            const compilerPathFromUrl = this.getCompilerPath();
+            if (await fsExtra.pathExists(compilerPathFromUrl)) {
+                await this._verifyCompilerAndSetVersionIfNeeded();
+                return true;
+            }
+            return false;
         }
 
         const compilerPath = this.getCompilerPath();
@@ -141,22 +182,32 @@ export class ZkVyperCompilerDownloader {
         if (compilerVersionInfo === undefined) {
             throw new ZkSyncVyperPluginError(COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR);
         }
-        if (!isVersionInRange(this._version, compilerVersionInfo)) {
+        if (!this._configCompilerPath && !isVersionInRange(this._version, compilerVersionInfo)) {
             throw new ZkSyncVyperPluginError(
                 COMPILER_VERSION_RANGE_ERROR(this._version, compilerVersionInfo.minVersion, compilerVersionInfo.latest),
             );
         }
 
         try {
-            console.info(chalk.yellow(`Downloading zkvyper ${this._version}`));
+            console.info(
+                chalk.yellow(
+                    `Downloading zkvyper ${!this._configCompilerPath ? this._version : 'from the remote origin'}`,
+                ),
+            );
             await this._downloadCompiler();
-            console.info(chalk.green(`zkvyper version ${this._version} successfully downloaded`));
+            console.info(
+                chalk.green(
+                    `zkvyper ${
+                        !this._configCompilerPath ? `version ${this._version}` : 'from the remote origin'
+                    } successfully downloaded`,
+                ),
+            );
         } catch (e: any) {
             throw new ZkSyncVyperPluginError(e.message.split('\n')[0]);
         }
 
         await this._postProcessCompilerDownload();
-        await this._verifyCompiler();
+        await this._verifyCompilerAndSetVersionIfNeeded();
     }
 
     private static async _downloadCompilerVersionInfo(compilersDir: string): Promise<void> {
@@ -215,7 +266,7 @@ export class ZkVyperCompilerDownloader {
         fsExtra.chmodSync(compilerPath, 0o755);
     }
 
-    private async _verifyCompiler(): Promise<void> {
+    private async _verifyCompilerAndSetVersionIfNeeded(): Promise<void> {
         const compilerPath = this.getCompilerPath();
 
         const versionOutput = spawnSync(compilerPath, ['--version']);
@@ -226,6 +277,10 @@ export class ZkVyperCompilerDownloader {
 
         if (versionOutput.status !== 0 || version === null) {
             throw new ZkSyncVyperPluginError(COMPILER_BINARY_CORRUPTION_ERROR(compilerPath));
+        }
+
+        if (this._configCompilerPath) {
+            this._version = version!;
         }
     }
 }

--- a/packages/hardhat-zksync-vyper/src/constants.ts
+++ b/packages/hardhat-zksync-vyper/src/constants.ts
@@ -7,6 +7,8 @@ export const DEFAULT_TIMEOUT_MILISECONDS = 30000;
 export const TASK_COMPILE_VYPER_CHECK_ERRORS = 'compile:vyper:check-errors';
 export const TASK_COMPILE_VYPER_LOG_COMPILATION_ERRORS = 'compile:vyper:log:compilation-errors';
 
+export const ZKVYPER_COMPILER_PATH_VERSION = 'local_or_remote';
+
 // User agent of MacOSX Chrome 120.0.0.0
 export const USER_AGENT =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';

--- a/packages/hardhat-zksync-vyper/src/index.ts
+++ b/packages/hardhat-zksync-vyper/src/index.ts
@@ -22,10 +22,14 @@ import {
     defaultZkVyperConfig,
     TASK_COMPILE_VYPER_CHECK_ERRORS,
     TASK_COMPILE_VYPER_LOG_COMPILATION_ERRORS,
+    ZKVYPER_COMPILER_PATH_VERSION,
 } from './constants';
 import { ZkVyperCompilerDownloader } from './compile/downloader';
 
 extendConfig((config, userConfig) => {
+    defaultZkVyperConfig.version = userConfig.zkvyper?.settings?.compilerPath
+        ? ZKVYPER_COMPILER_PATH_VERSION
+        : 'latest';
     config.zkvyper = { ...defaultZkVyperConfig, ...userConfig?.zkvyper };
     config.zkvyper.settings = { ...defaultZkVyperConfig.settings, ...userConfig?.zkvyper?.settings };
     config.zkvyper.settings.optimizer = {

--- a/packages/hardhat-zksync-vyper/src/utils.ts
+++ b/packages/hardhat-zksync-vyper/src/utils.ts
@@ -1,4 +1,5 @@
 import semver from 'semver';
+import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import util from 'util';
@@ -54,6 +55,13 @@ export function isURL(url: string): boolean {
     }
 }
 
+export function sha1(str: string): string {
+    return crypto.createHash('sha1').update(str).digest('hex');
+}
+
+export function saltFromUrl(url: string): string {
+    return sha1(url);
+}
 export function isVersionInRange(version: string, versionInfo: CompilerVersionInfo): boolean {
     const latest = versionInfo.latest;
     const minVersion = versionInfo.minVersion;


### PR DESCRIPTION
# What :computer: 
* Set zkvyper compiler version for specified compiler path

# Why :hand:
* Handle real zkvyper compilers versions when we download them from remote origins or if we provide a path to our local path.