### PR TITLE
fix: remove zksync-ethers dependency

### DIFF
--- a/packages/hardhat-zksync-verify-vyper/package.json
+++ b/packages/hardhat-zksync-verify-vyper/package.json
@@ -38,7 +38,6 @@
     "axios": "^1.6.2",
     "chai": "^4.3.6",
     "chalk": "4.1.2",
-    "zksync-ethers": "^6.0.0",
     "@nomiclabs/hardhat-vyper": "^3.0.5",
     "@ethersproject/abi":"^5.1.2",
     "@ethersproject/address": "5.7.0"

--- a/packages/hardhat-zksync-verify-vyper/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify-vyper/src/task-actions.ts
@@ -64,7 +64,7 @@ export async function verifyContract(
 ): Promise<number> {
     await hre.run(TASK_COMPILE_VYPER, { quiet: true });
 
-    const deployedBytecode = await retrieveContractBytecode(address, hre.network);
+    const deployedBytecode = await retrieveContractBytecode(address, hre);
 
     const artifact = await hre.run(TASK_VERIFY_GET_ARTIFACT, { contractFQN, deployedBytecode });
     const artificatBytecode = artifact.bytecode;

--- a/packages/hardhat-zksync-verify-vyper/src/utils.ts
+++ b/packages/hardhat-zksync-verify-vyper/src/utils.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import * as zk from 'zksync-ethers';
 import { ZkSyncVerifyPluginError } from './errors';
 import { WRONG_CONSTRUCTOR_ARGUMENTS } from './constants';
 
@@ -32,7 +31,8 @@ export async function encodeArguments(abi: any, constructorArgs: any[]) {
 }
 
 export async function retrieveContractBytecode(address: string, hreNetwork: any): Promise<string> {
-    const provider = new zk.Provider(hreNetwork.config.url);
+    const hre = await import('hardhat');
+    const provider = hre.network.provider;
     const bytecodeString = (await provider.send('eth_getCode', [address, 'latest'])) as string;
 
     if (bytecodeString.length === 0) {

--- a/packages/hardhat-zksync-verify-vyper/src/utils.ts
+++ b/packages/hardhat-zksync-verify-vyper/src/utils.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { ZkSyncVerifyPluginError } from './errors';
 import { WRONG_CONSTRUCTOR_ARGUMENTS } from './constants';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
 
 export function handleAxiosError(error: any): never {
     if (axios.isAxiosError(error)) {
@@ -30,15 +31,14 @@ export async function encodeArguments(abi: any, constructorArgs: any[]) {
     return deployArgumentsEncoded;
 }
 
-export async function retrieveContractBytecode(address: string, hreNetwork: any): Promise<string> {
-    const hre = await import('hardhat');
+export async function retrieveContractBytecode(address: string, hre:HardhatRuntimeEnvironment): Promise<string> {
     const provider = hre.network.provider;
     const bytecodeString = (await provider.send('eth_getCode', [address, 'latest'])) as string;
 
     if (bytecodeString.length === 0) {
         throw new ZkSyncVerifyPluginError(
             `The address ${address} has no bytecode. Is the contract deployed to this network?
-  The selected network is ${hreNetwork.name}.`
+  The selected network is ${hre.network.name}.`
         );
     }
     return bytecodeString;


### PR DESCRIPTION
# What :computer: 
Removed unnecessary dependency from the package.

# Why :hand:
The dependency is unnecessary, and its removal can reduce maintenance costs.