### PR TITLE
fix: remove hardhat-zksync-deploy import from index.ts

### DIFF
--- a/packages/hardhat-zksync-upgradable/src/index.ts
+++ b/packages/hardhat-zksync-upgradable/src/index.ts
@@ -1,5 +1,4 @@
 import '@matterlabs/hardhat-zksync-solc';
-import '@matterlabs/hardhat-zksync-deploy';
 import './type-extensions';
 
 import { extendEnvironment, subtask } from 'hardhat/internal/core/config/config-env';


### PR DESCRIPTION
# What :computer: 
* Remove hardhat-zksync-deploy import from index.ts

# Why :hand:
* The import of 'hardhat-zksync-deploy' inside index.ts is unnecessary since 'hardhat-zksync-upgradable' does not override its tasks or environment configurations.