### PR TITLE
fix: update deploy cache logic with script load path support for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build-test/
 dist
 artifacts-zk/
 cache-zk/
+deployments-zk/
 deployments/
 
 # Code coverage artifacts

--- a/examples/deploy-example/deploy/003_deploy.ts
+++ b/examples/deploy-example/deploy/003_deploy.ts
@@ -5,15 +5,14 @@ const deployScript = async function (hre: HardhatRuntimeEnvironment) {
     console.info(chalk.yellow(`Running deploy script for the Constant contract from deploy folder`));
 
     // Load the artifact we want to deploy.
-    const artifact = await hre.deployer.loadArtifact('Constant');
 
     // Deploy this contract. The returned object will be of a `Contract` type, similarly to ones in `ethers`.
     // This contract has no constructor arguments.
-    const factoryContract = await hre.deployer.deploy(artifact, []);
+    const factoryContract = await hre.deployer.deploy('Constant');
 
     // Show the contract info.
     const contractAddress = await factoryContract.getAddress();
-    console.info(chalk.green(`${artifact.contractName} was deployed to ${contractAddress}!`));
+    console.info(chalk.green(`Constant was deployed to ${contractAddress}!`));
 };
 
 export default deployScript;

--- a/packages/hardhat-zksync-deploy/package.json
+++ b/packages/hardhat-zksync-deploy/package.json
@@ -22,7 +22,7 @@
     "fmt": "yarn prettier --write",
     "eslint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "prettier": "prettier 'src/**/*.ts' 'test/**/*.ts'",
-    "test": "c8 mocha test/tests.ts --no-timeout --exit",
+    "test": "c8 mocha --recursive \"test/tests/**/*.ts\" --no-timeout --exit",
     "build": "tsc --build .",
     "clean": "rimraf dist"
   },
@@ -39,7 +39,9 @@
     "chai": "^4.3.6",
     "glob": "^10.3.10",
     "fs-extra": "^11.2.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "sinon-chai": "^3.7.0",
+    "sinon": "^17.0.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.0",

