### PR TITLE
feat: use deployment type in the deploy function

### DIFF
--- a/examples/basic-example/deploy/001_deploy.js
+++ b/examples/basic-example/deploy/001_deploy.js
@@ -15,12 +15,12 @@ module.exports = async function (hre) {
     const deployer = new Deployer(hre, zkWallet);
 
     // Deposit some funds to L2 in order to be able to perform deposits.
-    const depositHandle = await deployer.zkWallet.deposit({
-        to: deployer.zkWallet.address,
-        token: zk.utils.ETH_ADDRESS,
-        amount: ethers.parseEther('0.001'),
-    });
-    await depositHandle.wait();
+    // const depositHandle = await deployer.zkWallet.deposit({
+    //     to: deployer.zkWallet.address,
+    //     token: zk.utils.ETH_ADDRESS,
+    //     amount: ethers.parseEther('0.001'),
+    // });
+    // await depositHandle.wait();
 
     // Load the artifact we want to deploy.
     const artifact = await deployer.loadArtifact('Greeter');

--- a/examples/basic-example/deploy/002_factory.ts
+++ b/examples/basic-example/deploy/002_factory.ts
@@ -19,12 +19,12 @@ export default async function (hre: HardhatRuntimeEnvironment) {
     const deployer = new Deployer(hre, zkWallet);
 
     // Deposit some funds to L2 in order to be able to perform deposits.
-    const depositHandle = await deployer.zkWallet.deposit({
-        to: deployer.zkWallet.address,
-        token: zk.utils.ETH_ADDRESS,
-        amount: ethers.parseEther('0.01'),
-    });
-    await depositHandle.wait();
+    // const depositHandle = await deployer.zkWallet.deposit({
+    //     to: deployer.zkWallet.address,
+    //     token: zk.utils.ETH_ADDRESS,
+    //     amount: ethers.parseEther('0.01'),
+    // });
+    // await depositHandle.wait();
 
     // Load the artifact we want to deploy.
     const artifact = await deployer.loadArtifact('Import');

--- a/examples/deploy-example/deploy-zkSync/000_deploy.ts
+++ b/examples/deploy-example/deploy-zkSync/000_deploy.ts
@@ -1,6 +1,4 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import * as ethers from 'ethers';
-import * as zk from 'zksync-ethers';
 import chalk from 'chalk';
 
 const deployScript = async function (hre: HardhatRuntimeEnvironment) {
@@ -10,12 +8,12 @@ const deployScript = async function (hre: HardhatRuntimeEnvironment) {
     hre.deployer.setWallet(zkWallet);
 
     // Deposit some funds to L2 in order to be able to perform deposits.
-    const depositHandle = await zkWallet.deposit({
-        to: zkWallet.address,
-        token: zk.utils.ETH_ADDRESS,
-        amount: ethers.parseEther('0.01'),
-    });
-    await depositHandle.wait();
+    // const depositHandle = await zkWallet.deposit({
+    //     to: zkWallet.address,
+    //     token: zk.utils.ETH_ADDRESS,
+    //     amount: ethers.parseEther('0.01'),
+    // });
+    // await depositHandle.wait();
 
     // Load the artifact we want to deploy.
     const artifact = await hre.deployer.loadArtifact('Foo');

--- a/examples/deploy-example/deploy-zkSync/001_deploy.js
+++ b/examples/deploy-example/deploy-zkSync/001_deploy.js
@@ -10,7 +10,7 @@ var deployScript = async function (hre) {
     // Deploy this contract. The returned object will be of a `Contract` type, similarly to ones in `ethers`.
     // `greeting` is an argument for contract constructor.
     const greeting = 'Hi there!';
-    const greeterContract = await hre.deployer.deploy(artifact, [greeting], true);
+    const greeterContract = await hre.deployer.deploy(artifact, [greeting]);
 
     // Show the contract info.
     const contractAddress = await greeterContract.getAddress();

--- a/examples/deploy-example/deploy-zkSync/002_deploy.ts
+++ b/examples/deploy-example/deploy-zkSync/002_deploy.ts
@@ -9,7 +9,11 @@ const deployScript = async function (hre: HardhatRuntimeEnvironment) {
 
     // Deploy this contract. The returned object will be of a `Contract` type, similarly to ones in `ethers`.
     // This contract has no constructor arguments.
-    const factoryContract = await hre.deployer.deploy(artifact, []);
+    const factoryContract = await hre.deployer.deploy(artifact, [], 'create2', {
+        customData: {
+            salt: '0x7935910912126667836566922594852029127629416664760357073852948630'
+        }
+    });
 
     // Show the contract info.
     const contractAddress = await factoryContract.getAddress();

--- a/examples/node-example/deploy/001_deploy.js
+++ b/examples/node-example/deploy/001_deploy.js
@@ -15,12 +15,12 @@ module.exports = async function (hre) {
     const deployer = new Deployer(hre, zkWallet);
 
     // Deposit some funds to L2 in order to be able to perform deposits.
-    const depositHandle = await deployer.zkWallet.deposit({
-        to: deployer.zkWallet.address,
-        token: zk.utils.ETH_ADDRESS,
-        amount: ethers.parseEther('0.001'),
-    });
-    await depositHandle.wait();
+    // const depositHandle = await deployer.zkWallet.deposit({
+    //     to: deployer.zkWallet.address,
+    //     token: zk.utils.ETH_ADDRESS,
+    //     amount: ethers.parseEther('0.001'),
+    // });
+    // await depositHandle.wait();
 
     // Load the artifact we want to deploy.
     const artifact = await deployer.loadArtifact('Greeter');

--- a/examples/vyper-example/deploy/deploy.ts
+++ b/examples/vyper-example/deploy/deploy.ts
@@ -20,12 +20,12 @@ export default async function (hre: HardhatRuntimeEnvironment) {
     const deployer = new Deployer(hre, zkWallet);
 
     // Deposit some funds to L2 in order to be able to perform deposits.
-    const depositHandle = await deployer.zkWallet.deposit({
-        to: deployer.zkWallet.address,
-        token: zk.utils.ETH_ADDRESS,
-        amount: ethers.parseEther('0.01'),
-    });
-    await depositHandle.wait();
+    // const depositHandle = await deployer.zkWallet.deposit({
+    //     to: deployer.zkWallet.address,
+    //     token: zk.utils.ETH_ADDRESS,
+    //     amount: ethers.parseEther('0.01'),
+    // });
+    // await depositHandle.wait();
 
     // Load the artifact we want to deploy.
     const createForwarder = await deployer.loadArtifact('CreateForwarder');

--- a/examples/zksync-ethers-example/deploy/001_deploy.ts
+++ b/examples/zksync-ethers-example/deploy/001_deploy.ts
@@ -7,13 +7,13 @@ export default async function (hre: HardhatRuntimeEnvironment) {
     console.info(chalk.yellow(`Running deploy`));
     const wallet = await hre.zksyncEthers.getWallet(4);
 
-    console.info(chalk.yellow(`Depositing to wallet: ${await wallet.getAddress()}`));
-    const depositHandle = await wallet.deposit({
-        to: wallet.address,
-        token: utils.ETH_ADDRESS,
-        amount: ethers.parseEther('0.001'),
-    });
-    await depositHandle.wait();
+    // console.info(chalk.yellow(`Depositing to wallet: ${await wallet.getAddress()}`));
+    // const depositHandle = await wallet.deposit({
+    //     to: wallet.address,
+    //     token: utils.ETH_ADDRESS,
+    //     amount: ethers.parseEther('0.001'),
+    // });
+    // await depositHandle.wait();
 
     const artifact = await hre.zksyncEthers.loadArtifact('Greeter');
     const greets = await hre.zksyncEthers.deployContract(artifact, ['Hello, world with loadArtifact!'], wallet);

--- a/packages/hardhat-zksync-chai-matchers/test/reverted/reverted.ts
+++ b/packages/hardhat-zksync-chai-matchers/test/reverted/reverted.ts
@@ -41,9 +41,15 @@ describe('INTEGRATION: Reverted', function () {
             artifact = await deployer.loadArtifact('Matchers');
             matchers = await deployer.deploy(artifact);
 
-            aaDeployer = new Deployer(this.hre, wallet1, 'createAccount');
+            aaDeployer = new Deployer(this.hre, wallet1);
             artifact = await deployer.loadArtifact('TwoUserMultisig');
-            aaAccount = await aaDeployer.deploy(artifact, [wallet1.address, wallet2.address], undefined, []);
+            aaAccount = await aaDeployer.deploy(
+                artifact,
+                [wallet1.address, wallet2.address],
+                'createAccount',
+                undefined,
+                [],
+            );
         });
 
         // helpers

--- a/packages/hardhat-zksync-deploy/README.md
+++ b/packages/hardhat-zksync-deploy/README.md
@@ -47,9 +47,8 @@ It's main methods are:
 ```
    * @param hre Hardhat runtime environment. This object is provided to scripts by hardhat itself.
    * @param zkWallet The wallet which will be used to deploy the contracts.
-   * @param deploymentType Optional deployment type that relates to the ContractDeployer system contract function to be called. Defaults to deploying regular smart contracts.
 ```
- - `constructor(hre: HardhatRuntimeEnvironment, zkWallet: zk.Wallet, deploymentType?: zk.types.DeploymentType)`
+ - `constructor(hre: HardhatRuntimeEnvironment, zkWallet: zk.Wallet)`
 
 ```
    * Created a `Deployer` object on ethers.Wallet object.
@@ -58,7 +57,7 @@ It's main methods are:
    * @param ethWallet The wallet used to deploy smart contracts.
    * @param deploymentType The optional deployment type that relates to the `ContractDeployer` system contract function to be called. Defaults to deploying regular smart contracts.
 ```
- - `static fromEthWallet(hre: HardhatRuntimeEnvironment, ethWallet: ethers.Wallet, deploymentType?: zk.types.DeploymentType)`
+ - `static fromEthWallet(hre: HardhatRuntimeEnvironment, ethWallet: ethers.Wallet)`
 
 ```
    * Loads an artifact and verifies that it was compiled by `zksolc`.
@@ -80,11 +79,11 @@ It's main methods are:
    *
    * @param artifact The previously loaded artifact object.
    * @param constructorArguments The list of arguments to be passed to the contract constructor.
-   *
+   * @param deploymentType Optional deployment type that relates to the ContractDeployer system contract function to be called. Defaults to deploying regular smart contracts.
    * @returns Calculated fee in ETH wei.
    */
 ```
- - `public async estimateDeployFee(artifact: ZkSyncArtifact,constructorArguments: any[]): Promise<bigint>`
+ - `public async estimateDeployFee(artifact: ZkSyncArtifact, constructorArguments: any[], deploymentType?: zk.types.DeploymentType): Promise<bigint>`
 
 ```
    * Sends a deploy transaction to the zkSync network.
@@ -92,13 +91,14 @@ It's main methods are:
    *
    * @param contractNameOrArtifact The previously loaded artifact object, or contract name that will be resolved to artifact in the background.
    * @param constructorArguments The list of arguments to be passed to the contract constructor.
+   * @param deploymentType Optional deployment type that relates to the ContractDeployer system contract function to be called. Defaults to deploying regular smart contracts.
    * @param overrides Optional object with additional deploy transaction parameters.
    * @param additionalFactoryDeps Additional contract bytecodes to be added to the factory dependencies list.
    * The fee amount is requested automatically from the zkSync Era server.
    *
    * @returns A contract object.
 ```
- - `public async deploy(contractNameOrArtifact: ZkSyncArtifact | string, constructorArguments: any[], overrides?: OverridesAdditionalFactoryDeps?: ethers.BytesLike[],): Promise<zk.Contract>`
+ - `public async deploy(contractNameOrArtifact: ZkSyncArtifact | string, constructorArguments: any[], deploymentType?: zk.types.DeploymentType, overrides?: OverridesAdditionalFactoryDeps?: ethers.BytesLike[],): Promise<zk.Contract>`
 
 ```
    * Extracts factory dependencies from the artifact.
@@ -189,15 +189,6 @@ The described objects work together to provide users with a better deployment ex
 ### Methods
 
 Methods available for use in `hre.deployer` are the same as those available in the `Deployer` class object, as described above. Additionally, `hre.deployer` is extended with specific methods to facilitate the deployment process, making it more straightforward.
-
-```
-   * Set deployment type
-   *
-   * @param deployment type for future deployments 
-   *
-   */
-```
- - `public setDeploymentType(deploymentType: zk.types.DeploymentType): void`
 
 ```
    /**
@@ -491,7 +482,7 @@ module.exports = [
 ```
 - To allows the task to skip the compilation process, add  `--no-compile` argument, e.g. `hardhat deploy-zksync:contract --contract-name Contract --no-compile`.
 - To allows the task to specify which deployer smart contract function will be called, add `--deployment-type` argument. Permissible values for this parameter include `create`, `create2`, `createAccount`, and `create2Account`. If this parameter is omitted, the default value assumed will be `create`, e.g. `hardhat deploy-zksync:contract --contract-name Greeter 'Hello' --deployment-type create2`.
-
+- To specify which salt will be used in deployment, add `--salt` argument. If the salt parameters are ommited, the default value will be `0x0000000000000000000000000000000000000000000000000000000000000000`.
 The account used for deployment will be the one specified by the `deployerAccount` configuration within the `hardhat.config.ts` file. If no such configuration is present, the account with index `0` will be used.
 
 ## 📝 Documentation

--- a/packages/hardhat-zksync-deploy/src/deployer-extension.ts
+++ b/packages/hardhat-zksync-deploy/src/deployer-extension.ts
@@ -20,14 +20,7 @@ export class DeployerExtension implements AbstractDeployer {
     private zkWeb3Provider?: zk.Provider;
     private wallet?: zk.Wallet;
 
-    constructor(
-        private _hre: HardhatRuntimeEnvironment,
-        private _deploymentType?: zk.types.DeploymentType,
-    ) {}
-
-    public setDeploymentType(deploymentType: zk.types.DeploymentType) {
-        this._deploymentType = deploymentType;
-    }
+    constructor(private _hre: HardhatRuntimeEnvironment) {}
 
     public async loadArtifact(contractNameOrFullyQualifiedName: string): Promise<ZkSyncArtifact> {
         return await loadArtifact(this._hre, contractNameOrFullyQualifiedName);
@@ -36,6 +29,7 @@ export class DeployerExtension implements AbstractDeployer {
     public async deploy(
         contractNameOrArtifact: ZkSyncArtifact | string,
         constructorArguments: any[] = [],
+        deploymentType?: zk.types.DeploymentType,
         overrides?: ethers.Overrides,
         additionalFactoryDeps?: ethers.BytesLike[],
     ): Promise<zk.Contract> {
@@ -48,7 +42,7 @@ export class DeployerExtension implements AbstractDeployer {
             contractNameOrArtifact,
             constructorArguments,
             this.wallet,
-            this._deploymentType,
+            deploymentType,
             overrides,
             additionalFactoryDeps,
         );
@@ -62,12 +56,16 @@ export class DeployerExtension implements AbstractDeployer {
         return await estimateDeployFee(this._hre, artifact, constructorArguments, this.wallet);
     }
 
-    public async estimateDeployGas(artifact: ZkSyncArtifact, constructorArguments: any[]): Promise<bigint> {
+    public async estimateDeployGas(
+        artifact: ZkSyncArtifact,
+        constructorArguments: any[],
+        deploymentType?: zk.types.DeploymentType,
+    ): Promise<bigint> {
         if (!this.wallet) {
             this.wallet = await this.getWallet();
         }
 
-        return await estimateDeployGas(this._hre, artifact, constructorArguments, this.wallet, this._deploymentType);
+        return await estimateDeployGas(this._hre, artifact, constructorArguments, this.wallet, deploymentType);
     }
 
     public setWallet(wallet: zk.Wallet): void {

--- a/packages/hardhat-zksync-deploy/src/deployer.ts
+++ b/packages/hardhat-zksync-deploy/src/deployer.ts
@@ -19,15 +19,11 @@ import { AbstractDeployer } from './abstract-deployer';
 export class Deployer implements AbstractDeployer {
     public ethWallet: ethers.Wallet;
     public zkWallet: zk.Wallet;
-    public deploymentType?: zk.types.DeploymentType;
 
     constructor(
         private _hre: HardhatRuntimeEnvironment,
         zkWallet: zk.Wallet,
-        deploymentType?: zk.types.DeploymentType,
     ) {
-        this.deploymentType = deploymentType;
-
         // Initalize two providers: one for the Ethereum RPC (layer 1), and one for the zkSync RPC (layer 2).
         const { ethWeb3Provider, zkWeb3Provider }: Providers = createProviders(_hre.config.networks, _hre.network);
 
@@ -36,20 +32,20 @@ export class Deployer implements AbstractDeployer {
         this.ethWallet = this.zkWallet.ethWallet();
     }
 
-    public static fromEthWallet(
-        hre: HardhatRuntimeEnvironment,
-        ethWallet: ethers.Wallet,
-        deploymentType?: zk.types.DeploymentType,
-    ) {
-        return new Deployer(hre, new zk.Wallet(ethWallet.privateKey), deploymentType);
+    public static fromEthWallet(hre: HardhatRuntimeEnvironment, ethWallet: ethers.Wallet) {
+        return new Deployer(hre, new zk.Wallet(ethWallet.privateKey));
     }
 
     public async estimateDeployFee(artifact: ZkSyncArtifact, constructorArguments: any[]): Promise<bigint> {
         return await estimateDeployFee(this._hre, artifact, constructorArguments, this.zkWallet);
     }
 
-    public async estimateDeployGas(artifact: ZkSyncArtifact, constructorArguments: any[]): Promise<bigint> {
-        return await estimateDeployGas(this._hre, artifact, constructorArguments, this.zkWallet, this.deploymentType);
+    public async estimateDeployGas(
+        artifact: ZkSyncArtifact,
+        constructorArguments: any[],
+        deploymentType?: zk.types.DeploymentType,
+    ): Promise<bigint> {
+        return await estimateDeployGas(this._hre, artifact, constructorArguments, this.zkWallet, deploymentType);
     }
 
     public async loadArtifact(contractNameOrFullyQualifiedName: string): Promise<ZkSyncArtifact> {
@@ -59,6 +55,7 @@ export class Deployer implements AbstractDeployer {
     public async deploy(
         contractNameOrArtifact: ZkSyncArtifact | string,
         constructorArguments: any[] = [],
+        deploymentType?: zk.types.DeploymentType,
         overrides?: ethers.Overrides,
         additionalFactoryDeps?: ethers.BytesLike[],
     ): Promise<zk.Contract> {
@@ -67,7 +64,7 @@ export class Deployer implements AbstractDeployer {
             contractNameOrArtifact,
             constructorArguments,
             this.zkWallet,
-            this.deploymentType,
+            deploymentType,
             overrides,
             additionalFactoryDeps,
         );

--- a/packages/hardhat-zksync-deploy/src/index.ts
+++ b/packages/hardhat-zksync-deploy/src/index.ts
@@ -67,6 +67,7 @@ task(TASK_DEPLOY_ZKSYNC_CONTRACT, 'Runs the deploy scripts for zkSync network')
         types.inputFile,
     )
     .addOptionalParam('deploymentType', 'Type of deployment', undefined)
+    .addOptionalParam('salt', 'Type of deployment', undefined)
     .addFlag('noCompile', 'Flag to disable auto compilation')
     .setAction(deployZkSyncContract);
 

--- a/packages/hardhat-zksync-deploy/src/plugin.ts
+++ b/packages/hardhat-zksync-deploy/src/plugin.ts
@@ -189,6 +189,7 @@ export async function deployContract(
         constructorArgsParams: any[];
         constructorArgs?: string;
         deploymentType?: DeploymentType;
+        salt?: string;
         noCompile?: boolean;
     },
 ): Promise<Contract> {
@@ -201,8 +202,16 @@ export async function deployContract(
         taskArgs.constructorArgs,
     );
 
-    hre.deployer.setDeploymentType(taskArgs.deploymentType ?? 'create');
-    const contract: Contract = await hre.deployer.deploy(taskArgs.contractName, constructorArguments);
+    const contract: Contract = await hre.deployer.deploy(
+        taskArgs.contractName,
+        constructorArguments,
+        taskArgs.deploymentType,
+        {
+            customData: {
+                salt: taskArgs.salt,
+            },
+        },
+    );
     console.log(chalk.green(`Contract ${taskArgs.contractName} deployed at ${await contract.getAddress()}`));
     return contract;
 }

--- a/packages/hardhat-zksync-deploy/test/tests/plugin.test.ts
+++ b/packages/hardhat-zksync-deploy/test/tests/plugin.test.ts
@@ -278,7 +278,6 @@ describe('deployWithContract', () => {
                     getAddress: async () => '0x1234567890123456789012345678901234567890',
                     abi: [],
                 }),
-                setDeploymentType: sandbox.stub().resolves(),
             },
             run: sandbox.stub(),
         } as any;
@@ -299,7 +298,6 @@ describe('deployWithContract', () => {
         await deployContract(hre, taskArgs);
 
         expect(hre.deployer.deploy).to.have.been.callCount(1);
-        expect(hre.deployer.setDeploymentType).to.have.been.callCount(1);
         expect(hre.run).to.have.been.callCount(1);
     });
 
@@ -308,6 +306,5 @@ describe('deployWithContract', () => {
         await deployContract(hre, taskArgs);
         expect(hre.run).to.have.been.callCount(0);
         expect(hre.deployer.deploy).to.have.been.callCount(1);
-        expect(hre.deployer.setDeploymentType).to.have.been.callCount(1);
     });
 });


### PR DESCRIPTION
# What :computer: 
* Set deployment type per each deployment and not per per deployer object

# Why :hand:
* User can change deployment type per each deployment and don't need to set new deployment type in deployer object or create a new deployer to use a new deployment type.