### PR TITLE
fix: set valid fromBlock filter to check creation tx hash from the logs

### DIFF
--- a/packages/hardhat-zksync-upgradable/src/utils/utils-general.ts
+++ b/packages/hardhat-zksync-upgradable/src/utils/utils-general.ts
@@ -74,7 +74,7 @@ export function inferConstructorArgs(txInput: string, creationCode: string) {
  */
 export async function getContractCreationTxHash(provider: zk.Provider, address: string, topic: string): Promise<any> {
     const params = {
-        fromBlock: 0,
+        fromBlock: 'earliest',
         toBlock: 'latest',
         address,
         topics: [`0x${keccak256(Buffer.from(topic)).toString('hex')}`],


### PR DESCRIPTION
# What :computer: 
* Set valid fromBlock filter to check creation tx hash from the logs

# Why :hand:
* With the new version of zksync-ethers v5, specifying fromBlock as 0 is no longer valid, and filtering doesn't have the desired effect. To address this, we need to set the fromBlock filter to 'earliest' to effectively search for the creation transaction hash.