### PR TITLE
fix: add mock extension for compiler path remote origins

### DIFF
--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -117,10 +117,13 @@ export class ZksolcCompilerDownloader {
             return this._configCompilerPath;
         }
 
+        // Add mock extension '0' so windowns can run the binary
         return path.join(
             this._compilersDirectory,
             'zksolc',
-            `zksolc-${this._configCompilerPath ? `remote` : `v${this._version}`}${salt ? '-' : ''}${salt}`,
+            `zksolc-${this._configCompilerPath ? `remote` : `v${this._version}`}${salt ? '-' : ''}${salt}${
+                this._configCompilerPath ? '.0' : ''
+            }`,
         );
     }
 

--- a/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
+++ b/packages/hardhat-zksync-solc/test/tests/compile/downloader.test.ts
@@ -105,7 +105,7 @@ describe('Downloader', async () => {
             const compilerPath = downloader.getCompilerPath();
             const version = downloader.getVersion();
 
-            expect(compilerPath).to.equal('cache/zksolc/zksolc-remote-b2f43f92a73c853b1c1cd4cd578d3d8489c00d5d');
+            expect(compilerPath).to.equal('cache/zksolc/zksolc-remote-b2f43f92a73c853b1c1cd4cd578d3d8489c00d5d.0');
             expect(version).to.equal(ZKSOLC_COMPILER_PATH_VERSION);
         });
 
@@ -198,7 +198,7 @@ describe('Downloader', async () => {
             sandbox.stub(fse, 'pathExists').resolves(false);
 
             const result = downloader.getCompilerPath();
-            expect(result).to.be.equal('cache/zksolc/zksolc-remote-b2f43f92a73c853b1c1cd4cd578d3d8489c00d5d');
+            expect(result).to.be.equal('cache/zksolc/zksolc-remote-b2f43f92a73c853b1c1cd4cd578d3d8489c00d5d.0');
         });
     });
 


### PR DESCRIPTION
# What :computer: 
* Add mock extension for compiler path remote origins

# Why :hand:
* Windows cannot run binary files without a extension so we need set some mock extension.