### PR TITLE
fix: bump hardhat-zksync-deploy dependency in packages

### DIFF
--- a/packages/hardhat-zksync-ethers/package.json
+++ b/packages/hardhat-zksync-ethers/package.json
@@ -38,7 +38,7 @@
     "hardhat": "^2.19.4",
     "chai": "^4.2.0",
     "@matterlabs/hardhat-zksync-solc": "^1.1.2",
-    "@matterlabs/hardhat-zksync-deploy": "^1.1.2"
+    "@matterlabs/hardhat-zksync-deploy": "^1.2.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.0",

--- a/packages/hardhat-zksync-toolbox/package.json
+++ b/packages/hardhat-zksync-toolbox/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@matterlabs/hardhat-zksync-chai-matchers": "^1.2.2",
-    "@matterlabs/hardhat-zksync-deploy": "^1.1.2",
+    "@matterlabs/hardhat-zksync-deploy": "^1.2.0",
     "@matterlabs/hardhat-zksync-solc": "^1.1.2",
     "@matterlabs/hardhat-zksync-verify": "^1.3.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.4",
@@ -65,7 +65,7 @@
   },
   "peerDependencies": {
     "@matterlabs/hardhat-zksync-chai-matchers": "^1.2.2",
-    "@matterlabs/hardhat-zksync-deploy": "^1.1.2",
+    "@matterlabs/hardhat-zksync-deploy": "^1.2.0",
     "@matterlabs/hardhat-zksync-solc": "^1.1.2",
     "@matterlabs/hardhat-zksync-verify": "^1.3.0"
   },

--- a/packages/hardhat-zksync-upgradable/package.json
+++ b/packages/hardhat-zksync-upgradable/package.json
@@ -33,7 +33,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^1.1.0",
+    "@matterlabs/hardhat-zksync-deploy": "^1.2.0",
     "@matterlabs/hardhat-zksync-solc": "^1.0.3",
     "@openzeppelin/upgrades-core": "^1.31.3",
     "chalk": "4.1.2",
@@ -47,7 +47,7 @@
     "compare-versions": "^6.0.0"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^1.1.0",
+    "@matterlabs/hardhat-zksync-deploy": "^1.2.0",
     "@matterlabs/hardhat-zksync-solc": "^1.0.3",
     "@openzeppelin/contracts-upgradeable": "^4.9.2",
     "@types/fs-extra": "^11.0.1",


### PR DESCRIPTION
# What :computer: 
Bump hardhat-zksync-deploy dependencies in packages

# Why :hand:
In order to have a latest version of the hardhat-zksync-deploy plugin.
