### PR TITLE
chore: fix typos

### DIFF
--- a/examples/basic-example/contracts/003_account_abstraction/TwoUserMultisig.sol
+++ b/examples/basic-example/contracts/003_account_abstraction/TwoUserMultisig.sol
@@ -29,7 +29,7 @@ contract TwoUserMultisig is IAccount, IERC1271 {
             msg.sender == BOOTLOADER_FORMAL_ADDRESS,
             "Only bootloader can call this method"
         );
-        // Continure execution if called from the bootloader.
+        // Continue execution if called from the bootloader.
         _;
     }
 

--- a/examples/upgradable-example/README.md
+++ b/examples/upgradable-example/README.md
@@ -61,7 +61,7 @@ yarn hardhat compile
 To run a specific end-to-end script in the `scripts` folder, use the following command
 
 ```
-yarn hardhad run ./scipts/<SCRIPT_NAME>
+yarn hardhat run ./scipts/<SCRIPT_NAME>
 ```
 
 - Example: `yarn hardhat run ./scripts/deploy-box-proxy.ts`

--- a/examples/verify-example/test/tests.ts
+++ b/examples/verify-example/test/tests.ts
@@ -95,7 +95,7 @@ describe('verify plugin', async function () {
             }
         });
 
-        it('Test verification with the wrong nubmer of contructor arguments', async function () {
+        it('Test verification with the wrong numer of contructor arguments', async function () {
             try {
                 // Run the verification again on the previously verified contract
                 await this.env.run('verify:verify', {

--- a/examples/verify-example/test/tests.ts
+++ b/examples/verify-example/test/tests.ts
@@ -95,7 +95,7 @@ describe('verify plugin', async function () {
             }
         });
 
-        it('Test verification with the wrong numer of contructor arguments', async function () {
+        it('Test verification with the wrong number of contructor arguments', async function () {
             try {
                 // Run the verification again on the previously verified contract
                 await this.env.run('verify:verify', {

--- a/examples/verify-vyper-example/test/tests.ts
+++ b/examples/verify-vyper-example/test/tests.ts
@@ -22,7 +22,7 @@ describe('verify plugin', async function () {
     describe('Unknown verifyURL in config', async function () {
         useEnvironment('customNetwork');
 
-        it('Checks impoting deafault verifyURL when it does not exist in the config ', async function () {
+        it('Checks impoting default verifyURL when it does not exist in the config ', async function () {
             assert.equal(this.env.network.verifyURL, testnetVerifyURL);
         });
     });

--- a/packages/hardhat-zksync-chai-matchers/test/fixture-projects/hardhat-project/contracts/TwoUserMultisig.sol
+++ b/packages/hardhat-zksync-chai-matchers/test/fixture-projects/hardhat-project/contracts/TwoUserMultisig.sol
@@ -29,7 +29,7 @@ contract TwoUserMultisig is IAccount, IERC1271 {
             msg.sender == BOOTLOADER_FORMAL_ADDRESS,
             "Only bootloader can call this method"
         );
-        // Continure execution if called from the bootloader.
+        // Continue execution if called from the bootloader.
         _;
     }
 

--- a/packages/hardhat-zksync-deploy/README.md
+++ b/packages/hardhat-zksync-deploy/README.md
@@ -207,7 +207,7 @@ Methods available for use in `hre.deployer` are the same as those available in t
 ```
 - `async getWallet(privateKeyOrAccountNumber?: string | number): Promise<zk.Wallet>`
 
-### Tranistion from `Deployer` object to the `hre.deployer`
+### Transition from `Deployer` object to the `hre.deployer`
 
 The deployment logic remains the same, but instead of instantiating a `Deployer` class, you directly access the deployer object provided by `hre.deployer`. This simplifies the deployment process and enhances the developer experience.
 
@@ -258,7 +258,7 @@ const config: HardhatUserConfig = {
       ethNetwork: "sepolia", // The Ethereum Web3 RPC URL, or the identifier of the network (e.g. `mainnet` or `sepolia`)
       zksync: true,
       // ADDITON
-      forceDeploy: true // Specify is deploy proccess will use cache mechanism or it will force deploy of the contracts
+      forceDeploy: true // Specify is deploy process will use cache mechanism or it will force deploy of the contracts
     }
   },
 }
@@ -388,8 +388,8 @@ The default value for **tags** is `default`, and the default value for **priorit
 ## 📖 Example
 
 Note:
-- **hre** - hardhat runtime enviroment
-- **zkWallet** - instace of Wallet using [zksync-ethers](https://www.npmjs.com/package/zksync-ethers) SDK 
+- **hre** - hardhat runtime environment
+- **zkWallet** - instance of Wallet using [zksync-ethers](https://www.npmjs.com/package/zksync-ethers) SDK 
 
 ### Deployer class usage
 

--- a/packages/hardhat-zksync-deploy/src/utils.ts
+++ b/packages/hardhat-zksync-deploy/src/utils.ts
@@ -67,7 +67,7 @@ export function getLibraryInfos(hre: HardhatRuntimeEnvironment): MissingLibrary[
     const libraryPathFile = hre.config.zksolc.settings.missingLibrariesPath!;
 
     if (!fs.existsSync(libraryPathFile)) {
-        throw new ZkSyncDeployPluginError('Missing librararies file not found');
+        throw new ZkSyncDeployPluginError('Missing libraries file not found');
     }
 
     return JSON.parse(fs.readFileSync(libraryPathFile, 'utf8'));

--- a/packages/hardhat-zksync-verify-vyper/test/tests.ts
+++ b/packages/hardhat-zksync-verify-vyper/test/tests.ts
@@ -166,7 +166,7 @@ describe('verify plugin', async function () {
             }
         });
 
-        it('Fails to encode because missmatch in length', async function () {
+        it('Fails to encode because mismatch in length', async function () {
             try {
                 const artifact = await this.env.run(TASK_VERIFY_GET_ARTIFACT, { contractFQN, deployedBytecode });
                 await getDeployArgumentEncoded([], artifact);


### PR DESCRIPTION
1. Fix `examples/basic-example/contracts/003_account_abstraction/TwoUserMultisig.sol`   typo
2. Fix `examples/upgradable-example/README.md`   typo
3. Fix `examples/verify-example/test/tests.ts`   typo
4. Fix `examples/verify-vyper-example/test/tests.ts`   typo
5. Fix `packages/hardhat-zksync-chai-matchers/test/fixture-projects/hardhat-project/contracts/TwoUserMultisig.sol`   typo
6. Fix `packages/hardhat-zksync-deploy/README.md`   typo
7. Fix `packages/hardhat-zksync-deploy/src/utils.ts`   typo
8. Fix `packages/hardhat-zksync-verify-vyper/test/tests.ts`   typo