### PR TITLE
fix: call fallback verification with full soruce codes when BE throws…

### DIFF
--- a/packages/hardhat-zksync-verify/src/constants.ts
+++ b/packages/hardhat-zksync-verify/src/constants.ts
@@ -109,17 +109,17 @@ This means that unrelated contracts may be displayed on the zksync block explore
 export const COMPILERS_CONFLICT_ZKVM_SOLC = (version: string) =>
     `Solidity compiler versions in your Hardhat config file are in conflict for version ${version}. Please specify version of compiler only with zkVm support(eraVersion) or without it`;
 
-export const COMPILATION_ERRORS = [
-    {
-        error: ' CompilationError',
-        pattern: /^.*Compilation error.*$/,
-    },
-    {
-        error: 'MissingSource',
-        pattern: /^.*There is no .* source file$/,
-    },
-    {
-        error: 'MissingContract',
-        pattern: /^.*Contract with .* name is missing in sources$/,
-    },
-];
+    export const COMPILATION_ERRORS = [
+      {
+          error: ' CompilationError',
+          pattern: /^Backend verification error: Compilation error.*$/s,
+      },
+      {
+          error: 'MissingSource',
+          pattern: /^Backend verification error: There is no .* source file$/,
+      },
+      {
+          error: 'MissingContract',
+          pattern: /^Backend verification error: Contract with .* name is missing in sources$/,
+      },
+  ];

--- a/packages/hardhat-zksync-verify/src/constants.ts
+++ b/packages/hardhat-zksync-verify/src/constants.ts
@@ -111,7 +111,7 @@ export const COMPILERS_CONFLICT_ZKVM_SOLC = (version: string) =>
 
 export const COMPILATION_ERRORS = [
     {
-        error: ' CompilationError',
+        error: 'CompilationError',
         pattern: /^Backend verification error: Compilation error.*$/s,
     },
     {

--- a/packages/hardhat-zksync-verify/src/constants.ts
+++ b/packages/hardhat-zksync-verify/src/constants.ts
@@ -108,3 +108,18 @@ This means that unrelated contracts may be displayed on the zksync block explore
 
 export const COMPILERS_CONFLICT_ZKVM_SOLC = (version: string) =>
     `Solidity compiler versions in your Hardhat config file are in conflict for version ${version}. Please specify version of compiler only with zkVm support(eraVersion) or without it`;
+
+export const COMPILATION_ERRORS = [
+    {
+        error: ' CompilationError',
+        pattern: /^.*Compilation error.*$/,
+    },
+    {
+        error: 'MissingSource',
+        pattern: /^.*There is no .* source file$/,
+    },
+    {
+        error: 'MissingContract',
+        pattern: /^.*Contract with .* name is missing in sources$/,
+    },
+];

--- a/packages/hardhat-zksync-verify/src/constants.ts
+++ b/packages/hardhat-zksync-verify/src/constants.ts
@@ -109,17 +109,17 @@ This means that unrelated contracts may be displayed on the zksync block explore
 export const COMPILERS_CONFLICT_ZKVM_SOLC = (version: string) =>
     `Solidity compiler versions in your Hardhat config file are in conflict for version ${version}. Please specify version of compiler only with zkVm support(eraVersion) or without it`;
 
-    export const COMPILATION_ERRORS = [
-      {
-          error: ' CompilationError',
-          pattern: /^Backend verification error: Compilation error.*$/s,
-      },
-      {
-          error: 'MissingSource',
-          pattern: /^Backend verification error: There is no .* source file$/,
-      },
-      {
-          error: 'MissingContract',
-          pattern: /^Backend verification error: Contract with .* name is missing in sources$/,
-      },
-  ];
+export const COMPILATION_ERRORS = [
+    {
+        error: ' CompilationError',
+        pattern: /^Backend verification error: Compilation error.*$/s,
+    },
+    {
+        error: 'MissingSource',
+        pattern: /^Backend verification error: There is no .* source file$/,
+    },
+    {
+        error: 'MissingContract',
+        pattern: /^Backend verification error: Contract with .* name is missing in sources$/,
+    },
+];

--- a/packages/hardhat-zksync-verify/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify/src/task-actions.ts
@@ -236,7 +236,7 @@ export async function verifyContract(
         }
         console.info(chalk.red(UNSUCCESSFUL_CONTEXT_COMPILATION_MESSAGE));
 
-        request.sourceCode = contractInformation.compilerInput;
+        request.sourceCode.sources = contractInformation.compilerInput.sources;
 
         const fallbackResponse = await verifyContractRequest(request, hre.network.verifyURL);
         const fallbackVerificationId = parseInt(fallbackResponse.message, 10);

--- a/packages/hardhat-zksync-verify/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify/src/task-actions.ts
@@ -23,6 +23,7 @@ import {
     ENCODED_ARAGUMENTS_NOT_FOUND_ERROR,
     CONSTRUCTOR_MODULE_IMPORTING_ERROR,
     BUILD_INFO_NOT_FOUND_ERROR,
+    COMPILATION_ERRORS,
 } from './constants';
 
 import { encodeArguments, extractModule, normalizeCompilerVersions, retrieveContractBytecode } from './utils';
@@ -227,7 +228,10 @@ export async function verifyContract(
     } catch (error: any) {
         // The first verirication attempt with 'minimal' source code was unnsuccessful.
         // Now try with the full source code from the compilation context.
-        if (error.message !== NO_MATCHING_CONTRACT) {
+        if (
+            error.message !== NO_MATCHING_CONTRACT &&
+            COMPILATION_ERRORS.filter((compilationError) => compilationError.pattern.test(error.message)).length === 0
+        ) {
             throw error;
         }
         console.info(chalk.red(UNSUCCESSFUL_CONTEXT_COMPILATION_MESSAGE));


### PR DESCRIPTION
… a compilation error

# What :computer: 
* Call fallback verification with full source codes when BE throws a compilation error.

# Why :hand:
* The first verification attempt with 'minimal' source code was unnsuccessful we need to sent a full context with all source files and to try that way.
