### PR TITLE
fix: remove unnecessary devDependencies, remove hardhat-zksync-deploy…

### DIFF
--- a/packages/hardhat-zksync-upgradable/package.json
+++ b/packages/hardhat-zksync-upgradable/package.json
@@ -47,8 +47,6 @@
     "compare-versions": "^6.0.0"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync-deploy": "^1.2.0",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
     "@openzeppelin/contracts-upgradeable": "^4.9.2",
     "@types/fs-extra": "^11.0.1",
     "@types/node": "^18.11.17",

--- a/packages/hardhat-zksync-upgradable/src/index.ts
+++ b/packages/hardhat-zksync-upgradable/src/index.ts
@@ -1,5 +1,4 @@
 import '@matterlabs/hardhat-zksync-solc';
-import '@matterlabs/hardhat-zksync-deploy';
 import './type-extensions';
 
 import { extendEnvironment, subtask } from 'hardhat/internal/core/config/config-env';

--- a/yarn.lock
+++ b/yarn.lock
@@ -771,7 +771,7 @@
     read-yaml-file "^1.1.0"
 
 "@matterlabs/hardhat-zksync-chai-matchers@link:packages/hardhat-zksync-chai-matchers":
-  version "1.2.2"
+  version "1.3.0"
   dependencies:
     "@matterlabs/hardhat-zksync-deploy" "^1.2.0"
     "@matterlabs/hardhat-zksync-solc" "^1.1.3"
@@ -783,7 +783,7 @@
     zksync-ethers "^6.0.0"
 
 "@matterlabs/hardhat-zksync-deploy@link:packages/hardhat-zksync-deploy":
-  version "1.2.0"
+  version "1.2.1"
   dependencies:
     "@matterlabs/hardhat-zksync-solc" "^1.0.4"
     chai "^4.3.6"
@@ -791,6 +791,8 @@
     fs-extra "^11.2.0"
     glob "^10.3.10"
     lodash "^4.17.21"
+    sinon "^17.0.1"
+    sinon-chai "^3.7.0"
     ts-morph "^21.0.1"
 
 "@matterlabs/hardhat-zksync-ethers@link:packages/hardhat-zksync-ethers":
@@ -831,10 +833,10 @@
     undici "^5.14.0"
 
 "@matterlabs/hardhat-zksync-upgradable@link:packages/hardhat-zksync-upgradable":
-  version "1.2.4"
+  version "1.3.0"
   dependencies:
-    "@matterlabs/hardhat-zksync-deploy" "^1.1.0"
-    "@matterlabs/hardhat-zksync-solc" "^1.0.3"
+    "@matterlabs/hardhat-zksync-deploy" "^1.2.0"
+    "@matterlabs/hardhat-zksync-solc" "^1.1.4"
     "@openzeppelin/upgrades-core" "^1.31.3"
     chalk "4.1.2"
     compare-versions "^6.0.0"
@@ -859,11 +861,11 @@
     zksync-ethers "^6.0.0"
 
 "@matterlabs/hardhat-zksync-verify@link:packages/hardhat-zksync-verify":
-  version "1.3.0"
+  version "1.4.1"
   dependencies:
     "@ethersproject/abi" "^5.1.2"
     "@ethersproject/address" "5.7.0"
-    "@matterlabs/hardhat-zksync-solc" "^1.0.3"
+    "@matterlabs/hardhat-zksync-solc" "^1.1.4"
     "@nomicfoundation/hardhat-verify" "^2.0.0"
     "@openzeppelin/contracts" "^4.9.2"
     axios "^1.6.2"


### PR DESCRIPTION
… import from index.ts

# What :computer: 
* Remove unnecessary devDependencies, remove hardhat-zksync-deploy import from index.ts

# Why :hand:
* We need to remove duplicate dependencies in both 'dependencies' and 'devDependencies'. The import of 'hardhat-zksync-deploy' inside index.ts is unnecessary since 'hardhat-zksync-upgradable' does not override its tasks or environment configurations.