### PR TITLE
fix: properly construct fork arguments

### DIFF
--- a/packages/hardhat-zksync-node/src/utils.ts
+++ b/packages/hardhat-zksync-node/src/utils.ts
@@ -119,11 +119,11 @@ export function constructCommandArgs(args: CommandArguments): string[] {
         }
 
         if (args.forkBlockNumber) {
-            commandArgs.push(`fork --fork-at ${args.forkBlockNumber} ${args.fork}`);
+            commandArgs.push('fork', args.fork, '--fork-at', args.forkBlockNumber.toString());
         } else if (args.replayTx) {
-            commandArgs.push(`replay_tx ${args.fork} ${args.replayTx}`);
+            commandArgs.push('replay_tx', args.fork, '--tx', args.replayTx);
         } else {
-            commandArgs.push(`fork ${args.fork}`);
+            commandArgs.push('fork', args.fork);
         }
     } else {
         commandArgs.push('run');

--- a/packages/hardhat-zksync-node/test/tests.ts
+++ b/packages/hardhat-zksync-node/test/tests.ts
@@ -184,7 +184,10 @@ describe('node-zksync plugin', async function () {
                     '--show-calls=user',
                     '--resolve-hashes',
                     '--dev-use-local-contracts',
-                    'fork --fork-at 100 mainnet',
+                    'fork',
+                    'mainnet',
+                    '--fork-at',
+                    '100',
                 ]);
             });
 
@@ -210,7 +213,7 @@ describe('node-zksync plugin', async function () {
             it('should correctly construct command arguments with fork and replayTx', async function () {
                 const args = { fork: 'http://example.com', replayTx: '0x1234567890abcdef' };
                 const result = constructCommandArgs(args);
-                expect(result).to.deep.equal(['replay_tx http://example.com 0x1234567890abcdef']);
+                expect(result).to.deep.equal(['replay_tx', 'http://example.com', '--tx', '0x1234567890abcdef']);
             });
 
             it('should throw error for invalid fork URL pattern', () => {


### PR DESCRIPTION
# What :computer: 
Properly construct fork arguments when running node.

# Why :hand:
In order to make forking of the supported chains at specific block.