--- a/packages/hardhat-zksync-deploy/src/deployer-extension.ts
+++ b/packages/hardhat-zksync-deploy/src/deployer-extension.ts
@@ -34,7 +34,7 @@ export class DeployerExtension implements AbstractDeployer {
     }
 
     public async deploy(
-        artifact: ZkSyncArtifact,
+        contractNameOrArtifact: ZkSyncArtifact | string,
         constructorArguments: any[] = [],
         overrides?: ethers.Overrides,
         additionalFactoryDeps?: ethers.BytesLike[],
@@ -45,7 +45,7 @@ export class DeployerExtension implements AbstractDeployer {
 
         return await deploy(
             this._hre,
-            artifact,
+            contractNameOrArtifact,
             constructorArguments,
             this.wallet,
             this._deploymentType,

--- a/packages/hardhat-zksync-deploy/src/deployer-helper.ts
+++ b/packages/hardhat-zksync-deploy/src/deployer-helper.ts
@@ -67,12 +67,10 @@ export async function deploy(
     overrides?: ethers.Overrides,
     additionalFactoryDeps?: ethers.BytesLike[],
 ): Promise<zk.Contract> {
-    let artifact: ZkSyncArtifact;
-    if (typeof contractNameOrArtifact === 'string') {
-        artifact = await loadArtifact(hre, contractNameOrArtifact);
-    } else {
-        artifact = contractNameOrArtifact;
-    }
+    const artifact: ZkSyncArtifact =
+        typeof contractNameOrArtifact === 'string'
+            ? await loadArtifact(hre, contractNameOrArtifact)
+            : contractNameOrArtifact;
 
     const baseDeps = await _extractFactoryDeps(hre, artifact);
     const additionalDeps = additionalFactoryDeps ? additionalFactoryDeps.map((val) => ethers.hexlify(val)) : [];

--- a/packages/hardhat-zksync-deploy/src/deployer.ts
+++ b/packages/hardhat-zksync-deploy/src/deployer.ts
@@ -57,14 +57,14 @@ export class Deployer implements AbstractDeployer {
     }
 
     public async deploy(
-        artifact: ZkSyncArtifact,
+        contractNameOrArtifact: ZkSyncArtifact | string,
         constructorArguments: any[] = [],
         overrides?: ethers.Overrides,
         additionalFactoryDeps?: ethers.BytesLike[],
     ): Promise<zk.Contract> {
         return await deploy(
             this._hre,
-            artifact,
+            contractNameOrArtifact,
             constructorArguments,
             this.zkWallet,
             this.deploymentType,

--- a/packages/hardhat-zksync-deploy/src/deployment-saver.ts
+++ b/packages/hardhat-zksync-deploy/src/deployment-saver.ts
@@ -10,6 +10,7 @@ export interface DeploymentEntry {
     constructorArgs: any[];
     salt: string;
     deploymentType: DeploymentType;
+    factoryDeps: string[];
     address: string;
     txHash: string;
 }
@@ -18,6 +19,7 @@ export interface EntryToFind {
     constructorArgs: any[];
     salt: string;
     deploymentType: DeploymentType;
+    factoryDeps: string[];
 }
 
 export interface Deployment {
@@ -28,7 +30,7 @@ export interface Deployment {
     entries: DeploymentEntry[];
 }
 
-export const DEPLOYMENT_PATH: string = 'deployments';
+export const DEPLOYMENT_PATH: string = 'deployments-zk';
 export const CHAIN_ID_FILE: string = '.chainId';
 
 export async function saveCache(
@@ -59,6 +61,7 @@ export async function loadCache(
     deploymentType: DeploymentType,
     constructorArgs: any[],
     salt: string,
+    factoryDeps: string[],
 ): Promise<DeploymentEntry | undefined> {
     const deployment = await loadDeployment(hre, artifact);
 
@@ -70,6 +73,7 @@ export async function loadCache(
         constructorArgs,
         salt,
         deploymentType,
+        factoryDeps,
     };
 
     return loadDeploymentEntry(hre, deployment, entryToFind);
@@ -148,7 +152,8 @@ export async function loadDeploymentEntry(
         (entry) =>
             lodash.isEqual(entry.constructorArgs, deploymentForFound.constructorArgs) &&
             lodash.isEqual(entry.salt, deploymentForFound.salt) &&
-            lodash.isEqual(entry.deploymentType, deploymentForFound.deploymentType),
+            lodash.isEqual(entry.deploymentType, deploymentForFound.deploymentType) &&
+            lodash.isEqual(entry.factoryDeps.sort(), deploymentForFound.factoryDeps.sort()),
     );
 
     if (foundEntry) {

--- a/packages/hardhat-zksync-deploy/src/deployment-saver.ts
+++ b/packages/hardhat-zksync-deploy/src/deployment-saver.ts
@@ -166,8 +166,21 @@ export async function loadDeploymentEntry(
             return undefined;
         }
 
+        if (isDeploymentEntry(deploymentForFound)) {
+            if (foundEntry.txHash !== deploymentForFound.txHash && deploymentForFound.address !== foundEntry.address) {
+                const newEntry = { ...foundEntry };
+                newEntry.txHash = deploymentForFound.txHash;
+                newEntry.address = deploymentForFound.address;
+                deployment.entries.splice(entryIndex, 1, newEntry);
+            }
+        }
+
         return foundEntry;
     }
 
     return undefined;
+}
+
+export function isDeploymentEntry(object: any): object is DeploymentEntry {
+    return 'address' in object && 'txHash' in object;
 }

--- a/packages/hardhat-zksync-deploy/src/script-manager.ts
+++ b/packages/hardhat-zksync-deploy/src/script-manager.ts
@@ -26,8 +26,8 @@ export class ScriptManager {
             }
 
             const [tsFilesInDir, jsFilesInDir] = await Promise.all([
-                await glob(path.join(dir, '**', '*.ts'), {}),
-                await glob(path.join(dir, '**', '*.js'), {}),
+                await glob(path.join(dir, '**', '*.ts').replace(/\\/g, '/'), {}),
+                await glob(path.join(dir, '**', '*.js').replace(/\\/g, '/'), {}),
             ]);
 
             const filesInDir = tsFilesInDir.concat(jsFilesInDir);
@@ -44,7 +44,7 @@ export class ScriptManager {
                 continue;
             }
 
-            const matchedFiles = glob.sync(path.join(dir, '**', script));
+            const matchedFiles = glob.sync(path.join(dir, '**', script).replace(/\\/g, '/'));
 
             if (matchedFiles.length) {
                 return matchedFiles[0];

--- a/packages/hardhat-zksync-deploy/src/utils.ts
+++ b/packages/hardhat-zksync-deploy/src/utils.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import {
+    EthereumProvider,
     HardhatNetworkAccountsConfig,
     HardhatNetworkHDAccountsConfig,
     HardhatRuntimeEnvironment,
@@ -137,4 +138,13 @@ export async function getWalletsFromAccount(
     }
 
     return [];
+}
+
+export async function retrieveContractBytecode(address: string, provider: EthereumProvider): Promise<string> {
+    const bytecodeString = (await provider.send('eth_getCode', [address, 'latest'])) as string;
+
+    if (!bytecodeString || bytecodeString.length === 0) {
+        return undefined;
+    }
+    return bytecodeString;
 }

--- a/packages/hardhat-zksync-deploy/test/tests/deployment-saver.test.ts
+++ b/packages/hardhat-zksync-deploy/test/tests/deployment-saver.test.ts
@@ -57,7 +57,7 @@ describe('Deployment Saver', () => {
             expect(result).to.be.equal(undefined);
             expect(
                 existsSyncStub.calledOnceWithExactly(
-                    '/path/to/root/deployments/zkSyncNetwork/contracts/MyContract.sol/MyContract.json',
+                    '/path/to/root/deployments-zk/zkSyncNetwork/contracts/MyContract.sol/MyContract.json',
                 ),
             ).to.be.equal(true);
         });
@@ -140,7 +140,10 @@ describe('Deployment Saver', () => {
             );
 
             expect(
-                writeFileSyncStub.calledOnceWithExactly('/path/to/root/deployments/zkSyncNetwork/.chainId', '123456'),
+                writeFileSyncStub.calledOnceWithExactly(
+                    '/path/to/root/deployments-zk/zkSyncNetwork/.chainId',
+                    '123456',
+                ),
             ).to.be.eqls(true);
         });
 
@@ -157,7 +160,7 @@ describe('Deployment Saver', () => {
 
             expect(
                 writeJsonSyncStub.calledOnceWithExactly(
-                    '/path/to/root/deployments/zkSyncNetwork/contracts/subFolder/MyContract.sol/MyContract.json',
+                    '/path/to/root/deployments-zk/zkSyncNetwork/contracts/subFolder/MyContract.sol/MyContract.json',
                     deployment,
                     { spaces: 2 },
                 ),
@@ -178,12 +181,14 @@ describe('Deployment Saver', () => {
                         salt: 'salt1',
                         deploymentType: 'type1',
                         address: '0x1234567890',
+                        factoryDeps: ['1234', '3242'],
                     },
                     {
                         constructorArgs: [4, 5, 6],
                         salt: 'salt2',
                         deploymentType: 'type2',
                         address: '0x0987654321',
+                        factoryDeps: [],
                     },
                 ],
                 bytecode: '0x1234567890',
@@ -194,6 +199,7 @@ describe('Deployment Saver', () => {
                 constructorArgs: [1, 2, 3],
                 salt: 'salt1',
                 deploymentType: 'type1',
+                factoryDeps: ['3242', '1234'],
             };
         });
 
@@ -204,6 +210,7 @@ describe('Deployment Saver', () => {
                 constructorArgs: [1, 2, 3],
                 salt: 'salt1',
                 deploymentType: 'type1',
+                factoryDeps: ['1234', '3242'],
                 address: '0x1234567890',
             });
 
@@ -215,6 +222,7 @@ describe('Deployment Saver', () => {
                 constructorArgs: [7, 8, 9],
                 salt: 'salt3',
                 deploymentType: 'type3',
+                factoryDeps: [],
             };
 
             const entry = await loadDeploymentEntry(hre as any, deployment, deploymentForFound);

--- a/packages/hardhat-zksync-deploy/test/tests/deployment-saver.test.ts
+++ b/packages/hardhat-zksync-deploy/test/tests/deployment-saver.test.ts
@@ -1,0 +1,233 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import fse from 'fs-extra';
+import { ZkSyncArtifact } from '../../src/types';
+import { loadDeployment, loadDeploymentEntry, saveDeployment } from '../../src/deployment-saver';
+
+describe('Deployment Saver', () => {
+    const providerSentStub = sinon.stub();
+    const provider = {
+        send: providerSentStub,
+    };
+
+    const hre = {
+        network: {
+            provider,
+            name: 'zkSyncNetwork',
+            zksync: false,
+        },
+        config: {
+            paths: {
+                root: '/path/to/root/',
+            },
+            solidity: {
+                compilers: [],
+            },
+        },
+        run: sinon.stub(),
+    };
+
+    const existsSyncStub = sinon.stub(fse, 'existsSync').returns(false);
+    const readFileSyncStub = sinon.stub(fse, 'readFileSync').returns('123456');
+    const readJsonSyncStub = sinon.stub(fse, 'readJsonSync');
+
+    let artifact: ZkSyncArtifact;
+
+    beforeEach(() => {
+        artifact = {
+            contractName: 'MyContract',
+            bytecode: '0x1234567890',
+            abi: [{ name: 'method', inputs: [], outputs: [] }],
+            _format: 'full',
+            sourceName: 'contracts/MyContract.sol',
+            sourceMapping: '/path/to/MyContract.sol',
+            factoryDeps: {},
+            deployedBytecode: '0x1234567890',
+            deployedLinkReferences: {},
+            linkReferences: {},
+        };
+    });
+
+    describe('loadDeployment', () => {
+        it('should return undefined if deployment file does not exist', async () => {
+            existsSyncStub.returns(false);
+
+            const result = await loadDeployment(hre as any, artifact);
+
+            expect(result).to.be.equal(undefined);
+            expect(
+                existsSyncStub.calledOnceWithExactly(
+                    '/path/to/root/deployments/zkSyncNetwork/contracts/MyContract.sol/MyContract.json',
+                ),
+            ).to.be.equal(true);
+        });
+
+        it('should return undefined if chain ID in deployment file does not match current chain ID', async () => {
+            existsSyncStub.returns(true);
+            readFileSyncStub.returns('23333');
+            providerSentStub.returns('123456');
+            const result = await loadDeployment(hre as any, artifact);
+
+            expect(result).to.be.equal(undefined);
+        });
+
+        it('should return undefined if bytecode in deployment file does not match artifact bytecode', async () => {
+            existsSyncStub.returns(true);
+            readFileSyncStub.returns('123456');
+            providerSentStub.returns('123456');
+            readJsonSyncStub.returns({
+                bytecode: '0x0987654321',
+                abi: [],
+            });
+
+            const result = await loadDeployment(hre as any, artifact);
+
+            expect(result).to.be.equal(undefined);
+        });
+
+        it('should return undefined if ABI in deployment file does not match artifact ABI', async () => {
+            existsSyncStub.returns(true);
+            readFileSyncStub.returns('123456');
+            providerSentStub.returns('123456');
+            readJsonSyncStub.returns({
+                bytecode: '0x1234567890',
+                abi: [{ name: 'something', inputs: [], outputs: [] }],
+            });
+
+            const result = await loadDeployment(hre as any, artifact);
+
+            expect(result).to.be.equal(undefined);
+        });
+
+        it('should return the deployment if all conditions are met', async () => {
+            existsSyncStub.returns(true);
+            readFileSyncStub.returns('123456');
+            providerSentStub.returns('123456');
+            readJsonSyncStub.returns({
+                bytecode: '0x1234567890',
+                abi: [{ name: 'method', inputs: [], outputs: [] }],
+            });
+
+            const result = await loadDeployment(hre as any, artifact);
+
+            expect(result).to.deep.equal({
+                bytecode: '0x1234567890',
+                abi: [{ name: 'method', inputs: [], outputs: [] }],
+            });
+        });
+    });
+
+    describe('saveDeployment', () => {
+        const mkdirpSyncStub = sinon.stub(fse, 'mkdirpSync');
+        const writeFileSyncStub = sinon.stub(fse, 'writeFileSync');
+        const writeJsonSyncStub = sinon.stub(fse, 'writeJsonSync');
+
+        beforeEach(() => {
+            mkdirpSyncStub.reset();
+            writeFileSyncStub.reset();
+            writeJsonSyncStub.reset();
+        });
+
+        it('should write the chain ID to a file', async () => {
+            providerSentStub.returns('123456');
+
+            await saveDeployment(
+                hre as any,
+                {
+                    contractName: 'Something.sol',
+                    sourceName: 'contracts/Something.sol',
+                } as any,
+            );
+
+            expect(
+                writeFileSyncStub.calledOnceWithExactly('/path/to/root/deployments/zkSyncNetwork/.chainId', '123456'),
+            ).to.be.eqls(true);
+        });
+
+        it('should write the deployment to a JSON file', async () => {
+            const deployment = {
+                contractName: 'MyContract',
+                sourceName: 'contracts/subFolder/MyContract.sol',
+                bytecode: '0x1234567890',
+                abi: [],
+                entries: [],
+            };
+
+            await saveDeployment(hre as any, deployment);
+
+            expect(
+                writeJsonSyncStub.calledOnceWithExactly(
+                    '/path/to/root/deployments/zkSyncNetwork/contracts/subFolder/MyContract.sol/MyContract.json',
+                    deployment,
+                    { spaces: 2 },
+                ),
+            ).to.be.equal(true);
+        });
+    });
+
+    describe('loadDeploymentEntry', () => {
+        let deployment: any;
+        let deploymentForFound: any;
+
+        beforeEach(() => {
+            providerSentStub.returns('0x1234567890');
+            deployment = {
+                entries: [
+                    {
+                        constructorArgs: [1, 2, 3],
+                        salt: 'salt1',
+                        deploymentType: 'type1',
+                        address: '0x1234567890',
+                    },
+                    {
+                        constructorArgs: [4, 5, 6],
+                        salt: 'salt2',
+                        deploymentType: 'type2',
+                        address: '0x0987654321',
+                    },
+                ],
+                bytecode: '0x1234567890',
+                contractName: 'MyContract',
+                sourceName: 'contracts/MyContract.sol',
+            };
+            deploymentForFound = {
+                constructorArgs: [1, 2, 3],
+                salt: 'salt1',
+                deploymentType: 'type1',
+            };
+        });
+
+        it('should return the deployment entry if found', async () => {
+            const entry = await loadDeploymentEntry(hre as any, deployment, deploymentForFound);
+
+            expect(entry).to.deep.equal({
+                constructorArgs: [1, 2, 3],
+                salt: 'salt1',
+                deploymentType: 'type1',
+                address: '0x1234567890',
+            });
+
+            expect(deployment.entries.length).to.have.eqls(2);
+        });
+
+        it('should return undefined if deployment entry not found', async () => {
+            deploymentForFound = {
+                constructorArgs: [7, 8, 9],
+                salt: 'salt3',
+                deploymentType: 'type3',
+            };
+
+            const entry = await loadDeploymentEntry(hre as any, deployment, deploymentForFound);
+
+            expect(entry).to.be.equal(undefined);
+        });
+
+        it('should return undefined if retrieved contract bytecode does not match deployment bytecode', async () => {
+            deployment.bytecode = '0x0987654321';
+
+            const entry = await loadDeploymentEntry(hre as any, deployment, deploymentForFound);
+
+            expect(entry).to.be.eqls(undefined);
+        });
+    });
+});

--- a/packages/hardhat-zksync-deploy/test/tests/tests.ts
+++ b/packages/hardhat-zksync-deploy/test/tests/tests.ts
@@ -3,10 +3,10 @@ import * as path from 'path';
 import { ethers } from 'ethers';
 import { Provider, Wallet } from 'zksync-ethers';
 import chalk from 'chalk';
-import { TASK_DEPLOY_ZKSYNC, TASK_DEPLOY_ZKSYNC_LIBRARIES } from '../src/task-names';
-import { Deployer } from '../src/deployer';
-import { useEnvironment } from './helpers';
-import { ETH_NETWORK_RPC_URL, ZKSYNC_NETWORK_RPC_URL, ZKSYNC_NETWORK_NAME, WALLET_PRIVATE_KEY } from './constants';
+import { TASK_DEPLOY_ZKSYNC, TASK_DEPLOY_ZKSYNC_LIBRARIES } from '../../src/task-names';
+import { Deployer } from '../../src/deployer';
+import { useEnvironment } from '../helpers';
+import { ETH_NETWORK_RPC_URL, ZKSYNC_NETWORK_RPC_URL, ZKSYNC_NETWORK_NAME, WALLET_PRIVATE_KEY } from '../constants';
 
 describe('Plugin tests', async function () {
     describe('successful-compilation artifact', function () {

--- a/packages/hardhat-zksync-deploy/test/tests/tests.ts
+++ b/packages/hardhat-zksync-deploy/test/tests/tests.ts
@@ -253,8 +253,7 @@ describe('Plugin tests', async function () {
 
         it('should deploy with integrated wallet', async function () {
             await this.env.run('compile');
-            const artifact = await this.env.deployer.loadArtifact('Greeter');
-            const contract = await this.env.deployer.deploy(artifact, ['Hi there!']);
+            const contract = await this.env.deployer.deploy('Greeter', ['Hi there!']);
             const wallet = contract.runner as Wallet;
             expect(wallet.address).to.be.equal('0x36615Cf349d7F6344891B1e7CA7C72883F5dc049');
             expect(contract).to.be.an('object');

--- a/packages/hardhat-zksync-verify/test/tests/plugin.test.ts
+++ b/packages/hardhat-zksync-verify/test/tests/plugin.test.ts
@@ -255,7 +255,7 @@ Instead, this name was received: ${contractFQN}`);
                         '*': {
                             '*': ['evm'],
                         },
-                    }
+                    },
                 },
             });
 


### PR DESCRIPTION
# What :computer: 
*  Update deploy cache logic with script load path support for windows

# Why :hand:
* Update cache logic to support different constructorArgs, salt, deployment type and to return proper contract.