### PR TITLE
fix: estimateGas support for custom chains

### DIFF
--- a/packages/hardhat-zksync-upgradable/src/constants.ts
+++ b/packages/hardhat-zksync-upgradable/src/constants.ts
@@ -46,14 +46,3 @@ export const verifiableContracts = {
     transparentUpgradeableProxy: { event: 'AdminChanged(address,address)' },
     proxyAdmin: { event: 'OwnershipTransferred(address,address)' },
 };
-
-export const defaultImplAddresses: { [chainId in number]: { contractAddress: string; beacon: string } } = {
-    324: {
-        contractAddress: '0x71CF3E1430aA920903CeF2154202902dDbBE2c98',
-        beacon: '0x3DbAe90affFFAC8d20285f2f53e3f2e10368c11C',
-    },
-    280: {
-        contractAddress: '0xCFFF2D44a3d3361f86Aa9EA5c563B95FAcA7be8c',
-        beacon: '0x713499530cCAc7a09FecFf05C3a1d4413E4CCd12',
-    },
-};


### PR DESCRIPTION
# What :computer: 
* estimateGas support for custom chains

# Why :hand:
* Due to the hardcoded contracts for supported chains, users are unable to estimate gas for proxies in the current implementation.