### PR TITLE
feat: introducing a new upgradable tasks to run via ci command

### DIFF
--- a/packages/hardhat-zksync-deploy/README.md
+++ b/packages/hardhat-zksync-deploy/README.md
@@ -466,11 +466,12 @@ To run a specific script, add the `--script` argument, e.g. `yarn hardhat deploy
 
 To run a scripts with specific tags add the `--tags` argument, e.g `yarn hardhat deploy-zksync --tags all`. Run all scripts with tag `all`.
 
-`yarn hardhat deploy-zksync:libraries --private-key-or-index <PRIVATE_KEY_OR_INDEX>` -- compilation and deployment of missing libraries (the list of all missing libraries is provided by the output of [matterlabs/hardhat-zksync-solc](https://www.npmjs.com/package/@matterlabs/hardhat-zksync-solc) plugin). Read more about how zkSync deals with libraries on this [link](https://era.zksync.io/docs/tools/hardhat/compiling-libraries.html).
+`yarn hardhat deploy-zksync:libraries` -- compilation and deployment of missing libraries (the list of all missing libraries is provided by the output of [matterlabs/hardhat-zksync-solc](https://www.npmjs.com/package/@matterlabs/hardhat-zksync-solc) plugin). Read more about how zkSync deals with libraries on this [link](https://era.zksync.io/docs/tools/hardhat/compiling-libraries.html).
+The account used for deployment will be the one specified by the `deployerAccount` configuration within the `hardhat.config.ts` file. If no such configuration is present, the account with index `0` will be used.
 
 `yarn hardhat deploy-zksync:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--no-compile]`
 
-When executed, this command deploys the provided contract on the specified network, using the provided contract constructor arguments. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+When executed, this command deploys the provided contract on the specified network, using the provided contract constructor arguments. Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
 
 ## 📝 Documentation
 

--- a/packages/hardhat-zksync-deploy/README.md
+++ b/packages/hardhat-zksync-deploy/README.md
@@ -90,7 +90,7 @@ It's main methods are:
    * Sends a deploy transaction to the zkSync network.
    * For now it uses defaults values for the transaction parameters:
    *
-   * @param artifact The previously loaded artifact object.
+   * @param contractNameOrArtifact The previously loaded artifact object, or contract name that will be resolved to artifact in the background.
    * @param constructorArguments The list of arguments to be passed to the contract constructor.
    * @param overrides Optional object with additional deploy transaction parameters.
    * @param additionalFactoryDeps Additional contract bytecodes to be added to the factory dependencies list.
@@ -98,7 +98,7 @@ It's main methods are:
    *
    * @returns A contract object.
 ```
- - `public async deploy(artifact: ZkSyncArtifact, constructorArguments: any[], overrides?: OverridesAdditionalFactoryDeps?: ethers.BytesLike[],): Promise<zk.Contract>`
+ - `public async deploy(contractNameOrArtifact: ZkSyncArtifact | string, constructorArguments: any[], overrides?: OverridesAdditionalFactoryDeps?: ethers.BytesLike[],): Promise<zk.Contract>`
 
 ```
    * Extracts factory dependencies from the artifact.
@@ -108,6 +108,19 @@ It's main methods are:
    * @returns Factory dependencies in the format expected by SDK.
 ```
  - `async extractFactoryDeps(artifact: ZkSyncArtifact): Promise<string[]>`
+
+ In the method description, it's evident that `contractNameOrArtifact` can accept two types of objects. One type represents a loaded artifact, while the other type is a string representing a contract name, which the deploy method will internally convert to the corresponding artifact.
+
+ ```
+const wallet = new zk.Wallet("PRIVATE_KEY");
+const deployer = new Deployer(hre, zkWallet);
+............
+// Provided previously loaded artifact
+const artifact = await deployer.loadArtifact("ContractName");
+const contract = await deployer.deploy(artifact);
+// Provided contract name
+const contract = await deployer.deploy("ContractName");
+ ```
 
  ## Environment extensions
 
@@ -242,8 +255,7 @@ const contract = await hre.deployer.deploy(artifact, []);
 
 ## Caching mechanism
 
-The `hardhat-zksync-deploy` plugin supports a caching mechanism for contracts deployed on the same network, and by default, this feature is enabled for every deployment with specific network unless specified otherwise.
-For each deployment within your project, a new `deployments` folder is created. Inside this folder, you can find subfolders for each network specified in the `hardhat.config.ts` file. Each network folder contains JSON files named after deployed contracts where caching purposes information are stored, and additionally, a `.chainId` file contains the chainId specific to that network.
+The `hardhat-zksync-deploy` plugin supports a caching mechanism for contracts deployed on the same network, and by default, this feature is enabled for every deployment with specific network unless specified otherwise. For each deployment within your project, a new `deployments-zk` folder is created. Inside this folder, you can find subfolders for each network specified in the `hardhat.config.ts` file. Each network folder contains JSON files named after deployed contracts where caching purposes information are stored, and additionally, a `.chainId` file contains the chainId specific to that network.
 
 To explicitly use a cache mechanism or force deploy for a specific network in your `hardhat.config.ts` file, you would indeed need to set the `forceDeploy` flag for that network in the networks section.
 
