### PR TITLE
chore: pre-release support for hardhat-zksync-verify-vyper

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -40,6 +40,12 @@
         "packages/hardhat-zksync-ethers": {
             "release-type": "node",
             "component": "@matterlabs/hardhat-zksync-ethers"
+        },
+        "packages/hardhat-zksync-verify-vyper": {
+            "prerelease-type": "alpha",
+            "prerelease": true,
+            "release-type": "node",
+            "component": "@matterlabs/hardhat-zksync-verify-vyper"
         }
     }
 }

--- a/.github/release-please/manifest.json
+++ b/.github/release-please/manifest.json
@@ -7,5 +7,6 @@
     "packages/hardhat-zksync-toolbox": "1.3.0",
     "packages/hardhat-zksync-node": "1.0.2",
     "packages/hardhat-zksync-chai-matchers": "1.3.0",
-    "packages/hardhat-zksync-ethers": "1.0.0"
+    "packages/hardhat-zksync-ethers": "1.0.0",
+    "packages/hardhat-zksync-verify-vyper": "0.0.1-alpha.6"
 }


### PR DESCRIPTION
# What :computer: 
* pre-release support for hardhat-zksync-verify-vyper

# Why :hand:
* To automatically support pre-release versions for hardhat-zksync-verify-vyper