### PR TITLE
fix: send to verify service compiler input settings

### DIFF
--- a/packages/hardhat-zksync-verify/src/plugin.ts
+++ b/packages/hardhat-zksync-verify/src/plugin.ts
@@ -1,5 +1,5 @@
 import { TASK_FLATTEN_GET_FLATTENED_SOURCE } from 'hardhat/builtin-tasks/task-names';
-import { Artifacts, HardhatRuntimeEnvironment, ResolvedFile } from 'hardhat/types';
+import { Artifacts, CompilerInput, HardhatRuntimeEnvironment, ResolvedFile } from 'hardhat/types';
 import { isFullyQualifiedName, parseFullyQualifiedName } from 'hardhat/utils/contract-names';
 import path from 'path';
 import chalk from 'chalk';
@@ -69,13 +69,13 @@ Instead, this name was received: ${contractFQN}`,
     }
 }
 
-export function getSolidityStandardJsonInput(hre: HardhatRuntimeEnvironment, resolvedFiles: ResolvedFile[]): any {
+export function getSolidityStandardJsonInput(resolvedFiles: ResolvedFile[], input: CompilerInput): any {
     return {
-        language: 'Solidity',
+        language: input.language,
         sources: Object.fromEntries(
             resolvedFiles.map((file) => [file.sourceName, { content: file.content.rawContent }]),
         ),
-        settings: hre.config.zksolc.settings,
+        settings: input.settings,
     };
 }
 

--- a/packages/hardhat-zksync-verify/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify/src/task-actions.ts
@@ -208,7 +208,7 @@ export async function verifyContract(
 
     const request = {
         contractAddress: address,
-        sourceCode: getSolidityStandardJsonInput(hre, dependencyGraph.getResolvedFiles()),
+        sourceCode: getSolidityStandardJsonInput(dependencyGraph.getResolvedFiles(), contractInformation.compilerInput),
         codeFormat: JSON_INPUT_CODE_FORMAT,
         contractName: contractInformation.contractName,
         compilerSolcVersion: solcVersion,

--- a/packages/hardhat-zksync-verify/test/tests/plugin.test.ts
+++ b/packages/hardhat-zksync-verify/test/tests/plugin.test.ts
@@ -255,7 +255,7 @@ Instead, this name was received: ${contractFQN}`);
                         '*': {
                             '*': ['evm'],
                         },
-                    },
+                    }
                 },
             });
 
@@ -264,7 +264,6 @@ Instead, this name was received: ${contractFQN}`);
                 'contract Contract {}',
             );
             expect(solidityStandardJsonInput.settings.optimizer.enabled).to.equal(true);
-            expect(solidityStandardJsonInput.settings.areLibrariesMissing).to.equal(false);
         });
     });
 

--- a/packages/hardhat-zksync-verify/test/tests/plugin.test.ts
+++ b/packages/hardhat-zksync-verify/test/tests/plugin.test.ts
@@ -240,7 +240,24 @@ Instead, this name was received: ${contractFQN}`);
                 },
             ];
 
-            const solidityStandardJsonInput = getSolidityStandardJsonInput(this.env, resolvedFiles);
+            const solidityStandardJsonInput = getSolidityStandardJsonInput(resolvedFiles, {
+                language: 'Solidity',
+                sources: {
+                    'contracts/Contract.sol': {
+                        content: 'contract Contract {}',
+                    },
+                },
+                settings: {
+                    optimizer: {
+                        enabled: true,
+                    },
+                    outputSelection: {
+                        '*': {
+                            '*': ['evm'],
+                        },
+                    },
+                },
+            });
 
             expect(solidityStandardJsonInput.language).to.equal('Solidity');
             expect(solidityStandardJsonInput.sources['contracts/Contract.sol'].content).to.equal(


### PR DESCRIPTION
# What :computer: 
* Send to verify service compiler input settings

# Why :hand:
* Before implementing these changes, it's BE has received settings from zksolc. However, the introduction of the `evmVersion` field by Hardhat affects how our contracts are compiled. Notably, this change doesn't impact the verification process due to the lack of support for this field in older versions of the zksolc compiler (<1.4.0). Although zksolc compiler 1.4.0 incorporates this field into the compilation process, and now is absent from the verification request.