### PR TITLE
fix: estimateGas support for custom chains

### DIFF
--- a/packages/hardhat-zksync-upgradable/src/constants.ts
+++ b/packages/hardhat-zksync-upgradable/src/constants.ts
@@ -46,14 +46,3 @@ export const verifiableContracts = {
     transparentUpgradeableProxy: { event: 'AdminChanged(address,address)' },
     proxyAdmin: { event: 'OwnershipTransferred(address,address)' },
 };
-
-export const defaultImplAddresses: { [chainId in number]: { contractAddress: string; beacon: string } } = {
-    324: {
-        contractAddress: '0x71CF3E1430aA920903CeF2154202902dDbBE2c98',
-        beacon: '0x3DbAe90affFFAC8d20285f2f53e3f2e10368c11C',
-    },
-    280: {
-        contractAddress: '0xCFFF2D44a3d3361f86Aa9EA5c563B95FAcA7be8c',
-        beacon: '0x713499530cCAc7a09FecFf05C3a1d4413E4CCd12',
-    },
-};

--- a/packages/hardhat-zksync-upgradable/src/gas-estimation/estimate-gas-beacon.ts
+++ b/packages/hardhat-zksync-upgradable/src/gas-estimation/estimate-gas-beacon.ts
@@ -1,5 +1,4 @@
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
-import * as zk from 'zksync-ethers';
 import * as ethers from 'ethers';
 import chalk from 'chalk';
 import assert from 'assert';
@@ -9,11 +8,10 @@ import { Deployer } from '@matterlabs/hardhat-zksync-deploy';
 import { DeployProxyOptions } from '../utils/options';
 import { ZkSyncUpgradablePluginError } from '../errors';
 import { convertGasPriceToEth, getInitializerData } from '../utils/utils-general';
-import { UPGRADABLE_BEACON_JSON, defaultImplAddresses } from '../constants';
+import { UPGRADABLE_BEACON_JSON } from '../constants';
 
-import { getAdminArtifact, getAdminFactory } from '../proxy-deployment/deploy-proxy-admin';
+import { getAdminArtifact } from '../proxy-deployment/deploy-proxy-admin';
 import { getChainId } from '../core/provider';
-import { deploy } from '../proxy-deployment/deploy';
 
 export type EstimateGasFunction = (
     deployer: Deployer,
@@ -22,26 +20,6 @@ export type EstimateGasFunction = (
     opts?: DeployProxyOptions,
     quiet?: boolean,
 ) => Promise<bigint>;
-
-async function deployProxyAdminLocally(adminFactory: zk.ContractFactory) {
-    const mockContract = await deploy(adminFactory);
-    return mockContract.address;
-}
-
-async function deployBeaconLocally(impl: string, hre: HardhatRuntimeEnvironment, wallet: zk.Wallet) {
-    const upgradableBeaconPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
-        x.includes(path.sep + UPGRADABLE_BEACON_JSON),
-    );
-    assert(upgradableBeaconPath, 'Upgradable beacon artifact not found');
-    const upgradeableBeaconContract = await import(upgradableBeaconPath);
-
-    const upgradeableBeaconFactory = new zk.ContractFactory(
-        upgradeableBeaconContract.abi,
-        upgradeableBeaconContract.bytecode,
-        wallet,
-    );
-    return await deploy(upgradeableBeaconFactory, impl);
-}
 
 export async function getMockedBeaconData(
     deployer: Deployer,
@@ -55,22 +33,22 @@ export async function getMockedBeaconData(
         throw new ZkSyncUpgradablePluginError(`Chain id ${chainId} is not supported!`);
     }
 
-    let mockedBeaconAddress: string;
-    let mockImplAddress: string;
-    let data: string;
-
-    if (chainId === 270) {
-        const adminFactory = await getAdminFactory(hre, deployer.zkWallet);
-        mockImplAddress = await deployProxyAdminLocally(adminFactory);
-        mockedBeaconAddress = (await deployBeaconLocally(mockImplAddress, hre, deployer.zkWallet)).address;
-        data = getInitializerData(adminFactory.interface, args, opts.initializer);
-    } else {
-        mockedBeaconAddress = defaultImplAddresses[chainId].beacon;
-        const mockArtifact = await getAdminArtifact(hre);
-        data = getInitializerData(new ethers.Interface(mockArtifact.abi), args, opts.initializer);
-    }
+    const mockedBeaconAddress = await getDeployedBeaconAddress(deployer);
+    const mockArtifact = await getAdminArtifact(hre);
+    const data = getInitializerData(new ethers.Interface(mockArtifact.abi), args, opts.initializer);
 
     return { mockedBeaconAddress, data };
+}
+
+async function getDeployedBeaconAddress(deployer: Deployer) {
+    const defaultBridgeAddresses = await deployer.zkWallet.provider.getDefaultBridgeAddresses();
+    const sharedBridgeL2Contract = new ethers.Contract(
+        defaultBridgeAddresses.sharedL2,
+        ['function l2TokenBeacon() public view returns (address)'],
+        deployer.zkWallet.provider,
+    );
+    const beaconAddress = await sharedBridgeL2Contract.l2TokenBeacon();
+    return beaconAddress;
 }
 
 export function makeEstimateGasBeacon(hre: HardhatRuntimeEnvironment): EstimateGasFunction {


### PR DESCRIPTION
# What :computer: 
* estimateGas support for custom chains

# Why :hand:
* Due to the hardcoded contracts for supported chains, users are unable to estimate gas for proxies in the current implementation.