### PR TITLE
feat: switch to the default codegen with zksync solc

### DIFF
--- a/examples/basic-example/hardhat.config.ts
+++ b/examples/basic-example/hardhat.config.ts
@@ -7,7 +7,7 @@ const config: HardhatUserConfig = {
     zksolc: {
         compilerSource: 'binary',
         settings: {
-            isSystem: true,
+            enableEraVMExtensions: true,
             optimizer: {
                 enabled: true,
             },

--- a/examples/basic-example/package.json
+++ b/examples/basic-example/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "chalk": "^4.1.2",
     "hardhat": "^2.14.0",
     "ethers": "~5.7.2",

--- a/examples/deploy-example/package.json
+++ b/examples/deploy-example/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "chalk": "^4.1.2",
     "hardhat": "^2.14.0",
     "ethers": "~5.7.2",

--- a/examples/mixed-example/package.json
+++ b/examples/mixed-example/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "@matterlabs/hardhat-zksync-vyper": "^1.0.8",
     "@nomiclabs/hardhat-vyper": "^3.0.5",
     "ethers": "~5.7.2",

--- a/examples/node-example/hardhat.config.ts
+++ b/examples/node-example/hardhat.config.ts
@@ -8,7 +8,7 @@ const config: HardhatUserConfig = {
     zksolc: {
         compilerSource: 'binary',
         settings: {
-            isSystem: true,
+            enableEraVMExtensions: true,
             optimizer: {
                 enabled: true,
             },

--- a/examples/node-example/package.json
+++ b/examples/node-example/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "@matterlabs/hardhat-zksync-node": "workspace:^",
     "@matterlabs/hardhat-zksync-chai-matchers": "workspace:^",
     "chalk": "^4.1.2",

--- a/examples/noninline-libraries-example/package.json
+++ b/examples/noninline-libraries-example/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
       "@matterlabs/hardhat-zksync-deploy": "workspace:^",
-      "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+      "@matterlabs/hardhat-zksync-solc": "^1.2.0",
       "chalk": "^4.1.2",
       "hardhat": "^2.14.0",
       "ethers": "~5.7.2",

--- a/examples/upgradable-example/package.json
+++ b/examples/upgradable-example/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "@matterlabs/hardhat-zksync-upgradable": "workspace:^",
     "@openzeppelin/contracts-upgradeable": "^4.9.2",
     "zksync": "^0.13.1",

--- a/examples/verify-example/hardhat.config.ts
+++ b/examples/verify-example/hardhat.config.ts
@@ -11,7 +11,7 @@ const config: HardhatUserConfig = {
         compilerSource: 'binary',
         version: '1.3.16',
         settings: {
-            isSystem: true,
+            enableEraVMExtensions: true,
             optimizer: {
                 enabled: true,
             },

--- a/examples/verify-example/package.json
+++ b/examples/verify-example/package.json
@@ -30,7 +30,7 @@
     "typescript": "^5.3.0"
   },
   "dependencies": {
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
     "@matterlabs/hardhat-zksync-verify": "workspace:^",
     "chalk": "^4.1.2",

--- a/packages/hardhat-zksync-chai-matchers/package.json
+++ b/packages/hardhat-zksync-chai-matchers/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.1.2",
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.2",
     "ordinal": "^1.0.3",

--- a/packages/hardhat-zksync-deploy/package.json
+++ b/packages/hardhat-zksync-deploy/package.json
@@ -33,7 +33,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@matterlabs/hardhat-zksync-solc": "^1.0.5",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "chalk": "^4.1.2",
     "ts-morph": "^22.0.0",
     "chai": "^4.3.4",

--- a/packages/hardhat-zksync-deploy/test/fixture-projects/plugin-functionalities/hardhat.config.ts
+++ b/packages/hardhat-zksync-deploy/test/fixture-projects/plugin-functionalities/hardhat.config.ts
@@ -7,7 +7,7 @@ const config: HardhatUserConfig = {
     zksolc: {
         compilerSource: 'binary',
         settings: {
-            isSystem: true,
+            enableEraVMExtensions: true,
             optimizer: {
                 enabled: true,
             },

--- a/packages/hardhat-zksync-node/package.json
+++ b/packages/hardhat-zksync-node/package.json
@@ -33,7 +33,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "axios": "^1.7.2",
     "chalk": "^4.1.2",
     "fs-extra": "^11.2.0",

--- a/packages/hardhat-zksync-upgradable/package.json
+++ b/packages/hardhat-zksync-upgradable/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "@openzeppelin/upgrades-core": "~1.29.0",
     "chalk": "^4.1.2",
     "fs-extra": "^11.2.0",

--- a/packages/hardhat-zksync-verify/package.json
+++ b/packages/hardhat-zksync-verify/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/address": "5.7.0",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "@nomicfoundation/hardhat-verify": "^2.0.8",
     "@openzeppelin/contracts": "^4.9.2",
     "axios": "^1.7.2",

--- a/packages/hardhat-zksync-verify/src/plugin.ts
+++ b/packages/hardhat-zksync-verify/src/plugin.ts
@@ -1,13 +1,12 @@
 import {
     TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
-    TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES,
-    TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS,
     TASK_FLATTEN_GET_FLATTENED_SOURCE,
 } from 'hardhat/builtin-tasks/task-names';
 import { Artifacts, CompilerInput, DependencyGraph, HardhatRuntimeEnvironment, ResolvedFile } from 'hardhat/types';
 import { isFullyQualifiedName, parseFullyQualifiedName } from 'hardhat/utils/contract-names';
 import path from 'path';
 import chalk from 'chalk';
+import { isBreakableCompilerVersion } from '@matterlabs/hardhat-zksync-solc/dist/src/utils';
 import { CONTRACT_NAME_NOT_FOUND, NO_MATCHING_CONTRACT, LIBRARIES_EXPORT_ERROR } from './constants';
 import { Bytecode, extractMatchingContractInformation } from './solc/bytecode';
 import { ZkSyncVerifyPluginError } from './errors';
@@ -78,14 +77,8 @@ export async function getMinimalResolvedFiles(
     hre: HardhatRuntimeEnvironment,
     sourceName: string,
 ): Promise<ResolvedFile[]> {
-    hre.config.zksolc.settings.contractsToCompile = [sourceName];
-    const sourcePaths = await hre.run(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS, { sourcePath: hre.config.paths.sources });
-    const sourceNames = await hre.run(TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES, {
-        rootPath: hre.config.paths.root,
-        sourcePaths,
-    });
     const dependencyGraph: DependencyGraph = await hre.run(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH, {
-        sourceNames,
+        sourceNames: [sourceName],
     });
 
     return dependencyGraph.getResolvedFiles();
@@ -96,17 +89,25 @@ export function getSolidityStandardJsonInput(
     resolvedFiles: ResolvedFile[],
     input: CompilerInput,
 ): any {
-    return {
+    const standardInput = {
         language: input.language,
         sources: Object.fromEntries(
             resolvedFiles.map((file) => [file.sourceName, { content: file.content.rawContent }]),
         ),
-        settings: {
-            ...input.settings,
-            isSystem: hre.config.zksolc.settings.isSystem ?? false,
-            forceEvmla: hre.config.zksolc.settings.forceEvmla ?? false,
-        },
+        settings: {},
     };
+
+    standardInput.settings = !isBreakableCompilerVersion(hre.config.zksolc.version)
+        ? {
+              ...input.settings,
+              isSystem: hre.config.zksolc.settings.enableEraVMExtensions ?? false,
+              forceEvmla: hre.config.zksolc.settings.forceEVMLA ?? false,
+          }
+        : {
+              ...input.settings,
+          };
+
+    return standardInput;
 }
 
 export async function getLibraries(librariesModule: string) {

--- a/packages/hardhat-zksync-verify/src/utils.ts
+++ b/packages/hardhat-zksync-verify/src/utils.ts
@@ -129,6 +129,8 @@ export function getZkVmNormalizedVersion(solcVersion: string, zkVmSolcVersion: s
 
 export function normalizeCompilerVersions(
     solcConfigData: SolcConfigData,
+    zkSolcConfig: any,
+    latestEraVersion: string,
     userConfigCompilers: SolcUserConfig[] | Map<string, SolcUserConfig>,
 ): string | undefined {
     const noramlizers: SolcUserConfigNormalizer[] = [
@@ -139,5 +141,5 @@ export function normalizeCompilerVersions(
     const compiler = solcConfigData.compiler;
     return noramlizers
         .find((normalize) => normalize.suituble(userConfigCompilers, solcConfigData.file))
-        ?.normalize(compiler, userConfigCompilers, solcConfigData.file);
+        ?.normalize(compiler, zkSolcConfig, latestEraVersion, userConfigCompilers, solcConfigData.file);
 }

--- a/packages/hardhat-zksync-verify/test/tests/config-normalizer.test.ts
+++ b/packages/hardhat-zksync-verify/test/tests/config-normalizer.test.ts
@@ -46,6 +46,10 @@ describe('CompilerSolcUserConfigNormalizer', () => {
                 version: '0.8.17',
                 settings: {},
             };
+            const zkSolcConfig = {
+                version: '1.3.21',
+                settings: {},
+            };
             const userConfigCompilers: SolcUserConfig[] = [
                 {
                     version: '0.8.17',
@@ -54,7 +58,7 @@ describe('CompilerSolcUserConfigNormalizer', () => {
             ];
             const file = undefined;
 
-            const result = normalizer.normalize(compiler, userConfigCompilers, file);
+            const result = normalizer.normalize(compiler, zkSolcConfig, '1.0.0', userConfigCompilers, file);
 
             expect(result).to.equal('zkVM-0.8.17-0.1.0');
         });
@@ -65,10 +69,14 @@ describe('CompilerSolcUserConfigNormalizer', () => {
                 version: '0.8.17',
                 settings: {},
             };
+            const zkSolcConfig = {
+                version: '1.3.21',
+                settings: {},
+            };
             const userConfigCompilers: SolcUserConfig[] = [];
             const file = undefined;
 
-            const result = normalizer.normalize(compiler, userConfigCompilers, file);
+            const result = normalizer.normalize(compiler, zkSolcConfig, '1.0.0', userConfigCompilers, file);
 
             expect(result).to.equal('0.8.17');
         });
@@ -77,6 +85,10 @@ describe('CompilerSolcUserConfigNormalizer', () => {
             const normalizer = new CompilerSolcUserConfigNormalizer();
             const compiler: SolcConfig = {
                 version: '0.8.17',
+                settings: {},
+            };
+            const zkSolcConfig = {
+                version: '1.3.21',
                 settings: {},
             };
             const userConfigCompilers: SolcUserConfig[] = [
@@ -91,7 +103,7 @@ describe('CompilerSolcUserConfigNormalizer', () => {
             const file = undefined;
 
             try {
-                normalizer.normalize(compiler, userConfigCompilers, file);
+                normalizer.normalize(compiler, zkSolcConfig, '1.0.0', userConfigCompilers, file);
                 fail('Expected an error to be thrown');
             } catch (error: any) {
                 expect(error.message).to.equal(
@@ -142,12 +154,16 @@ describe('OverrideCompilerSolcUserConfigNormalizer', () => {
                 version: '0.8.17',
                 settings: {},
             };
+            const zkSolcConfig = {
+                version: '1.3.21',
+                settings: {},
+            };
             const userConfigCompilers: Map<string, SolcUserConfig> = new Map([
                 ['path/to/file.sol', { version: '0.8.17', eraVersion: '0.1.0' }],
             ]);
             const file = 'path/to/file.sol';
 
-            const result = normalizer.normalize(compiler, userConfigCompilers, file);
+            const result = normalizer.normalize(compiler, zkSolcConfig, '1.0.0', userConfigCompilers, file);
 
             expect(result).to.equal('zkVM-0.8.17-0.1.0');
         });
@@ -158,12 +174,16 @@ describe('OverrideCompilerSolcUserConfigNormalizer', () => {
                 version: '0.8.17',
                 settings: {},
             };
+            const zkSolcConfig = {
+                version: '1.5.0',
+                settings: {},
+            };
             const userConfigCompilers: Map<string, SolcUserConfig> = new Map();
             const file = 'path/to/file.sol';
 
-            const result = normalizer.normalize(compiler, userConfigCompilers, file);
+            const result = normalizer.normalize(compiler, zkSolcConfig, '1.0.0', userConfigCompilers, file);
 
-            expect(result).to.equal('0.8.17');
+            expect(result).to.equal('zkVM-0.8.17-1.0.0');
         });
     });
 });

--- a/packages/hardhat-zksync-verify/test/tests/plugin.test.ts
+++ b/packages/hardhat-zksync-verify/test/tests/plugin.test.ts
@@ -263,6 +263,7 @@ Instead, this name was received: ${contractFQN}`);
             const hre = {
                 config: {
                     zksolc: {
+                        version: '1.4.0',
                         settings: {},
                     },
                 },
@@ -283,6 +284,7 @@ Instead, this name was received: ${contractFQN}`);
             const hre = {
                 config: {
                     zksolc: {
+                        version: '1.4.0',
                         settings: {},
                     },
                 },
@@ -296,8 +298,9 @@ Instead, this name was received: ${contractFQN}`);
             const hre1 = {
                 config: {
                     zksolc: {
+                        version: '1.4.0',
                         settings: {
-                            isSystem: true,
+                            enableEraVMExtensions: true,
                         },
                     },
                 },
@@ -310,8 +313,9 @@ Instead, this name was received: ${contractFQN}`);
             const hre2 = {
                 config: {
                     zksolc: {
+                        version: '1.4.0',
                         settings: {
-                            forceEvmla: true,
+                            forceEVMLA: true,
                         },
                     },
                 },
@@ -324,9 +328,10 @@ Instead, this name was received: ${contractFQN}`);
             const hre3 = {
                 config: {
                     zksolc: {
+                        version: '1.4.0',
                         settings: {
-                            isSystem: true,
-                            forceEvmla: true,
+                            enableEraVMExtensions: true,
+                            forceEVMLA: true,
                         },
                     },
                 },

--- a/packages/hardhat-zksync-verify/test/tests/task-actions.test.ts
+++ b/packages/hardhat-zksync-verify/test/tests/task-actions.test.ts
@@ -1,12 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { fail } from 'assert';
-import {
-    TASK_COMPILE,
-    TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
-    TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES,
-    TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS,
-} from 'hardhat/builtin-tasks/task-names';
+import { TASK_COMPILE, TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH } from 'hardhat/builtin-tasks/task-names';
 import {
     getCompilerVersions,
     getConstructorArguments,
@@ -194,10 +189,6 @@ describe('verifyContract', async function () {
                     solcVersion: '0.8.0',
                 })
                 .onCall(3)
-                .resolves(['contracts/'])
-                .onCall(4)
-                .resolves(['contracts/Contract.sol'])
-                .onCall(5)
                 .resolves({
                     getResolvedFiles: sinon.stub().resolves(),
                 }),
@@ -208,10 +199,8 @@ describe('verifyContract', async function () {
         expect(hre.run.firstCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
         expect(hre.run.secondCall.args[0]).to.equal(TASK_COMPILE);
         expect(hre.run.thirdCall.args[0]).to.equal(TASK_VERIFY_GET_CONTRACT_INFORMATION);
-        expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS);
-        expect(hre.run.getCall(4).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES);
-        expect(hre.run.getCall(5).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
-        expect(hre.run.getCall(6).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
+        expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
+        expect(hre.run.getCall(4).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
     });
 
     it('should call fallback request sent if there is compilation error', async function () {
@@ -299,16 +288,12 @@ describe('verifyContract', async function () {
                     solcVersion: '0.8.0',
                 })
                 .onCall(3)
-                .resolves(['contracts/'])
-                .onCall(4)
-                .resolves(['contracts/Contract.sol'])
-                .onCall(5)
                 .resolves({
                     getResolvedFiles: sinon.stub().resolves(),
                 })
-                .onCall(6)
+                .onCall(4)
                 .throwsException(new ZkSyncVerifyPluginError(errorMessage))
-                .onCall(7)
+                .onCall(5)
                 .resolves(true),
         };
 
@@ -317,11 +302,9 @@ describe('verifyContract', async function () {
         expect(hre.run.firstCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
         expect(hre.run.secondCall.args[0]).to.equal(TASK_COMPILE);
         expect(hre.run.thirdCall.args[0]).to.equal(TASK_VERIFY_GET_CONTRACT_INFORMATION);
-        expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS);
-        expect(hre.run.getCall(4).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES);
-        expect(hre.run.getCall(5).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
-        expect(hre.run.getCall(6).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
-        expect(hre.run.getCall(7).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
+        expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
+        expect(hre.run.getCall(4).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
+        expect(hre.run.getCall(5).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
     });
 
     it('should call fallback request sent if there is missing source file', async function () {
@@ -408,16 +391,12 @@ describe('verifyContract', async function () {
                     solcVersion: '0.8.0',
                 })
                 .onCall(3)
-                .resolves(['contracts/'])
-                .onCall(4)
-                .resolves(['contracts/Contract.sol'])
-                .onCall(5)
                 .resolves({
                     getResolvedFiles: sinon.stub().resolves(),
                 })
-                .onCall(6)
+                .onCall(4)
                 .throwsException(new ZkSyncVerifyPluginError(errorMessage))
-                .onCall(7)
+                .onCall(5)
                 .resolves(true),
         };
 
@@ -426,11 +405,9 @@ describe('verifyContract', async function () {
         expect(hre.run.firstCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
         expect(hre.run.secondCall.args[0]).to.equal(TASK_COMPILE);
         expect(hre.run.thirdCall.args[0]).to.equal(TASK_VERIFY_GET_CONTRACT_INFORMATION);
-        expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS);
-        expect(hre.run.getCall(4).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES);
-        expect(hre.run.getCall(5).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
-        expect(hre.run.getCall(6).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
-        expect(hre.run.getCall(7).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
+        expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
+        expect(hre.run.getCall(4).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
+        expect(hre.run.getCall(5).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
     });
 
     it('should call fallback request sent if there is missing contract file', async function () {
@@ -518,16 +495,12 @@ describe('verifyContract', async function () {
                     solcVersion: '0.8.0',
                 })
                 .onCall(3)
-                .resolves(['contracts/'])
-                .onCall(4)
-                .resolves(['contracts/Contract.sol'])
-                .onCall(5)
                 .resolves({
                     getResolvedFiles: sinon.stub().resolves(),
                 })
-                .onCall(6)
+                .onCall(4)
                 .throwsException(new ZkSyncVerifyPluginError(errorMessage))
-                .onCall(7)
+                .onCall(5)
                 .resolves(true),
         };
 
@@ -537,11 +510,9 @@ describe('verifyContract', async function () {
         expect(hre.run.firstCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
         expect(hre.run.secondCall.args[0]).to.equal(TASK_COMPILE);
         expect(hre.run.thirdCall.args[0]).to.equal(TASK_VERIFY_GET_CONTRACT_INFORMATION);
-        expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS);
-        expect(hre.run.getCall(4).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES);
-        expect(hre.run.getCall(5).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
-        expect(hre.run.getCall(6).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
-        expect(hre.run.getCall(7).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
+        expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
+        expect(hre.run.getCall(4).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
+        expect(hre.run.getCall(5).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
     });
 });
 describe('getCompilerVersions', async function () {
@@ -571,6 +542,9 @@ describe('getCompilerVersions', async function () {
                 zksync: true,
             },
             config: {
+                zksolc: {
+                    version: 'latest',
+                },
                 solidity: {
                     compilers: [{ version: '0.8.0' }, { version: '0.7.0' }],
                     overrides: {
@@ -590,7 +564,7 @@ describe('getCompilerVersions', async function () {
         };
 
         const result = await getCompilerVersions({}, hre as any, runSuperStub as any);
-        expect(result).to.deep.equal(['0.8.0', '0.7.0', '0.6.0']);
+        expect(result).to.deep.equal(['zkVM-0.8.0-1.0.1', 'zkVM-0.7.0-1.0.1', 'zkVM-0.6.0-1.0.1']);
         expect(runSuperStub.called).to.equal(false);
     });
 });
@@ -603,6 +577,11 @@ describe('verify', async function () {
     it('should call runSuper if zksync is false', async function () {
         const runSuperStub = sinon.stub().resolves(0);
         const hre = {
+            config: {
+                zksolc: {
+                    version: 'latest',
+                },
+            },
             network: {
                 zksync: false,
                 verifyURL: 'http://localhost:3000/verify',

--- a/packages/hardhat-zksync/package.json
+++ b/packages/hardhat-zksync/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "@matterlabs/hardhat-zksync-verify": "workspace:^",
     "@matterlabs/hardhat-zksync-upgradable": "workspace:^",
     "@matterlabs/hardhat-zksync-node": "workspace:^",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.0",
     "@matterlabs/hardhat-zksync-verify": "workspace:^",
     "@matterlabs/hardhat-zksync-upgradable": "workspace:^",
     "@matterlabs/hardhat-zksync-node": "workspace:^"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/hardhat-zksync-deploy
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@matterlabs/zksync-contracts':
         specifier: ^0.6.1
         version: 0.6.1(@openzeppelin/contracts-upgradeable@4.9.6)(@openzeppelin/contracts@4.9.6)
@@ -103,8 +103,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/hardhat-zksync-deploy
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -161,8 +161,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/hardhat-zksync-deploy
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@matterlabs/hardhat-zksync-vyper':
         specifier: ^1.0.8
         version: 1.0.8(@nomiclabs/hardhat-vyper@3.0.6(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)))(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
@@ -228,8 +228,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/hardhat-zksync-node
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@matterlabs/zksync-contracts':
         specifier: ^0.6.1
         version: 0.6.1(@openzeppelin/contracts-upgradeable@4.9.6)(@openzeppelin/contracts@4.9.6)
@@ -307,8 +307,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/hardhat-zksync-deploy
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@matterlabs/zksync-contracts':
         specifier: ^0.6.1
         version: 0.6.1(@openzeppelin/contracts-upgradeable@4.9.6)(@openzeppelin/contracts@4.9.6)
@@ -374,8 +374,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/hardhat-zksync-deploy
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@matterlabs/hardhat-zksync-upgradable':
         specifier: workspace:^
         version: link:../../packages/hardhat-zksync-upgradable
@@ -441,8 +441,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/hardhat-zksync-deploy
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@matterlabs/hardhat-zksync-verify':
         specifier: workspace:^
         version: link:../../packages/hardhat-zksync-verify
@@ -569,8 +569,8 @@ importers:
         specifier: workspace:^
         version: link:../hardhat-zksync-node
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@matterlabs/hardhat-zksync-upgradable':
         specifier: workspace:^
         version: link:../hardhat-zksync-upgradable
@@ -675,8 +675,8 @@ importers:
         specifier: workspace:^
         version: link:../hardhat-zksync-deploy
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       chai:
         specifier: ^4.3.4
         version: 4.4.1
@@ -757,8 +757,8 @@ importers:
   packages/hardhat-zksync-deploy:
     dependencies:
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.0.5
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       chai:
         specifier: ^4.3.4
         version: 4.4.1
@@ -851,8 +851,8 @@ importers:
   packages/hardhat-zksync-node:
     dependencies:
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       axios:
         specifier: ^1.7.2
         version: 1.7.2(debug@4.3.5)
@@ -954,8 +954,8 @@ importers:
         specifier: workspace:^
         version: link:../hardhat-zksync-deploy
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@openzeppelin/upgrades-core':
         specifier: ~1.29.0
         version: 1.29.0
@@ -1051,8 +1051,8 @@ importers:
         specifier: 5.7.0
         version: 5.7.0
       '@matterlabs/hardhat-zksync-solc':
-        specifier: ^1.1.4
-        version: 1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
+        specifier: ^1.2.0
+        version: 1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@nomicfoundation/hardhat-verify':
         specifier: ^2.0.8
         version: 2.0.8(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
@@ -1480,10 +1480,10 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==, tarball: https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz}
 
-  '@matterlabs/hardhat-zksync-solc@1.1.4':
-    resolution: {integrity: sha512-4/usbogh9neewR2/v8Dn2OzqVblZMUuT/iH2MyPZgPRZYQlL4SlZtMvokU9UQjZT6iSoaKCbbdWESHDHSzfUjA==, tarball: https://registry.npmjs.org/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-1.1.4.tgz}
+  '@matterlabs/hardhat-zksync-solc@1.2.0':
+    resolution: {integrity: sha512-zM3LY6jeCVfFe2MZfiK/6k8GUcxk9BcCBiNs1Ywh4PZ4OaabYOP3HuFFmVo89BFisIRROnQ+IyT9fayKKVbFCg==, tarball: https://registry.npmjs.org/@matterlabs/hardhat-zksync-solc/-/hardhat-zksync-solc-1.2.0.tgz}
     peerDependencies:
-      hardhat: ^2.19.4
+      hardhat: ^2.22.5
 
   '@matterlabs/hardhat-zksync-vyper@1.0.8':
     resolution: {integrity: sha512-XR7rbfDuBG5/LZWYfhQTP9gD+U24hSJHDuZ9U55wgIfiQTOxPoztFwEbQNiC39vjT5MjP/Nv8/IDrlEBkaVCgw==, tarball: https://registry.npmjs.org/@matterlabs/hardhat-zksync-vyper/-/hardhat-zksync-vyper-1.0.8.tgz}
@@ -5029,7 +5029,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@matterlabs/hardhat-zksync-solc@1.1.4(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))':
+  '@matterlabs/hardhat-zksync-solc@1.2.0(hardhat@2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))':
     dependencies:
       '@nomiclabs/hardhat-docker': 2.0.2
       chai: 4.4.1
@@ -5040,9 +5040,9 @@ snapshots:
       hardhat: 2.14.0(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.36)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)
       proper-lockfile: 4.1.2
       semver: 7.6.2
-      sinon: 17.0.2
-      sinon-chai: 3.7.0(chai@4.4.1)(sinon@17.0.2)
-      undici: 5.28.4
+      sinon: 18.0.0
+      sinon-chai: 3.7.0(chai@4.4.1)(sinon@18.0.0)
+      undici: 6.19.2
     transitivePeerDependencies:
       - encoding
       - supports-color


### PR DESCRIPTION
# What :computer: 
* Switches to the default codegen with the zksolc for ethers v5

# Why :hand:
* These changes with new version 1.5.0 of zksolc will affect a plugin where arguments will be sent from standard json input.