### PR TITLE
fix: set forceDeploy to true as a default value

### DIFF
--- a/packages/hardhat-zksync-deploy/src/index.ts
+++ b/packages/hardhat-zksync-deploy/src/index.ts
@@ -16,7 +16,7 @@ extendConfig((config, userConfig) => {
 
 extendEnvironment((hre) => {
     hre.network.zksync = hre.network.config.zksync ?? false;
-    hre.network.forceDeploy = hre.network.config.forceDeploy ?? false;
+    hre.network.forceDeploy = hre.network.config.forceDeploy ?? true;
     hre.network.deployPaths = hre.network.config.deployPaths
         ? typeof hre.network.config.deployPaths === 'string'
             ? [hre.network.config.deployPaths]


### PR DESCRIPTION
# What :computer: 
* Set forceDeploy to true as a default value

# Why :hand:
* To address unexpected behavior where contracts are being deployed multiple times where forceDeploy being set to false by default, we're considering setting forceDeploy to true as the default value. This adjustment aims to align with user expectations and maintain compatibility with previous versions of the system.