### PR TITLE
fix: extend deploy and upgrade of proxy with deployment type and salt for ethers-v5

### DIFF
--- a/packages/hardhat-zksync-upgradable/README.md
+++ b/packages/hardhat-zksync-upgradable/README.md
@@ -44,7 +44,7 @@ await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [initializerFuncti
 
 The deployProxy method deploys your implementation contract on zkSync Era, deploys the proxy admin contract, and finally, deploys the transparent proxy.
 
-In the options section, include the following arguments to configure the deployment of the proxy and implementation with different deployment types and salts:
+Additionaly, in the options section optionaly include the folowing arguments to configure the deployment of the proxy and implementation with different deployment types and salts:
  - `deploymentTypeImpl`
  - `saltImpl`
  - `deploymentTypeProxy`
@@ -62,6 +62,7 @@ await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [initializerFuncti
 ```
 
 Permissible values for the deployment type include `create`, `create2`, `createAccount`, and `create2Account`. If this parameter is omitted, the default value will be `create`.
+If the salt parameters are ommited, the default value will be `0x0000000000000000000000000000000000000000000000000000000000000000`
 
 - **Deploying UUPS proxies**
 
@@ -96,7 +97,7 @@ Use the `deployBeaconProxy` method which receives the zkSync Era wallet, beacon 
 const box = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, beacon, boxContract, [42]);
 ```
 
-In the options section, include the `deploymentType` and `salt` arguments to configure deployment type and salt.
+Additionaly, in the options section optionaly include the `deploymentType` and `salt` arguments to configure deployment type and salt.
 
 ```
 const beacon = await hre.zkUpgrades.deployBeacon(deployer.zkWallet, boxContract, {
@@ -113,6 +114,7 @@ await box.deployed();
 ```
 
 Permissible values for the deployment type include `create`, `create2`, `createAccount`, and `create2Account`. If this parameter is omitted, the default value will be `create`.
+If the salt parameters are ommited, the default value will be `0x0000000000000000000000000000000000000000000000000000000000000000`
 
 - **Upgrading proxies**
 
@@ -125,7 +127,7 @@ const myContractV2 = await deployer.loadArtifact('contractV2');
 await hre.zkUpgrades.upgradeProxy(deployer.zkWallet, <PROXY_ADDRESS>, myContractV2);
 ```
 
-In the options section, include the `deploymentType` and `salt` to configure deployment type and salt.
+Optionaly in the other options section include `deploymentType` and `salt` to configure deployment type and salt for deploy of the new implementation.
 
  ```
 const myContractV2 = await deployer.loadArtifact('contractV2');
@@ -148,7 +150,7 @@ const myContractV2 = await deployer.loadArtifact('contractV2');
 await hre.zkUpgrades.upgradeBeacon(deployer.zkWallet, <BEACON_PROXY_ADDRESS>, myContractV2);
 ```
 
-In the options section, include the `deploymentType` and `salt` to configure deployment type and salt.
+Optionaly in the other options section include `deploymentType` and `salt` to configure deployment type and salt for deploy of the new implementation.
 
  ```
 const myContractV2 = await deployer.loadArtifact('contractV2');
@@ -295,6 +297,7 @@ module.exports = [
 - When utilizing the `upgrade-zksync:beacon` or `upgrade-zksync:proxy` tasks, specify the deployment type and salt using the `--deployment-type` and `--salt` arguments respectively.
 
 Permissible values for the deployment type include `create`, `create2`, `createAccount`, and `create2Account`. If this parameter is omitted, the default value will be `create`.
+If the salt parameters are ommited, the default value will be `0x0000000000000000000000000000000000000000000000000000000000000000`
 
 The account used for deployment will be the one specified by the `deployerAccount` configuration within the `hardhat.config.ts` file. If no such configuration is present, the account with index `0` will be used.
 

--- a/packages/hardhat-zksync-upgradable/README.md
+++ b/packages/hardhat-zksync-upgradable/README.md
@@ -44,6 +44,25 @@ await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [initializerFuncti
 
 The deployProxy method deploys your implementation contract on zkSync Era, deploys the proxy admin contract, and finally, deploys the transparent proxy.
 
+In the options section, include the following arguments to configure the deployment of the proxy and implementation with different deployment types and salts:
+ - `deploymentTypeImpl`
+ - `saltImpl`
+ - `deploymentTypeProxy`
+ - `saltProxy`
+
+```
+await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [initializerFunctionArguments], 
+  { initializer: "initialize",
+    saltImpl: "0x4273795673417857416686492163276941983664248508133571812215241323",
+    deploymentTypeImpl: "create2",
+    saltProxy: "0x5273795673417857416686492163276941983664248508133571812215241323",
+    deploymentTypeProxy: "create2"
+  }
+);
+```
+
+Permissible values for the deployment type include `create`, `create2`, `createAccount`, and `create2Account`. If this parameter is omitted, the default value will be `create`.
+
 - **Deploying UUPS proxies**
 
 The UUPS proxy pattern is similar to the transparent proxy pattern, except that the upgrade is triggered via the logic contract instead of from the proxy contract.
@@ -56,6 +75,45 @@ Beacon proxies enable a more advanced upgrade pattern, where multiple implementa
 
 Start by creating a Deployer for the zkSync Era network and load the Box artifact:
 
+```
+// mnemonic for local node rich wallet
+const testMnemonic = "stuff slice staff easily soup parent arm payment cotton trade scatter struggle";
+const zkWallet = Wallet.fromMnemonic(testMnemonic);
+const deployer = new Deployer(hre, zkWallet);
+const contractName = "Box";
+const boxContract = await deployer.loadArtifact(contractName);
+```
+
+Deploy the beacon contract using `deployBeacon` method from the `zkUpgrades`:
+
+```
+await hre.zkUpgrades.deployBeacon(deployer.zkWallet, boxContract);
+```
+
+Use the `deployBeaconProxy` method which receives the zkSync Era wallet, beacon contract, and the implementation (Box) contract with its arguments.
+
+```
+const box = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, beacon, boxContract, [42]);
+```
+
+In the options section, include the `deploymentType` and `salt` arguments to configure deployment type and salt.
+
+```
+const beacon = await hre.zkUpgrades.deployBeacon(deployer.zkWallet, boxContract, {
+  deploymentType: 'create2',
+  salt: '0x5273795673417857416686492163276941983664248508133571812215241323'
+});
+await beacon.deployed();
+
+const box = await hre.zkUpgrades.deployBeaconProxy(deployer.zkWallet, beacon, boxContract, [42], {
+  deploymentType: 'create2',
+  salt: '0x6273795673417857416686492163276941983664248508133571812215241323'
+});
+await box.deployed();
+```
+
+Permissible values for the deployment type include `create`, `create2`, `createAccount`, and `create2Account`. If this parameter is omitted, the default value will be `create`.
+
 - **Upgrading proxies**
 
 In order for a smart contract implementation to be upgradable, it has to follow specific [rules](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable).
@@ -65,6 +123,16 @@ To upgrade the implementation of the transparent upgradeable contract, use the u
 ```
 const myContractV2 = await deployer.loadArtifact('contractV2');
 await hre.zkUpgrades.upgradeProxy(deployer.zkWallet, <PROXY_ADDRESS>, myContractV2);
+```
+
+In the options section, include the `deploymentType` and `salt` to configure deployment type and salt.
+
+ ```
+const myContractV2 = await deployer.loadArtifact('contractV2');
+await hre.zkUpgrades.upgradeProxy(deployer.zkWallet, <PROXY_ADDRESS>, myContractV2, {
+  deploymentType: 'create2',
+  salt: '0x6273795673417857416686492163276941983664248508133571812215241323'
+});
 ```
 
 - **Upgrade UUPS proxy**
@@ -78,6 +146,16 @@ Beacon proxy implementation can be upgraded using a similarly structured method 
 ```
 const myContractV2 = await deployer.loadArtifact('contractV2');
 await hre.zkUpgrades.upgradeBeacon(deployer.zkWallet, <BEACON_PROXY_ADDRESS>, myContractV2);
+```
+
+In the options section, include the `deploymentType` and `salt` to configure deployment type and salt.
+
+ ```
+const myContractV2 = await deployer.loadArtifact('contractV2');
+await hre.zkUpgrades.upgradeBeacon(deployer.zkWallet, <BEACON_PROXY_ADDRESS>, myContractV2 {
+  deploymentType: 'create2',
+  salt: '0x6273795673417857416686492163276941983664248508133571812215241323'
+});
 ```
 
 The hardhat-zksync-upgradable plugin supports proxy verification, which means you can verify all the contracts deployed during the proxy deployment with a single verify command.
@@ -173,22 +251,22 @@ const config: HardhatUserConfig = {
 
 ### 🕹 Command list
 
-`yarn hardhat deploy-zksync:proxy --contract-name <contract name or FQN> [<constructor arguments>] [--constructor-args <javascript module name>] [--deployment-type <deployment type>] [--initializer <initialize method>] [--no-compile]`
+`yarn hardhat deploy-zksync:proxy --contract-name <contract name or FQN> [<constructor arguments>] [--constructor-args <javascript module name>] [--initializer <initialize method>] [--no-compile] [--deployment-type-impl <deployment type>] [--salt-impl <salt>] [--deployment-type-proxy <deployment type>] [--salt-proxy <salt>]`
 
 When executed, this command will automatically determine whether the deployment is for a Transparent or UUPS proxy. 
 If the Transparent proxy is chosen, it will deploy implementation, admin, and proxy. 
 If the UUPS proxy is chosen, it will deploy implementation and proxy.
 
-`yarn hardhat upgrade-zksync:proxy --contract-name <contract name or FQN> --proxy-address <proxy address> [--deployment-type <deployment type>] [--no-compile]`
+`yarn hardhat upgrade-zksync:proxy --contract-name <contract name or FQN> --proxy-address <proxy address> [--deployment-type <deployment type>] [--salt <salt>] [--no-compile]`
 
 When executed, this command upgrade UUPS or Transparent implementation.
 To upgrade a implementation we need to specify proxy address, add `--proxy-address <proxy address>` argument, e.g. `yarn hardhat upgrade-zksync:proxy --contract-name BoxV2 --proxy-address 0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520`.
 
-`yarn hardhat deploy-zksync:beacon --contract-name <contract name or FQN> [<constructor arguments>] [--constructor-args <javascript module name>] [--deployment-type <deployment type>] [--initializer <initialize method>] [--no-compile]`
+`yarn hardhat deploy-zksync:beacon --contract-name <contract name or FQN> [<constructor arguments>] [--constructor-args <javascript module name>] [--initializer <initialize method>] [--deployment-type-impl <deployment type>] [--salt-impl <salt>] [--deployment-type-proxy <deployment type>] [--salt-proxy <salt>] [--no-compile]`
 
 When executed, this command deploys the provided implementation, beacon and proxy on the specified network, using the provided contract constructor arguments.
 
-`yarn hardhat upgrade-zksync:beacon --contract-name <contract name or FQN> --beacon-address <beacon address> [--deployment-type <deployment type>] [--no-compile]`
+`yarn hardhat upgrade-zksync:beacon --contract-name <contract name or FQN> --beacon-address <beacon address> [--deployment-type <deployment type>] [--salt <salt>] [--no-compile]`
 
 When executed, this command upgrade beacon implementation.
 To upgrade a implementation we need to specify beacon address, add `--beacon-address <beacon address>` argument, e.g. `yarn hardhat upgrade-zksync:beacon --contract-name BoxV2 --beacon-address 0x4bbeEB066eD09B7AEd07bF39EEe0460DFa261520`.
@@ -210,7 +288,13 @@ module.exports = [
 ```
 - To provide a initializer method name at deploy tasks, add `--initializer <initializer method>`, e.g. `hardhat deploy-zksync:proxy --contract-name Contract --initializer store`. If this parameter is omitted, the default value will be `initialize`.
 - To allows the task to skip the compilation process, add  `--no-compile` argument, e.g. `hardhat deploy-zksync:beacon --contract-name Contract --no-compile`.
-- To allows the task to specify which deployer smart contract function will be called, add `--deployment-type` argument. Permissible values for this parameter include `create`, `create2`, `createAccount`, and `create2Account`. If this parameter is omitted, the default value will be `create`, e.g. `hardhat deploy-zksync:beacon --contract-name Greeter 'Hello' --deployment-type create2`.
+- To allows the task to specify which deployer smart contract function will be called for implementation, add `--deployment-type-impl` argument, e.g. `hardhat deploy-zksync:beacon --contract-name Greeter 'Hello' --deployment-type-impl create2`.
+- To allows the task to specify which deployer smart contract function will be called for proxy, add `--deployment-type-proxy` argument, e.g. `hardhat deploy-zksync:beacon --contract-name Greeter 'Hello' --deployment-type-proxy create2`.
+- To specify which salt will be used in deployment of the implementation, add `--salt-impl` argument, e.g. `hardhat deploy-zksync:beacon --contract-name Greeter 'Hello' --salt-impl 0x42737956734178574166864921632769419836642485081335718122152413290`
+- To specify which salt will be used in deployment of the proxy, add `--salt-proxy` argument, e.g. `hardhat deploy-zksync:beacon --contract-name Greeter 'Hello' --salt-proxy 0x42737956734178574166864921632769419836642485081335718122152413290`
+- When utilizing the `upgrade-zksync:beacon` or `upgrade-zksync:proxy` tasks, specify the deployment type and salt using the `--deployment-type` and `--salt` arguments respectively.
+
+Permissible values for the deployment type include `create`, `create2`, `createAccount`, and `create2Account`. If this parameter is omitted, the default value will be `create`.
 
 The account used for deployment will be the one specified by the `deployerAccount` configuration within the `hardhat.config.ts` file. If no such configuration is present, the account with index `0` will be used.
 

--- a/packages/hardhat-zksync-upgradable/src/index.ts
+++ b/packages/hardhat-zksync-upgradable/src/index.ts
@@ -74,7 +74,10 @@ task(TASK_DEPLOY_ZKSYNC_BEACON, 'Runs the beaccon deploy for zkSync network')
         types.inputFile,
     )
     .addOptionalParam('initializer', 'Initializer function name', undefined)
-    .addOptionalParam('deploymentType', 'Type of deployment', undefined)
+    .addOptionalParam('deploymentTypeImpl', 'Type of deployment for implementation', undefined)
+    .addOptionalParam('deploymentTypeProxy', 'Type of deployment for proxy', undefined)
+    .addOptionalParam('saltImpl', 'Salt for implementation deployment', undefined)
+    .addOptionalParam('saltProxy', 'Salt for proxy deployment', undefined)
     .addFlag('noCompile', 'No compile flag')
     .setAction(deployZkSyncBeacon);
 
@@ -92,7 +95,10 @@ task(TASK_DEPLOY_ZKSYNC_PROXY, 'Deploy proxy for zkSync network')
         types.inputFile,
     )
     .addOptionalParam('initializer', 'Initializer function name', undefined)
-    .addOptionalParam('deploymentType', 'Type of deployment', undefined)
+    .addOptionalParam('deploymentTypeImpl', 'Type of deployment for implementation', undefined)
+    .addOptionalParam('deploymentTypeProxy', 'Type of deployment for proxy', undefined)
+    .addOptionalParam('saltImpl', 'Salt for implementation deployment', undefined)
+    .addOptionalParam('saltProxy', 'Salt for proxy deployment', undefined)
     .addFlag('noCompile', 'No compile flag')
     .setAction(deployZkSyncProxy);
 
@@ -100,6 +106,7 @@ task(TASK_UPGRADE_ZKSYNC_BEACON, 'Runs the beacon upgrade for zkSync network')
     .addParam('contractName', 'A contract name or a FQN', '')
     .addParam('beaconAddress', 'Beacon address of the deployed contract', '')
     .addOptionalParam('deploymentType', 'Type of deployment', undefined)
+    .addOptionalParam('salt', 'Salt for deployment', undefined)
     .addFlag('noCompile', 'No compile flag')
     .setAction(upgradeZkSyncBeacon);
 
@@ -107,6 +114,7 @@ task(TASK_UPGRADE_ZKSYNC_PROXY, 'Runs the proxy upgrade for zkSync network')
     .addParam('contractName', 'A contract name or a FQN', '')
     .addParam('proxyAddress', 'Proxy address of the deployed contract', '')
     .addOptionalParam('deploymentType', 'Type of deployment', undefined)
+    .addOptionalParam('salt', 'Salt for deployment', undefined)
     .addFlag('noCompile', 'No compile flag')
     .setAction(upgradeZkSyncProxy);
 

--- a/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-beacon-proxy.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-beacon-proxy.ts
@@ -94,11 +94,16 @@ export function makeDeployBeaconProxy(hre: HardhatRuntimeEnvironment): DeployBea
             beaconProxyContract.abi,
             beaconProxyContract.bytecode,
             wallet,
+            opts.deploymentType,
         );
 
         const proxyDeployment: Required<ProxyDeployment & DeployTransaction> = {
             kind: opts.kind,
-            ...(await deploy(beaconProxyFactory, beaconAddress, data)),
+            ...(await deploy(beaconProxyFactory, beaconAddress, data, {
+                customData: {
+                    salt: opts.salt,
+                },
+            })),
         };
         if (!quiet) {
             console.info(chalk.green('Beacon proxy deployed at: ', proxyDeployment.address));

--- a/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-impl.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-impl.ts
@@ -63,11 +63,11 @@ export async function deployProxyImpl(
     return await deployImpl(hre, deployData, contractFactory, opts);
 }
 
-async function deployImpl(
+async function deployImpl<TRequiredSeperateForProxy extends boolean | undefined>(
     hre: HardhatRuntimeEnvironment,
     deployData: DeployData,
     factory: zk.ContractFactory,
-    opts: UpgradeOptions,
+    opts: UpgradeOptions<TRequiredSeperateForProxy>,
 ): Promise<any> {
     const layout = deployData.layout;
 
@@ -84,7 +84,15 @@ async function deployImpl(
                         factory,
                         ...[
                             ...deployData.fullOpts.constructorArgs,
-                            { customData: { factoryDeps: deployData.fullOpts.factoryDeps } },
+                            {
+                                customData: {
+                                    factoryDeps: deployData.fullOpts.factoryDeps,
+                                    salt:
+                                        'salt' in opts
+                                            ? (opts as UpgradeOptions<false>).salt
+                                            : (opts as UpgradeOptions).saltImpl,
+                                },
+                            },
                         ],
                     );
 

--- a/packages/hardhat-zksync-upgradable/src/utils/options.ts
+++ b/packages/hardhat-zksync-upgradable/src/utils/options.ts
@@ -10,18 +10,34 @@ import {
 import { DeploymentType } from 'zksync-ethers/src/types';
 import { LOCAL_SETUP_ZKSYNC_NETWORK } from '../constants';
 
-export type StandaloneOptions = StandaloneValidationOptions &
-    DeployOpts & {
-        constructorArgs?: unknown[];
-        useDeployedImplementation?: boolean;
-        provider?: any;
-        factoryDeps?: string[];
-        deploymentType?: DeploymentType;
-    };
+export type StandaloneOptions<TRequiredSeperateForProxy extends boolean | undefined = true | undefined> =
+    StandaloneValidationOptions &
+        DeployOpts & {
+            constructorArgs?: unknown[];
+            useDeployedImplementation?: boolean;
+            provider?: any;
+            factoryDeps?: string[];
+        } & DeploymentTypesOptions<TRequiredSeperateForProxy>;
 
-export type UpgradeOptions = ValidationOptions & StandaloneOptions;
+export type DeploymentTypesOptions<TRequiredSeperateForProxy extends boolean | undefined = true | undefined> =
+    TRequiredSeperateForProxy extends true | undefined
+        ? {
+              deploymentTypeImpl?: DeploymentType;
+              deploymentTypeProxy?: DeploymentType;
+              saltImpl?: string;
+              saltProxy?: string;
+          }
+        : {
+              deploymentType?: DeploymentType;
+              salt?: string;
+          };
 
-export function withDefaults(opts: UpgradeOptions = {}): Required<UpgradeOptions> {
+export type UpgradeOptions<TRequiredSeperateForProxy extends boolean | undefined = true | undefined> =
+    ValidationOptions & StandaloneOptions<TRequiredSeperateForProxy>;
+
+export function withDefaults<TRequiredSeperateForProxy extends boolean | undefined = true | undefined>(
+    opts: UpgradeOptions<TRequiredSeperateForProxy> = {},
+): Required<UpgradeOptions<TRequiredSeperateForProxy>> {
     return {
         constructorArgs: opts.constructorArgs ?? [],
         timeout: opts.timeout ?? 60e3,
@@ -29,22 +45,21 @@ export function withDefaults(opts: UpgradeOptions = {}): Required<UpgradeOptions
         pollingInterval: opts.pollingInterval ?? 5e3,
         useDeployedImplementation: opts.useDeployedImplementation ?? true,
         factoryDeps: opts.factoryDeps ?? [],
-        deploymentType: opts.deploymentType ?? 'create',
         ...withValidationDefaults(opts),
-    };
+    } as Required<UpgradeOptions<TRequiredSeperateForProxy>>;
 }
 
 interface Initializer {
     initializer?: string | false;
 }
 
-export type DeployBeaconProxyOptions = ProxyKindOption & Initializer;
-export type DeployBeaconOptions = StandaloneOptions;
+export type DeployBeaconProxyOptions = ProxyKindOption & Initializer & DeploymentTypesOptions<false>;
+export type DeployBeaconOptions = StandaloneOptions<false>;
 export type DeployImplementationOptions = StandaloneOptions;
 export type DeployProxyAdminOptions = DeployOpts;
 export type DeployProxyOptions = StandaloneOptions & Initializer;
-export type UpgradeBeaconOptions = UpgradeOptions;
-export type UpgradeProxyOptions = UpgradeOptions & {
+export type UpgradeBeaconOptions = UpgradeOptions<false>;
+export type UpgradeProxyOptions = UpgradeOptions<false> & {
     call?: { fn: string; args?: unknown[] } | string;
 };
 export type ValidateImplementationOptions = StandaloneValidationOptions;


### PR DESCRIPTION
# What :computer: 
* Extend deploy and upgrade of proxy with deployment type and salt

# Why :hand:
* To support different deployment types and salts.