@@ -268,6 +280,7 @@ const config: HardhatUserConfig = {
 If the `forceDeploy` flag is set to `true` for a specific network in your `hardhat.config.ts` file, it indicates that the deployment process will force deploy contracts to that network, bypassing any cache mechanism.
 
 Conversely, if the `forceDeploy` flag is set to `false` or not specified for a network, `hardhat-zksync-deploy` will use caching mechanism during deployment. This means it will check whether the contracts have changed since the last deployment, and if not, it will reuse the already deployed contracts instead of redeploying them.
+If a `forceDeploy` isn't explicitly defined, it automatically defaults to `true`.
 
 ## Scripts configuration
 

--- a/packages/hardhat-zksync-upgradable/README.md
+++ b/packages/hardhat-zksync-upgradable/README.md
@@ -110,27 +110,58 @@ If you want to get the estimation for the beacon proxy contract, please use the 
 
 `const totalGasEstimation = await hre.zkUpgrades.estimation.estimateGasBeacon(deployer, contract, []);`
 
-## 🕹 Commands
+## 🕹 Shortcuts commands
+
+### 📥 Configuration
+To extend the configuration to support commands, we need to add an accounts field to the specific network configuration in the networks section of the hardhat.config.ts file. This accounts field can support an array of private keys or a mnemonic object and represents accounts that will be used as wallet automaticlly.
+
+```
+const config: HardhatUserConfig = {
+  networks: {
+    sepolia: {
+      url: "https://sepolia.infura.io/v3/<API_KEY>" // The Ethereum Web3 RPC URL (optional).
+    },
+    zkTestnet: {
+      url: "https://sepolia.era.zksync.dev", // The testnet RPC URL of zkSync Era network.
+      ethNetwork: "sepolia", // The Ethereum Web3 RPC URL, or the identifier of the network (e.g. `mainnet` or `sepolia`)
+      zksync: true,
+      // ADDITON
+      accounts: ['0xac1e735be8536c6534bb4f17f06f6afc73b2b5ba84ac2cfb12f7461b20c0bbe3', '0x28a574ab2de8a00364d5dd4b07c4f2f574ef7fcc2a86a197f65abaec836d1959'], // The private keys for the accounts used in the deployment or in the upgradation process.
+      accounts: {
+          mnemonic: 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle'
+      }
+      // Mnemonic used in the deployment or in the upgradation process
+    }
+  },
+};
+```
+- accounts represents a list of the private keys or mnemonic object for the account used in the deployment or in the upgradation process.
+
+accounts object will be automaticly be populated with rich accounts if used network is zkSync Era Test Node or zksync-cli Local Node
+
+### 🕹 Commands
 
 `yarn hardhat deploy-beacon:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--no-compile]`
 
-When executed, this command deploys the provided implementation, beacon and proxy on the specified network, using the provided contract constructor arguments. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+When executed, this command deploys the provided implementation, beacon and proxy on the specified network, using the provided contract constructor arguments. Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
 
-`yarn hardhat deploy-proxy:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--no-compile]`
+`yarn hardhat deploy-proxy:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--initializer <initialize method>] [--no-compile]`
 
 When executed, this command will automatically determine whether the deployment is for a Transparent or UUps proxy. 
 If the Transparent proxy is chosen, it will deploy implementation, admin, and proxy. 
-If the UUps proxy is chosen, it will deploy implementation and proxy. Optionally, the no-compile parameter allows the task to skip the compilation process.
+If the Uups proxy is chosen, it will deploy implementation and proxy.
+The initializer method name can optionally be specified using `--initializer <initializer method name>`, with the default method name being set to initialize.
+The `--no-compile` parameter allows the task to skip the compilation process.
 
 `yarn hardhat upgrade-beacon:oneline --contract-name <contract name or fully qualified name> --beacon-address <beacon address> [--no-compile]`
 
-When executed, this command upgrade beacon implementation. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+When executed, this command upgrade beacon implementation. Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
 
 `yarn hardhat upgrade-proxy:oneline --contract-name <contract name or fully qualified name> --proxy-address <proxy address> [--no-compile]`
 
-When executed, this command upgrade uups or transparent implementation. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+When executed, this command upgrade uups or transparent implementation. Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
 
-Please consider that while the provided CLI commands enable contract deployment and upgrading, not all arguments may be available (e.g. initializer or kind propery). If these commands lack the required functionality, it may be necessary to utilize scripting for a more comprehensive approach.
+Please consider that while the provided CLI commands enable contract deployment and upgrading, not all arguments may be available. If these commands lack the required functionality, it may be necessary to utilize scripting for a more comprehensive approach.
 
 ## 📝 Documentation
 

--- a/packages/hardhat-zksync-upgradable/README.md
+++ b/packages/hardhat-zksync-upgradable/README.md
@@ -110,6 +110,28 @@ If you want to get the estimation for the beacon proxy contract, please use the 
 
 `const totalGasEstimation = await hre.zkUpgrades.estimation.estimateGasBeacon(deployer, contract, []);`
 
+## 🕹 Commands
+
+`yarn hardhat deploy-beacon:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--no-compile]`
+
+When executed, this command deploys the provided implementation, beacon and proxy on the specified network, using the provided contract constructor arguments. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+
+`yarn hardhat deploy-proxy:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--no-compile]`
+
+When executed, this command will automatically determine whether the deployment is for a Transparent or UUps proxy. 
+If the Transparent proxy is chosen, it will deploy implementation, admin, and proxy. 
+If the UUps proxy is chosen, it will deploy implementation and proxy. Optionally, the no-compile parameter allows the task to skip the compilation process.
+
+`yarn hardhat upgrade-beacon:oneline --contract-name <contract name or fully qualified name> --beacon-address <beacon address> [--no-compile]`
+
+When executed, this command upgrade beacon implementation. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+
+`yarn hardhat upgrade-proxy:oneline --contract-name <contract name or fully qualified name> --proxy-address <proxy address> [--no-compile]`
+
+When executed, this command upgrade uups or transparent implementation. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+
+Please consider that while the provided CLI commands enable contract deployment and upgrading, not all arguments may be available (e.g. initializer or kind propery). If these commands lack the required functionality, it may be necessary to utilize scripting for a more comprehensive approach.
+
 ## 📝 Documentation
 
 In addition to the [hardhat-zksync-upgradable](https://era.zksync.io/docs/tools/hardhat/hardhat-zksync-upgradable.html), zkSync's Era [website](https://era.zksync.io/docs/) offers a variety of resources including:

--- a/packages/hardhat-zksync-upgradable/README.md
+++ b/packages/hardhat-zksync-upgradable/README.md
@@ -143,23 +143,26 @@ accounts object will be automaticly be populated with rich accounts if used netw
 
 `yarn hardhat deploy-beacon:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--no-compile]`
 
-When executed, this command deploys the provided implementation, beacon and proxy on the specified network, using the provided contract constructor arguments. Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
+When executed, this command deploys the provided implementation, beacon and proxy on the specified network, using the provided contract constructor arguments. 
+Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
 
 `yarn hardhat deploy-proxy:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--initializer <initialize method>] [--no-compile]`
 
-When executed, this command will automatically determine whether the deployment is for a Transparent or UUps proxy. 
+When executed, this command will automatically determine whether the deployment is for a Transparent or Uups proxy. 
 If the Transparent proxy is chosen, it will deploy implementation, admin, and proxy. 
 If the Uups proxy is chosen, it will deploy implementation and proxy.
-The initializer method name can optionally be specified using `--initializer <initializer method name>`, with the default method name being set to initialize.
+The initializer method name can optionally be specified using `--initializer <initializer method name>`, with the default method name being set to `initialize`.
 The `--no-compile` parameter allows the task to skip the compilation process.
 
 `yarn hardhat upgrade-beacon:oneline --contract-name <contract name or fully qualified name> --beacon-address <beacon address> [--no-compile]`
 
-When executed, this command upgrade beacon implementation. Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
+When executed, this command upgrade beacon implementation. 
+Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
 
 `yarn hardhat upgrade-proxy:oneline --contract-name <contract name or fully qualified name> --proxy-address <proxy address> [--no-compile]`
 
-When executed, this command upgrade uups or transparent implementation. Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
+When executed, this command upgrade Uups or Transparent implementation. 
+Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
 
 Please consider that while the provided CLI commands enable contract deployment and upgrading, not all arguments may be available. If these commands lack the required functionality, it may be necessary to utilize scripting for a more comprehensive approach.
 

--- a/packages/hardhat-zksync-upgradable/src/index.ts
+++ b/packages/hardhat-zksync-upgradable/src/index.ts
@@ -94,6 +94,7 @@ task(TASK_DEPLOY_PROXY_ONELINE, 'Deploy proxy for zkSync network')
         undefined,
         types.inputFile,
     )
+    .addOptionalParam('initializer', 'Initializer function name', undefined)
     .addFlag('noCompile', 'No compile flag')
     .setAction(deployProxyZkSyncWithOneLine);
 

--- a/packages/hardhat-zksync-upgradable/src/index.ts
+++ b/packages/hardhat-zksync-upgradable/src/index.ts
@@ -1,7 +1,7 @@
 import '@matterlabs/hardhat-zksync-solc';
 import './type-extensions';
 
-import { extendEnvironment, subtask } from 'hardhat/internal/core/config/config-env';
+import { extendEnvironment, subtask, task, types } from 'hardhat/internal/core/config/config-env';
 
 import {
     TASK_COMPILE_SOLIDITY_COMPILE,
@@ -9,14 +9,28 @@ import {
 } from 'hardhat/builtin-tasks/task-names';
 
 import { lazyObject } from 'hardhat/plugins';
+import { createProviders } from '@matterlabs/hardhat-zksync-deploy/src/deployer-helper';
+import { getWallet } from '@matterlabs/hardhat-zksync-deploy/src/plugin';
 import { HardhatUpgrades, RunCompilerArgs } from './interfaces';
 import { extendCompilerOutputSelection, isFullZkSolcOutput } from './utils/utils-general';
 import { validate } from './core/validate';
-import { PROXY_SOURCE_NAMES } from './constants';
 import { makeChangeProxyAdmin, makeGetInstanceFunction, makeTransferProxyAdminOwnership } from './admin';
+import {
+    TASK_DEPLOY_BEACON_ONELINE,
+    TASK_DEPLOY_PROXY_ONELINE,
+    TASK_UPGRADE_BEACON_ONELINE,
+    TASK_UPGRADE_PROXY_ONELINE,
+} from './task-names';
+import {
+    deployBeaconZkSyncWithOneLine,
+    deployProxyZkSyncWithOneLine,
+    upgradeBeaconZkSyncWithOneLine,
+    upgradeProxyZkSyncWithOneLine,
+} from './task-actions';
 
 extendEnvironment((hre) => {
     hre.zkUpgrades = lazyObject((): HardhatUpgrades => {
+        const { ethWeb3Provider, zkWeb3Provider } = createProviders(hre.config.networks, hre.network);
         const { makeDeployProxy } = require('./proxy-deployment/deploy-proxy');
         const { makeUpgradeProxy } = require('./proxy-upgrade/upgrade-proxy');
         const { makeValidateImplementation } = require('./validations/validate-implementation');
@@ -28,6 +42,9 @@ extendEnvironment((hre) => {
         const { makeEstimateGasBeacon } = require('./gas-estimation/estimate-gas-beacon');
         const { makeEstimateGasBeaconProxy } = require('./gas-estimation/estimate-gas-beacon-proxy');
         return {
+            providerL1: ethWeb3Provider,
+            providerL2: zkWeb3Provider,
+            getWallet: (privateKeyOrIndex?: string | number) => getWallet(hre, privateKeyOrIndex),
             deployProxy: makeDeployProxy(hre),
             upgradeProxy: makeUpgradeProxy(hre),
             validateImplementation: makeValidateImplementation(hre),
@@ -53,6 +70,50 @@ extendEnvironment((hre) => {
     });
 });
 
+task(TASK_DEPLOY_BEACON_ONELINE, 'Runs the beaccon deploy for zkSync network')
+    .addParam('contractName', 'A contract name or a full quilify name', '')
+    .addOptionalVariadicPositionalParam(
+        'constructorArgsParams',
+        'Contract constructor arguments. Cannot be used if the --constructor-args option is provided',
+        [],
+    )
+    .addOptionalParam(
+        'constructorArgs',
+        'Path to a Javascript module that exports the constructor arguments',
+        undefined,
+        types.inputFile,
+    )
+    .addFlag('noCompile', 'No compile flag')
+    .setAction(deployBeaconZkSyncWithOneLine);
+
+task(TASK_DEPLOY_PROXY_ONELINE, 'Deploy proxy for zkSync network')
+    .addParam('contractName', 'A contract name or a full quilify name', '')
+    .addOptionalVariadicPositionalParam(
+        'constructorArgsParams',
+        'Contract constructor arguments. Cannot be used if the --constructor-args option is provided',
+        [],
+    )
+    .addOptionalParam(
+        'constructorArgs',
+        'Path to a Javascript module that exports the constructor arguments',
+        undefined,
+        types.inputFile,
+    )
+    .addFlag('noCompile', 'No compile flag')
+    .setAction(deployProxyZkSyncWithOneLine);
+
+task(TASK_UPGRADE_BEACON_ONELINE, 'Runs the beacon upgrade for zkSync network')
+    .addParam('contractName', 'A contract name or a full quilify name', '')
+    .addParam('beaconAddress', 'Beacon address of the deployed contract', '')
+    .addFlag('noCompile', 'No compile flag')
+    .setAction(upgradeBeaconZkSyncWithOneLine);
+
+task(TASK_UPGRADE_PROXY_ONELINE, 'Runs the proxy upgrade for zkSync network')
+    .addParam('contractName', 'A contract name or a full quilify name', '')
+    .addParam('proxyAddress', 'Proxy address of the deployed contract', '')
+    .addFlag('noCompile', 'No compile flag')
+    .setAction(upgradeProxyZkSyncWithOneLine);
+
 subtask(TASK_COMPILE_SOLIDITY_COMPILE, async (args: RunCompilerArgs, hre, runSuper) => {
     const { solcInputOutputDecoder } = await import('@openzeppelin/upgrades-core');
     const { writeValidations } = await import('./validations/validations');
@@ -70,8 +131,8 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE, async (args: RunCompilerArgs, hre, runSup
 
 subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES, async (args: RunCompilerArgs, _, runSuper) => {
     const sourceNames = await runSuper();
-
-    return [...sourceNames, ...PROXY_SOURCE_NAMES];
+    return sourceNames;
+    // return [...sourceNames, ...PROXY_SOURCE_NAMES];
 });
 
 subtask('verify:verify').setAction(async (args, hre, runSuper) => {

--- a/packages/hardhat-zksync-upgradable/src/index.ts
+++ b/packages/hardhat-zksync-upgradable/src/index.ts
@@ -9,8 +9,6 @@ import {
 } from 'hardhat/builtin-tasks/task-names';
 
 import { lazyObject } from 'hardhat/plugins';
-import { createProviders } from '@matterlabs/hardhat-zksync-deploy/src/deployer-helper';
-import { getWallet } from '@matterlabs/hardhat-zksync-deploy/src/plugin';
 import { HardhatUpgrades, RunCompilerArgs } from './interfaces';
 import { extendCompilerOutputSelection, isFullZkSolcOutput } from './utils/utils-general';
 import { validate } from './core/validate';
@@ -27,10 +25,10 @@ import {
     upgradeBeaconZkSyncWithOneLine,
     upgradeProxyZkSyncWithOneLine,
 } from './task-actions';
+import { PROXY_SOURCE_NAMES } from './constants';
 
 extendEnvironment((hre) => {
     hre.zkUpgrades = lazyObject((): HardhatUpgrades => {
-        const { ethWeb3Provider, zkWeb3Provider } = createProviders(hre.config.networks, hre.network);
         const { makeDeployProxy } = require('./proxy-deployment/deploy-proxy');
         const { makeUpgradeProxy } = require('./proxy-upgrade/upgrade-proxy');
         const { makeValidateImplementation } = require('./validations/validate-implementation');
@@ -42,9 +40,6 @@ extendEnvironment((hre) => {
         const { makeEstimateGasBeacon } = require('./gas-estimation/estimate-gas-beacon');
         const { makeEstimateGasBeaconProxy } = require('./gas-estimation/estimate-gas-beacon-proxy');
         return {
-            providerL1: ethWeb3Provider,
-            providerL2: zkWeb3Provider,
-            getWallet: (privateKeyOrIndex?: string | number) => getWallet(hre, privateKeyOrIndex),
             deployProxy: makeDeployProxy(hre),
             upgradeProxy: makeUpgradeProxy(hre),
             validateImplementation: makeValidateImplementation(hre),
@@ -131,8 +126,7 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE, async (args: RunCompilerArgs, hre, runSup
 
 subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES, async (args: RunCompilerArgs, _, runSuper) => {
     const sourceNames = await runSuper();
-    return sourceNames;
-    // return [...sourceNames, ...PROXY_SOURCE_NAMES];
+    return [...sourceNames, ...PROXY_SOURCE_NAMES];
 });
 
 subtask('verify:verify').setAction(async (args, hre, runSuper) => {

--- a/packages/hardhat-zksync-upgradable/src/interfaces.ts
+++ b/packages/hardhat-zksync-upgradable/src/interfaces.ts
@@ -2,7 +2,6 @@ import { SolcInput, SolcOutput } from '@openzeppelin/upgrades-core';
 
 import * as zk from 'zksync-ethers';
 
-import { ethers } from 'ethers';
 import { DeployAdminFunction } from './proxy-deployment/deploy-proxy-admin';
 import { UpgradeFunction } from './proxy-upgrade/upgrade-proxy';
 import { DeployBeaconFunction } from './proxy-deployment/deploy-beacon';
@@ -20,9 +19,6 @@ export type ValidateImplementationFunction = (
 ) => Promise<void>;
 
 export interface HardhatUpgrades {
-    providerL1: ethers.Provider;
-    providerL2: zk.Provider;
-    getWallet: () => Promise<zk.Wallet>;
     deployProxy: DeployFunction;
     upgradeProxy: UpgradeFunction;
     validateImplementation: ValidateImplementationFunction;

--- a/packages/hardhat-zksync-upgradable/src/interfaces.ts
+++ b/packages/hardhat-zksync-upgradable/src/interfaces.ts
@@ -2,6 +2,7 @@ import { SolcInput, SolcOutput } from '@openzeppelin/upgrades-core';
 
 import * as zk from 'zksync-ethers';
 
+import { ethers } from 'ethers';
 import { DeployAdminFunction } from './proxy-deployment/deploy-proxy-admin';
 import { UpgradeFunction } from './proxy-upgrade/upgrade-proxy';
 import { DeployBeaconFunction } from './proxy-deployment/deploy-beacon';
@@ -19,6 +20,9 @@ export type ValidateImplementationFunction = (
 ) => Promise<void>;
 
 export interface HardhatUpgrades {
+    providerL1: ethers.Provider;
+    providerL2: zk.Provider;
+    getWallet: () => Promise<zk.Wallet>;
     deployProxy: DeployFunction;
     upgradeProxy: UpgradeFunction;
     validateImplementation: ValidateImplementationFunction;

--- a/packages/hardhat-zksync-upgradable/src/plugin.ts
+++ b/packages/hardhat-zksync-upgradable/src/plugin.ts
@@ -1,0 +1,132 @@
+import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
+import { getConstructorArguments } from '@matterlabs/hardhat-zksync-deploy/src/utils';
+import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names';
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { Contract } from 'zksync-ethers';
+
+export async function deployBeaconWithOneLine(
+    hre: HardhatRuntimeEnvironment,
+    taskArgs: {
+        contractName: string;
+        constructorArgsParams: any[];
+        constructorArgs?: string;
+        noCompile?: boolean;
+    },
+): Promise<{
+    proxy: Contract;
+    beacon: Contract;
+}> {
+    if (!taskArgs.noCompile) {
+        await hre.run(TASK_COMPILE);
+    }
+
+    const constructorArguments: any[] = await getConstructorArguments(
+        taskArgs.constructorArgsParams,
+        taskArgs.constructorArgs,
+    );
+
+    const wallet = (await hre.zkUpgrades.getWallet())
+        .connect(hre.zkUpgrades.providerL2)
+        .connectToL1(hre.zkUpgrades.providerL1);
+
+    const deployer = new Deployer(hre, wallet);
+
+    const contract = await deployer.loadArtifact(taskArgs.contractName);
+    const beacon = await hre.zkUpgrades.deployBeacon(wallet, contract);
+    await beacon.waitForDeployment();
+
+    const proxy = await hre.zkUpgrades.deployBeaconProxy(
+        deployer.zkWallet,
+        await beacon.getAddress(),
+        contract,
+        constructorArguments,
+    );
+    await proxy.waitForDeployment();
+
+    return {
+        proxy,
+        beacon,
+    };
+}
+
+export async function deployProxyWithOneLine(
+    hre: HardhatRuntimeEnvironment,
+    taskArgs: {
+        contractName: string;
+        constructorArgsParams: any[];
+        constructorArgs?: string;
+        noCompile?: boolean;
+    },
+): Promise<Contract> {
+    if (!taskArgs.noCompile) {
+        await hre.run(TASK_COMPILE);
+    }
+
+    const constructorArguments: any[] = await getConstructorArguments(
+        taskArgs.constructorArgsParams,
+        taskArgs.constructorArgs,
+    );
+
+    const wallet = (await hre.zkUpgrades.getWallet())
+        .connect(hre.zkUpgrades.providerL2)
+        .connectToL1(hre.zkUpgrades.providerL1);
+
+    const deployer = new Deployer(hre, wallet);
+
+    const contract = await deployer.loadArtifact(taskArgs.contractName);
+
+    const proxy = await hre.zkUpgrades.deployProxy(wallet, contract, constructorArguments);
+    await proxy.waitForDeployment();
+
+    return proxy;
+}
+
+export async function upgradeBeaconWithOneLine(
+    hre: HardhatRuntimeEnvironment,
+    taskArgs: {
+        contractName: string;
+        beaconAddress: string;
+        noCompile?: boolean;
+    },
+): Promise<Contract> {
+    if (!taskArgs.noCompile) {
+        await hre.run(TASK_COMPILE);
+    }
+
+    const wallet = (await hre.zkUpgrades.getWallet())
+        .connect(hre.zkUpgrades.providerL2)
+        .connectToL1(hre.zkUpgrades.providerL1);
+
+    const deployer = new Deployer(hre, wallet);
+
+    const contractV2 = await deployer.loadArtifact(taskArgs.contractName);
+    const beaconUpgrade = await hre.zkUpgrades.upgradeBeacon(wallet, taskArgs.beaconAddress, contractV2);
+    await beaconUpgrade.waitForDeployment();
+
+    return beaconUpgrade;
+}
+
+export async function upgradeProxyWithOneLine(
+    hre: HardhatRuntimeEnvironment,
+    taskArgs: {
+        contractName: string;
+        proxyAddress: string;
+        noCompile?: boolean;
+    },
+): Promise<Contract> {
+    if (!taskArgs.noCompile) {
+        await hre.run(TASK_COMPILE);
+    }
+
+    const wallet = (await hre.zkUpgrades.getWallet())
+        .connect(hre.zkUpgrades.providerL2)
+        .connectToL1(hre.zkUpgrades.providerL1);
+
+    const deployer = new Deployer(hre, wallet);
+
+    const contractV2 = await deployer.loadArtifact(taskArgs.contractName);
+    const proxyUpgrade = await hre.zkUpgrades.upgradeProxy(wallet, taskArgs.proxyAddress, contractV2);
+    await proxyUpgrade.waitForDeployment();
+
+    return proxyUpgrade;
+}

--- a/packages/hardhat-zksync-upgradable/src/plugin.ts
+++ b/packages/hardhat-zksync-upgradable/src/plugin.ts
@@ -3,6 +3,7 @@ import { getConstructorArguments } from '@matterlabs/hardhat-zksync-deploy/src/u
 import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { Contract } from 'zksync-ethers';
+import { getWallet } from './utils';
 
 export async function deployBeaconWithOneLine(
     hre: HardhatRuntimeEnvironment,
@@ -25,10 +26,7 @@ export async function deployBeaconWithOneLine(
         taskArgs.constructorArgs,
     );
 
-    const wallet = (await hre.zkUpgrades.getWallet())
-        .connect(hre.zkUpgrades.providerL2)
-        .connectToL1(hre.zkUpgrades.providerL1);
-
+    const wallet = await getWallet(hre);
     const deployer = new Deployer(hre, wallet);
 
     const contract = await deployer.loadArtifact(taskArgs.contractName);
@@ -67,14 +65,10 @@ export async function deployProxyWithOneLine(
         taskArgs.constructorArgs,
     );
 
-    const wallet = (await hre.zkUpgrades.getWallet())
-        .connect(hre.zkUpgrades.providerL2)
-        .connectToL1(hre.zkUpgrades.providerL1);
-
+    const wallet = await getWallet(hre);
     const deployer = new Deployer(hre, wallet);
 
     const contract = await deployer.loadArtifact(taskArgs.contractName);
-
     const proxy = await hre.zkUpgrades.deployProxy(wallet, contract, constructorArguments);
     await proxy.waitForDeployment();
 
@@ -93,10 +87,7 @@ export async function upgradeBeaconWithOneLine(
         await hre.run(TASK_COMPILE);
     }
 
-    const wallet = (await hre.zkUpgrades.getWallet())
-        .connect(hre.zkUpgrades.providerL2)
-        .connectToL1(hre.zkUpgrades.providerL1);
-
+    const wallet = await getWallet(hre);
     const deployer = new Deployer(hre, wallet);
 
     const contractV2 = await deployer.loadArtifact(taskArgs.contractName);
@@ -118,10 +109,7 @@ export async function upgradeProxyWithOneLine(
         await hre.run(TASK_COMPILE);
     }
 
-    const wallet = (await hre.zkUpgrades.getWallet())
-        .connect(hre.zkUpgrades.providerL2)
-        .connectToL1(hre.zkUpgrades.providerL1);
-
+    const wallet = await getWallet(hre);
     const deployer = new Deployer(hre, wallet);
 
     const contractV2 = await deployer.loadArtifact(taskArgs.contractName);

--- a/packages/hardhat-zksync-upgradable/src/plugin.ts
+++ b/packages/hardhat-zksync-upgradable/src/plugin.ts
@@ -1,4 +1,4 @@
-import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
+import { Deployer } from '@matterlabs/hardhat-zksync-deploy/src/deployer';
 import { getConstructorArguments } from '@matterlabs/hardhat-zksync-deploy/src/utils';
 import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';

--- a/packages/hardhat-zksync-upgradable/src/plugin.ts
+++ b/packages/hardhat-zksync-upgradable/src/plugin.ts
@@ -1,5 +1,5 @@
-import { Deployer } from '@matterlabs/hardhat-zksync-deploy/src/deployer';
-import { getConstructorArguments } from '@matterlabs/hardhat-zksync-deploy/src/utils';
+import { Deployer } from '@matterlabs/hardhat-zksync-deploy/dist/deployer';
+import { getConstructorArguments } from '@matterlabs/hardhat-zksync-deploy/dist/utils';
 import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { Contract } from 'zksync-ethers';

--- a/packages/hardhat-zksync-upgradable/src/plugin.ts
+++ b/packages/hardhat-zksync-upgradable/src/plugin.ts
@@ -53,6 +53,7 @@ export async function deployProxyWithOneLine(
         contractName: string;
         constructorArgsParams: any[];
         constructorArgs?: string;
+        initializer?: string;
         noCompile?: boolean;
     },
 ): Promise<Contract> {
@@ -69,7 +70,17 @@ export async function deployProxyWithOneLine(
     const deployer = new Deployer(hre, wallet);
 
     const contract = await deployer.loadArtifact(taskArgs.contractName);
-    const proxy = await hre.zkUpgrades.deployProxy(wallet, contract, constructorArguments);
+    const proxy = await hre.zkUpgrades.deployProxy(
+        wallet,
+        contract,
+        constructorArguments,
+        taskArgs.initializer
+            ? {
+                  initializer: taskArgs.initializer,
+              }
+            : undefined,
+    );
+
     await proxy.waitForDeployment();
 
     return proxy;
@@ -114,6 +125,7 @@ export async function upgradeProxyWithOneLine(
 
     const contractV2 = await deployer.loadArtifact(taskArgs.contractName);
     const proxyUpgrade = await hre.zkUpgrades.upgradeProxy(wallet, taskArgs.proxyAddress, contractV2);
+
     await proxyUpgrade.waitForDeployment();
 
     return proxyUpgrade;

--- a/packages/hardhat-zksync-upgradable/src/task-actions.ts
+++ b/packages/hardhat-zksync-upgradable/src/task-actions.ts
@@ -1,0 +1,39 @@
+import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types';
+import { Contract } from 'zksync-ethers';
+import {
+    deployBeaconWithOneLine,
+    deployProxyWithOneLine,
+    upgradeBeaconWithOneLine,
+    upgradeProxyWithOneLine,
+} from './plugin';
+
+export async function deployBeaconZkSyncWithOneLine(
+    taskArgs: TaskArguments,
+    hre: HardhatRuntimeEnvironment,
+): Promise<{
+    proxy: Contract;
+    beacon: Contract;
+}> {
+    return await deployBeaconWithOneLine(hre, taskArgs);
+}
+
+export async function deployProxyZkSyncWithOneLine(
+    taskArgs: TaskArguments,
+    hre: HardhatRuntimeEnvironment,
+): Promise<Contract> {
+    return await deployProxyWithOneLine(hre, taskArgs);
+}
+
+export async function upgradeBeaconZkSyncWithOneLine(
+    taskArgs: TaskArguments,
+    hre: HardhatRuntimeEnvironment,
+): Promise<Contract> {
+    return await upgradeBeaconWithOneLine(hre, taskArgs);
+}
+
+export async function upgradeProxyZkSyncWithOneLine(
+    taskArgs: TaskArguments,
+    hre: HardhatRuntimeEnvironment,
+): Promise<Contract> {
+    return await upgradeProxyWithOneLine(hre, taskArgs);
+}

--- a/packages/hardhat-zksync-upgradable/src/task-names.ts
+++ b/packages/hardhat-zksync-upgradable/src/task-names.ts
@@ -1,0 +1,4 @@
+export const TASK_DEPLOY_BEACON_ONELINE = 'deploy-beacon:oneline';
+export const TASK_UPGRADE_BEACON_ONELINE = 'upgrade-beacon:oneline';
+export const TASK_DEPLOY_PROXY_ONELINE = 'deploy-proxy:oneline';
+export const TASK_UPGRADE_PROXY_ONELINE = 'upgrade-proxy:oneline';

--- a/packages/hardhat-zksync-upgradable/src/utils.ts
+++ b/packages/hardhat-zksync-upgradable/src/utils.ts
@@ -1,0 +1,13 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { Wallet } from 'zksync-ethers';
+import { getNetworkAccount, getWallet as getRealWallet } from '@matterlabs/hardhat-zksync-deploy/src/plugin';
+import { Providers, createProviders } from '@matterlabs/hardhat-zksync-deploy/src/deployer-helper';
+
+export async function getWallet(hre: HardhatRuntimeEnvironment, privateKeyOrIndex?: string | number): Promise<Wallet> {
+    const { ethWeb3Provider, zkWeb3Provider }: Providers = createProviders(hre.config.networks, hre.network);
+
+    const wallet = (await getRealWallet(hre, privateKeyOrIndex ?? getNetworkAccount(hre)))
+        .connect(zkWeb3Provider)
+        .connectToL1(ethWeb3Provider);
+    return wallet;
+}

--- a/packages/hardhat-zksync-upgradable/src/utils.ts
+++ b/packages/hardhat-zksync-upgradable/src/utils.ts
@@ -1,7 +1,7 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { Wallet } from 'zksync-ethers';
-import { getNetworkAccount, getWallet as getRealWallet } from '@matterlabs/hardhat-zksync-deploy/src/plugin';
-import { Providers, createProviders } from '@matterlabs/hardhat-zksync-deploy/src/deployer-helper';
+import { getNetworkAccount, getWallet as getRealWallet } from '@matterlabs/hardhat-zksync-deploy/dist/plugin';
+import { Providers, createProviders } from '@matterlabs/hardhat-zksync-deploy/dist/deployer-helper';
 
 export async function getWallet(hre: HardhatRuntimeEnvironment, privateKeyOrIndex?: string | number): Promise<Wallet> {
     const { ethWeb3Provider, zkWeb3Provider }: Providers = createProviders(hre.config.networks, hre.network);

--- a/packages/hardhat-zksync-upgradable/test/fixture-projects/beacon-e2e/hardhat.config.ts
+++ b/packages/hardhat-zksync-upgradable/test/fixture-projects/beacon-e2e/hardhat.config.ts
@@ -9,6 +9,15 @@ const config: HardhatUserConfig = {
         compilerSource: 'binary',
     },
     networks: {
+        ethNetwork: {
+            url: 'http://0.0.0.0:8545',
+        },
+        zkSyncNetwork: {
+            url: 'http://0.0.0.0:3050',
+            ethNetwork: 'ethNetwork',
+            zksync: true,
+            forceDeploy: true,
+        },
         hardhat: {
             zksync: true,
         },

--- a/packages/hardhat-zksync-upgradable/test/fixture-projects/tup-e2e/hardhat.config.ts
+++ b/packages/hardhat-zksync-upgradable/test/fixture-projects/tup-e2e/hardhat.config.ts
@@ -9,6 +9,15 @@ const config: HardhatUserConfig = {
         compilerSource: 'binary',
     },
     networks: {
+        ethNetwork: {
+            url: 'http://0.0.0.0:8545',
+        },
+        zkSyncNetwork: {
+            url: 'http://0.0.0.0:3050',
+            ethNetwork: 'ethNetwork',
+            zksync: true,
+            forceDeploy: true,
+        },
         hardhat: {
             zksync: true,
         },

--- a/packages/hardhat-zksync-upgradable/test/fixture-projects/uups-e2e/hardhat.config.ts
+++ b/packages/hardhat-zksync-upgradable/test/fixture-projects/uups-e2e/hardhat.config.ts
@@ -9,6 +9,15 @@ const config: HardhatUserConfig = {
         compilerSource: 'binary',
     },
     networks: {
+        ethNetwork: {
+            url: 'http://0.0.0.0:8545',
+        },
+        zkSyncNetwork: {
+            url: 'http://0.0.0.0:3050',
+            ethNetwork: 'ethNetwork',
+            zksync: true,
+            forceDeploy: true,
+        },
         hardhat: {
             zksync: true,
         },

--- a/packages/hardhat-zksync/README.md
+++ b/packages/hardhat-zksync/README.md
@@ -70,10 +70,10 @@ Optionally, the `--no-compile` parameter allows the task to skip the compilation
 
 `yarn hardhat deploy-proxy:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--initializer <initializer method>] [--verify] [--no-compile]`
 
-When executed, this command will automatically determine whether the deployment is for a Transparent or UUps proxy. 
+When executed, this command will automatically determine whether the deployment is for a Transparent or Uups proxy. 
 If the Transparent proxy is chosen, it will deploy implementation, admin, and proxy. 
 If the Uups proxy is chosen, it will deploy implementation and proxy.
-The initializer method name can optionally be specified using `--initializer <initializer method name>`, with the default method name being set to initialize.
+The initializer method name can optionally be specified using `--initializer <initializer method name>`, with the default method name being set to `initialize`.
 The `--no-compile` parameter allows the task to skip the compilation process.
 The `--verify` parameter allow the task to verify all deployed contracts.
 

--- a/packages/hardhat-zksync/README.md
+++ b/packages/hardhat-zksync/README.md
@@ -25,9 +25,33 @@ or
 
 ## 🕹 Commands
 
+### Contract deployment shortcuts 
+
 `yarn hardhat deploy-zksync:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--verify] [--no-compile]`
 
 When executed, this command deploys the provided contract on the specified network, using the provided contract constructor arguments. Using the `verify` parameter verifies the contract after deployment, while `no-compile` skips the compilation process.
+
+### Contract upgrades shortcuts 
+
+`yarn hardhat deploy-beacon:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--no-compile]`
+
+When executed, this command deploys the provided implementation, beacon and proxy on the specified network, using the provided contract constructor arguments. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+
+`yarn hardhat deploy-proxy:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--no-compile]`
+
+When executed, this command will automatically determine whether the deployment is for a Transparent or UUps proxy. 
+If the Transparent proxy is chosen, it will deploy implementation, admin, and proxy. 
+If the UUps proxy is chosen, it will deploy implementation and proxy. Optionally, the no-compile parameter allows the task to skip the compilation process.
+
+`yarn hardhat upgrade-beacon:oneline --contract-name <contract name or fully qualified name> --beacon-address <beacon address> [--no-compile]`
+
+When executed, this command upgrade beacon implementation. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+
+`yarn hardhat upgrade-proxy:oneline --contract-name <contract name or fully qualified name> --proxy-address <proxy address> [--no-compile]`
+
+When executed, this command upgrade uups or transparent implementation. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+
+Please consider that while the provided CLI commands enable contract deployment and upgrading, not all arguments may be available (e.g. initializer or kind propery). If these commands lack the required functionality, it may be necessary to utilize scripting for a more comprehensive approach.
 
 ## 📝 Documentation
 

--- a/packages/hardhat-zksync/README.md
+++ b/packages/hardhat-zksync/README.md
@@ -23,35 +23,73 @@ or
 
 `yarn add -D @matterlabs/hardhat-zksync`
 
-## 🕹 Commands
+## 🕹 Shortcuts commands
 
-### Contract deployment shortcuts 
+### 📥 Configuration
+To extend the configuration to support commands, we need to add an accounts field to the specific network configuration in the networks section of the hardhat.config.ts file. This accounts field can support an array of private keys or a mnemonic object and represents accounts that will be used as wallet automaticlly.
+
+```
+const config: HardhatUserConfig = {
+  networks: {
+    sepolia: {
+      url: "https://sepolia.infura.io/v3/<API_KEY>" // The Ethereum Web3 RPC URL (optional).
+    },
+    zkTestnet: {
+      url: "https://sepolia.era.zksync.dev", // The testnet RPC URL of zkSync Era network.
+      ethNetwork: "sepolia", // The Ethereum Web3 RPC URL, or the identifier of the network (e.g. `mainnet` or `sepolia`)
+      zksync: true,
+      // ADDITON
+      accounts: ['0xac1e735be8536c6534bb4f17f06f6afc73b2b5ba84ac2cfb12f7461b20c0bbe3', '0x28a574ab2de8a00364d5dd4b07c4f2f574ef7fcc2a86a197f65abaec836d1959'], // The private keys for the accounts used in the deployment or in the upgradation process.
+      accounts: {
+          mnemonic: 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle'
+      }
+      // Mnemonic used in the deployment or in the upgradation process
+    }
+  },
+};
+```
+- accounts represents a list of the private keys or mnemonic object for the account used in the deployment or in the upgradation process.
+
+accounts object will be automaticly be populated with rich accounts if used network is zkSync Era Test Node or zksync-cli Local Node
+
+### 🕹 Commands
+
+#### Contract deployment shortcuts 
 
 `yarn hardhat deploy-zksync:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--verify] [--no-compile]`
 
-When executed, this command deploys the provided contract on the specified network, using the provided contract constructor arguments. Using the `verify` parameter verifies the contract after deployment, while `no-compile` skips the compilation process.
+When executed, this command deploys the provided contract on the specified network, using the provided contract constructor arguments. 
+Using the `verify` parameter verifies the contract after deployment, while `no-compile` skips the compilation process.
 
-### Contract upgrades shortcuts 
+#### Contract upgrades shortcuts 
 
-`yarn hardhat deploy-beacon:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--no-compile]`
+`yarn hardhat deploy-beacon:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--verify] [--no-compile]`
 
-When executed, this command deploys the provided implementation, beacon and proxy on the specified network, using the provided contract constructor arguments. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+When executed, this command deploys the provided implementation, beacon and proxy on the specified network, using the provided contract constructor arguments. 
+Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
 
-`yarn hardhat deploy-proxy:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--no-compile]`
+`yarn hardhat deploy-proxy:oneline --contract-name <contract name or fully qualified name> <constructor arguments> [--initializer <initializer method>] [--verify] [--no-compile]`
 
 When executed, this command will automatically determine whether the deployment is for a Transparent or UUps proxy. 
 If the Transparent proxy is chosen, it will deploy implementation, admin, and proxy. 
-If the UUps proxy is chosen, it will deploy implementation and proxy. Optionally, the no-compile parameter allows the task to skip the compilation process.
+If the Uups proxy is chosen, it will deploy implementation and proxy.
+The initializer method name can optionally be specified using `--initializer <initializer method name>`, with the default method name being set to initialize.
+The `--no-compile` parameter allows the task to skip the compilation process.
+The `--verify` parameter allow the task to verify all deployed contracts.
 
-`yarn hardhat upgrade-beacon:oneline --contract-name <contract name or fully qualified name> --beacon-address <beacon address> [--no-compile]`
+`yarn hardhat upgrade-beacon:oneline --contract-name <contract name or fully qualified name> --beacon-address <beacon address> [--verify] [--no-compile]`
 
-When executed, this command upgrade beacon implementation. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+When executed, this command upgrade beacon implementation. 
+Optionally, the `--no-compile` parameter allows the task to skip the compilation process.
+The `--verify` parameter allow the task to verify all deployed contracts.
 
-`yarn hardhat upgrade-proxy:oneline --contract-name <contract name or fully qualified name> --proxy-address <proxy address> [--no-compile]`
+`yarn hardhat upgrade-proxy:oneline --contract-name <contract name or fully qualified name> --proxy-address <proxy address>  [--verify] [--no-compile]`
 
-When executed, this command upgrade uups or transparent implementation. Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+When executed, this command upgrade uups or transparent implementation. 
+Optionally, the `no-compile` parameter allows the task to skip the compilation process.
+The `--verify` parameter allow the task to verify all deployed contracts.
 
-Please consider that while the provided CLI commands enable contract deployment and upgrading, not all arguments may be available (e.g. initializer or kind propery). If these commands lack the required functionality, it may be necessary to utilize scripting for a more comprehensive approach.
+Please consider that while the provided CLI commands enable contract deployment and upgrading, not all arguments may be available. If these commands lack the required functionality, it may be necessary to utilize scripting for a more comprehensive approach.
 
 ## 📝 Documentation
 

--- a/packages/hardhat-zksync/src/index.ts
+++ b/packages/hardhat-zksync/src/index.ts
@@ -8,13 +8,13 @@ import '@matterlabs/hardhat-zksync-upgradable';
 import '@matterlabs/hardhat-zksync-ethers';
 import '@matterlabs/hardhat-zksync-node';
 
-import { TASK_DEPLOY_ZKSYNC_ONELINE } from '@matterlabs/hardhat-zksync-deploy/src/task-names';
+import { TASK_DEPLOY_ZKSYNC_ONELINE } from '@matterlabs/hardhat-zksync-deploy/dist/task-names';
 import {
     TASK_DEPLOY_BEACON_ONELINE,
     TASK_DEPLOY_PROXY_ONELINE,
     TASK_UPGRADE_BEACON_ONELINE,
     TASK_UPGRADE_PROXY_ONELINE,
-} from '@matterlabs/hardhat-zksync-upgradable/src/task-names';
+} from '@matterlabs/hardhat-zksync-upgradable/dist/src/task-names';
 import {
     deployBeaconZkSyncWithOneLineAndVerify,
     deployProxyZkSyncWithOneLineAndVerify,

--- a/packages/hardhat-zksync/src/index.ts
+++ b/packages/hardhat-zksync/src/index.ts
@@ -9,10 +9,44 @@ import '@matterlabs/hardhat-zksync-ethers';
 import '@matterlabs/hardhat-zksync-node';
 
 import { TASK_DEPLOY_ZKSYNC_ONELINE } from '@matterlabs/hardhat-zksync-deploy/src/task-names';
-import { deployZkSyncWithOneLineAndVerify } from './task-action';
+import {
+    TASK_DEPLOY_BEACON_ONELINE,
+    TASK_DEPLOY_PROXY_ONELINE,
+    TASK_UPGRADE_BEACON_ONELINE,
+    TASK_UPGRADE_PROXY_ONELINE,
+} from '@matterlabs/hardhat-zksync-upgradable/src/task-names';
+import {
+    deployBeaconZkSyncWithOneLineAndVerify,
+    deployProxyZkSyncWithOneLineAndVerify,
+    deployZkSyncWithOneLineAndVerify,
+    upgradeBeaconZkSyncWithOneLineAndVerify,
+    upgradeProxyZkSyncWithOneLineAndVerify,
+} from './task-action';
 // Export Deployer class.
 export { Deployer } from '@matterlabs/hardhat-zksync-deploy';
 
 task(TASK_DEPLOY_ZKSYNC_ONELINE, 'Runs the deploy and verify from one line for zkSync network')
     .addFlag('verify', 'Contract verification flag')
     .setAction(deployZkSyncWithOneLineAndVerify);
+
+task(TASK_DEPLOY_BEACON_ONELINE, 'Runs the deploy and verify for beacon from one line for zkSync network')
+    .addFlag('verify', 'Contract verification flag')
+    .setAction(deployBeaconZkSyncWithOneLineAndVerify);
+
+task(TASK_DEPLOY_PROXY_ONELINE, 'Runs the deploy and verify for proxy from one line for zkSync network')
+    .addFlag('verify', 'Contract verification flag')
+    .setAction(deployProxyZkSyncWithOneLineAndVerify);
+
+task(
+    TASK_UPGRADE_BEACON_ONELINE,
+    'Runs the upgrade and verify for beacon new implementation from one line for zkSync network',
+)
+    .addFlag('verify', 'Contract verification flag')
+    .setAction(upgradeBeaconZkSyncWithOneLineAndVerify);
+
+task(
+    TASK_UPGRADE_PROXY_ONELINE,
+    'Runs the upgrade and verify for proxy new implementation from one line for zkSync network',
+)
+    .addFlag('verify', 'Contract verification flag')
+    .setAction(upgradeProxyZkSyncWithOneLineAndVerify);

--- a/packages/hardhat-zksync/src/plugin.ts
+++ b/packages/hardhat-zksync/src/plugin.ts
@@ -23,3 +23,77 @@ export async function deployWithOneLineAndVerify(
         });
     }
 }
+
+export async function deployBeaconWithOneLineAndVerify(
+    hre: HardhatRuntimeEnvironment,
+    runSuper: RunSuperFunction<TaskArguments>,
+    taskArgs: {
+        contractName: string;
+        constructorArgsParams: any[];
+        constructorArgs?: string;
+        noCompile?: boolean;
+        verify?: boolean;
+    },
+): Promise<void> {
+    const { proxy, _ } = await runSuper(taskArgs);
+    if (taskArgs.verify) {
+        await hre.run('verify:verify', {
+            address: await proxy.getAddress(),
+        });
+    }
+}
+
+export async function deployProxyWithOneLineAndVerify(
+    hre: HardhatRuntimeEnvironment,
+    runSuper: RunSuperFunction<TaskArguments>,
+    taskArgs: {
+        contractName: string;
+        constructorArgsParams: any[];
+        constructorArgs?: string;
+        noCompile?: boolean;
+        verify?: boolean;
+    },
+): Promise<void> {
+    const proxy = await runSuper(taskArgs);
+    if (taskArgs.verify) {
+        await hre.run('verify:verify', {
+            address: await proxy.getAddress(),
+        });
+    }
+}
+
+export async function upgradeBeaconWithOneLineAndVerify(
+    hre: HardhatRuntimeEnvironment,
+    runSuper: RunSuperFunction<TaskArguments>,
+    taskArgs: {
+        contractName: string;
+        beaconAddress: string;
+        noCompile?: boolean;
+        verify?: boolean;
+    },
+): Promise<void> {
+    const proxy = await runSuper(taskArgs);
+    if (taskArgs.verify) {
+        await hre.run('verify:verify', {
+            address: await proxy.getAddress(),
+        });
+    }
+}
+
+export async function upgradeProxyWithOneLineAndVerify(
+    hre: HardhatRuntimeEnvironment,
+    runSuper: RunSuperFunction<TaskArguments>,
+    taskArgs: {
+        contractName: string;
+        proxyAddress: string;
+        noCompile?: boolean;
+        verify?: boolean;
+    },
+): Promise<void> {
+    const proxy = await runSuper(taskArgs);
+    if (taskArgs.verify) {
+        await hre.run('verify:verify', {
+            address: await proxy.getAddress(),
+        });
+    }
+}

--- a/packages/hardhat-zksync/src/plugin.ts
+++ b/packages/hardhat-zksync/src/plugin.ts
@@ -1,4 +1,5 @@
 import { HardhatRuntimeEnvironment, RunSuperFunction, TaskArguments } from 'hardhat/types';
+import { Contract } from 'zksync-ethers';
 
 export async function deployWithOneLineAndVerify(
     hre: HardhatRuntimeEnvironment,
@@ -10,7 +11,7 @@ export async function deployWithOneLineAndVerify(
         noCompile?: boolean;
         verify?: boolean;
     },
-): Promise<void> {
+): Promise<Contract> {
     const contract = await runSuper(taskArgs);
     if (taskArgs.verify) {
         const artifact = await hre.deployer.loadArtifact(taskArgs.contractName);
@@ -22,6 +23,8 @@ export async function deployWithOneLineAndVerify(
             noCompile: taskArgs.noCompile,
         });
     }
+
+    return contract;
 }
 
 export async function deployBeaconWithOneLineAndVerify(
@@ -34,13 +37,18 @@ export async function deployBeaconWithOneLineAndVerify(
         noCompile?: boolean;
         verify?: boolean;
     },
-): Promise<void> {
-    const { proxy, _ } = await runSuper(taskArgs);
+): Promise<{
+    proxy: Contract;
+    beacon: Contract;
+}> {
+    const { proxy, beacon } = await runSuper(taskArgs);
     if (taskArgs.verify) {
         await hre.run('verify:verify', {
             address: await proxy.getAddress(),
         });
     }
+
+    return { proxy, beacon };
 }
 
 export async function deployProxyWithOneLineAndVerify(
@@ -53,13 +61,15 @@ export async function deployProxyWithOneLineAndVerify(
         noCompile?: boolean;
         verify?: boolean;
     },
-): Promise<void> {
+): Promise<Contract> {
     const proxy = await runSuper(taskArgs);
     if (taskArgs.verify) {
         await hre.run('verify:verify', {
             address: await proxy.getAddress(),
         });
     }
+
+    return proxy;
 }
 
 export async function upgradeBeaconWithOneLineAndVerify(
@@ -71,13 +81,15 @@ export async function upgradeBeaconWithOneLineAndVerify(
         noCompile?: boolean;
         verify?: boolean;
     },
-): Promise<void> {
+): Promise<Contract> {
     const proxy = await runSuper(taskArgs);
     if (taskArgs.verify) {
         await hre.run('verify:verify', {
             address: await proxy.getAddress(),
         });
     }
+
+    return proxy;
 }
 
 export async function upgradeProxyWithOneLineAndVerify(
@@ -89,11 +101,13 @@ export async function upgradeProxyWithOneLineAndVerify(
         noCompile?: boolean;
         verify?: boolean;
     },
-): Promise<void> {
+): Promise<Contract> {
     const proxy = await runSuper(taskArgs);
     if (taskArgs.verify) {
         await hre.run('verify:verify', {
             address: await proxy.getAddress(),
         });
     }
+
+    return proxy;
 }

--- a/packages/hardhat-zksync/src/task-action.ts
+++ b/packages/hardhat-zksync/src/task-action.ts
@@ -1,5 +1,11 @@
 import { HardhatRuntimeEnvironment, RunSuperFunction, TaskArguments } from 'hardhat/types';
-import { deployWithOneLineAndVerify } from './plugin';
+import {
+    deployBeaconWithOneLineAndVerify,
+    deployProxyWithOneLineAndVerify,
+    deployWithOneLineAndVerify,
+    upgradeBeaconWithOneLineAndVerify,
+    upgradeProxyWithOneLineAndVerify,
+} from './plugin';
 
 export async function deployZkSyncWithOneLineAndVerify(
     taskArgs: TaskArguments,
@@ -7,4 +13,36 @@ export async function deployZkSyncWithOneLineAndVerify(
     runSuper: RunSuperFunction<TaskArguments>,
 ) {
     await deployWithOneLineAndVerify(hre, runSuper, taskArgs);
+}
+
+export async function deployBeaconZkSyncWithOneLineAndVerify(
+    taskArgs: TaskArguments,
+    hre: HardhatRuntimeEnvironment,
+    runSuper: RunSuperFunction<TaskArguments>,
+) {
+    await deployBeaconWithOneLineAndVerify(hre, runSuper, taskArgs);
+}
+
+export async function deployProxyZkSyncWithOneLineAndVerify(
+    taskArgs: TaskArguments,
+    hre: HardhatRuntimeEnvironment,
+    runSuper: RunSuperFunction<TaskArguments>,
+) {
+    await deployProxyWithOneLineAndVerify(hre, runSuper, taskArgs);
+}
+
+export async function upgradeBeaconZkSyncWithOneLineAndVerify(
+    taskArgs: TaskArguments,
+    hre: HardhatRuntimeEnvironment,
+    runSuper: RunSuperFunction<TaskArguments>,
+) {
+    await upgradeBeaconWithOneLineAndVerify(hre, runSuper, taskArgs);
+}
+
+export async function upgradeProxyZkSyncWithOneLineAndVerify(
+    taskArgs: TaskArguments,
+    hre: HardhatRuntimeEnvironment,
+    runSuper: RunSuperFunction<TaskArguments>,
+) {
+    await upgradeProxyWithOneLineAndVerify(hre, runSuper, taskArgs);
 }

--- a/packages/hardhat-zksync/src/task-action.ts
+++ b/packages/hardhat-zksync/src/task-action.ts
@@ -12,7 +12,7 @@ export async function deployZkSyncWithOneLineAndVerify(
     hre: HardhatRuntimeEnvironment,
     runSuper: RunSuperFunction<TaskArguments>,
 ) {
-    await deployWithOneLineAndVerify(hre, runSuper, taskArgs);
+    return await deployWithOneLineAndVerify(hre, runSuper, taskArgs);
 }
 
 export async function deployBeaconZkSyncWithOneLineAndVerify(
@@ -20,7 +20,7 @@ export async function deployBeaconZkSyncWithOneLineAndVerify(
     hre: HardhatRuntimeEnvironment,
     runSuper: RunSuperFunction<TaskArguments>,
 ) {
-    await deployBeaconWithOneLineAndVerify(hre, runSuper, taskArgs);
+    return await deployBeaconWithOneLineAndVerify(hre, runSuper, taskArgs);
 }
 
 export async function deployProxyZkSyncWithOneLineAndVerify(
@@ -28,7 +28,7 @@ export async function deployProxyZkSyncWithOneLineAndVerify(
     hre: HardhatRuntimeEnvironment,
     runSuper: RunSuperFunction<TaskArguments>,
 ) {
-    await deployProxyWithOneLineAndVerify(hre, runSuper, taskArgs);
+    return await deployProxyWithOneLineAndVerify(hre, runSuper, taskArgs);
 }
 
 export async function upgradeBeaconZkSyncWithOneLineAndVerify(
@@ -36,7 +36,7 @@ export async function upgradeBeaconZkSyncWithOneLineAndVerify(
     hre: HardhatRuntimeEnvironment,
     runSuper: RunSuperFunction<TaskArguments>,
 ) {
-    await upgradeBeaconWithOneLineAndVerify(hre, runSuper, taskArgs);
+    return await upgradeBeaconWithOneLineAndVerify(hre, runSuper, taskArgs);
 }
 
 export async function upgradeProxyZkSyncWithOneLineAndVerify(
@@ -44,5 +44,5 @@ export async function upgradeProxyZkSyncWithOneLineAndVerify(
     hre: HardhatRuntimeEnvironment,
     runSuper: RunSuperFunction<TaskArguments>,
 ) {
-    await upgradeProxyWithOneLineAndVerify(hre, runSuper, taskArgs);
+    return await upgradeProxyWithOneLineAndVerify(hre, runSuper, taskArgs);
 }


### PR DESCRIPTION
# What :computer: 
* Introducing a new upgradable tasks to run via ci command

# Why :hand:
* Provided CLI commands enable contract deployment and upgrading, not all arguments may be available (e.g. initializer or kind propery). If these commands lack the required functionality, it may be necessary to utilize scripting for a more comprehensive approach.