### PR TITLE
fix: use hardhat with caret to use single version of hardhat

### DIFF
--- a/packages/hardhat-zksync-upgradable/package.json
+++ b/packages/hardhat-zksync-upgradable/package.json
@@ -43,7 +43,7 @@
     "ethers": "~5.7.2",
     "@ethersproject/abi": "^5.1.2",
     "fs-extra": "^11.1.1",
-    "hardhat": "2.14.0",
+    "hardhat": "^2.14.0",
     "proper-lockfile": "^4.1.1",
     "solidity-ast": "npm:solidity-ast@0.4.45",
     "zksync-ethers": "^5.0.0"


### PR DESCRIPTION
# What :computer: 
* Use hardhat with caret to use single version of hardhat

# Why :hand:
* The addition of the new hardhat dependency to the project has resulted in Hardhat being unable to extend its environment.