### PR TITLE
fix: support for non-inline libraries 'export default' expressions an…

### DIFF
--- a/packages/hardhat-zksync-deploy/src/utils.ts
+++ b/packages/hardhat-zksync-deploy/src/utils.ts
@@ -10,7 +10,7 @@ import {
 import fs from 'fs';
 import { Wallet } from 'zksync-ethers';
 import { ContractFullQualifiedName, ContractInfo, MissingLibrary } from './types';
-import { MorphTsBuilder } from './morph-ts-builder';
+import { MorphBuilderInitialDefaultAssignment, MorphTsBuilder } from './morph-ts-builder';
 import { ZkSyncDeployPluginError } from './errors';
 import { LOCAL_CHAIN_IDS } from './constants';
 import { richWallets } from './rich-wallets';
@@ -27,11 +27,12 @@ export function updateHardhatConfigFile(
     try {
         new MorphTsBuilder(externalConfigObjectPath ?? hre.config.paths.configFile)
             .intialStep([
+                { initialModule: 'module.exports' },
+                {} as MorphBuilderInitialDefaultAssignment,
                 { initialVariableType: 'HardhatUserConfig' },
                 { initialVariable: exportedConfigObject },
-                { initialModule: 'module.exports' },
             ])
-            .nextStep({ propertyName: 'zksolc', isRequired: true })
+            .nextStep({ propertyName: 'zksolc' })
             .nextStep({ propertyName: 'settings' })
             .replaceStep({ propertyName: 'libraries', replaceObject: hre.config.zksolc.settings.libraries })
             .save();


### PR DESCRIPTION
…d zksolc is not reqired for config update

# What :computer: 
* Support for non-inline libraries 'export default' expressions and zksolc is not reqired for config update

# Why :hand:
* Some of users use **export default {}** so this PR is created to support this feature. Also, zksolc section is not required anymore for non-inline libraries update.