### PR TITLE
fix: compiler path issue with compiler breakable changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Test zksolc example with remote origin
         env:
-          ZKSOLC_PATH: https://github.com/matter-labs/zksolc-bin/releases/download/v1.5.1/zksolc-linux-arm64-musl-v1.5.1
+          ZKSOLC_PATH: https://github.com/matter-labs/zksolc-bin/releases/download/v1.5.1/zksolc-linux-amd64-musl-v1.5.1
         run: |
           cd examples/download-with-compiler-origin
           pnpm hardhat compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,14 @@ jobs:
           pnpm hardhat compile
           pnpm hardhat deploy-zksync
 
+      - name: Test zksolc example with remote origin
+        env:
+          ZKSOLC_PATH: https://github.com/matter-labs/zksolc-bin/releases/download/v1.5.1/zksolc-linux-arm64-musl-v1.5.1
+        run: |
+          cd examples/download-with-compiler-origin
+          pnpm hardhat compile
+          pnpm hardhat deploy-zksync
+
       - name: Test deploy example
         run: |
           cd examples/deploy-example

--- a/examples/download-with-compiler-origin/.eslintrc.js
+++ b/examples/download-with-compiler-origin/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: [`${__dirname}/../../config/eslint/eslintrc.cjs`],
+  parserOptions: {
+    project: `${__dirname}/tsconfig.json`,
+    sourceType: "module",
+  },
+};

--- a/examples/download-with-compiler-origin/.gitignore
+++ b/examples/download-with-compiler-origin/.gitignore
@@ -1,0 +1,4 @@
+cache
+artifacts
+contracts/tmp
+deployments

--- a/examples/download-with-compiler-origin/README.md
+++ b/examples/download-with-compiler-origin/README.md
@@ -1,0 +1,64 @@
+# ZKsync Era deploy environment example
+
+This project demonstrates how to compile and deploy your contracts in ZKsync Era using the Hardhat plugins.
+
+## Prerequisites
+
+- node.js 16.x or later.
+- yarn.
+
+## Configuration
+
+Plugin configuration is located in [`hardhat.config.ts`](./hardhat.config.ts).
+You should only change the ZKsync network configuration.
+
+`hardhat.config.ts` example with ZKsync network configured with the name `ZKsyncNetwork` and `ethNetwork` used as the underlying layer 1 network:
+```ts
+import "@matterlabs/hardhat-zksync-deploy";
+import { HardhatUserConfig } from 'hardhat/types';
+
+const config: HardhatUserConfig = {
+    networks: {
+        ethNetwork: {
+            url: 'http://0.0.0.0:8545',
+        },
+        ZKsyncNetwork: {
+            url: 'http://0.0.0.0:3050',
+            ethNetwork: 'ethNetwork',
+            zksync: true,
+            deployPaths: ['deploy-ZKsync', 'deploy'],
+            accounts: ['0xac1e735be8536c6534bb4f17f06f6afc73b2b5ba84ac2cfb12f7461b20c0bbe3', '0x28a574ab2de8a00364d5dd4b07c4f2f574ef7fcc2a86a197f65abaec836d1959'],
+        },
+    }
+};
+
+export default config;
+```
+
+## Usage
+
+Before using plugins, you need to build them first
+
+```sh
+# Run the following in the *root* of the repo.
+yarn
+yarn build
+```
+Setup your `ZKSOLC_PATH` path inside your `.env` file
+
+After that you should be able to run plugins:
+
+```sh
+# Run the following in `examples/basic-example` folder.
+yarn
+yarn hardhat compile
+yarn hardhat deploy-zksync
+```
+
+- `yarn hardhat compile`: compiles all the contracts in the `contracts` folder.
+- `yarn hardhat deploy-zksync`: runs all the deploy scripts.
+    - To run a specific script, add the `--script` argument, e.g. `--script 002_deploy.ts`.
+    - To run on a specific ZKsync network, use standard hardhat `--network` argument, e.g. `--network ZKsyncNetworkV2`
+    (with `ZKsyncNetwork` network specified in the `hardhat.config` networks section, with the `zksync` flag set to `true` and `ethNetwork` specified).
+
+If you don't specify ZKsync network (`--network`), `local-setup` with <http://localhost:8545> (Ethereum RPC URL) and <http://localhost:3050> (ZKsync RPC URL) will be used.

--- a/examples/download-with-compiler-origin/contracts/Constant.sol
+++ b/examples/download-with-compiler-origin/contracts/Constant.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+contract Constant {
+    uint c = 42;
+    constructor() {}
+
+    function getValue() public view returns (uint) {
+        return c;
+    }
+}

--- a/examples/download-with-compiler-origin/contracts/Foo.sol
+++ b/examples/download-with-compiler-origin/contracts/Foo.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+contract Foo {
+    string public name = "Foo";
+}

--- a/examples/download-with-compiler-origin/contracts/Greeter.sol
+++ b/examples/download-with-compiler-origin/contracts/Greeter.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.7.0;
-pragma abicoder v2;
+pragma solidity ^0.8.0;
 
 contract Greeter {
     string greeting;

--- a/examples/download-with-compiler-origin/deploy/003_deploy.ts
+++ b/examples/download-with-compiler-origin/deploy/003_deploy.ts
@@ -1,0 +1,18 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import chalk from 'chalk';
+
+const deployScript = async function (hre: HardhatRuntimeEnvironment) {
+    console.info(chalk.yellow(`Running deploy script for the Constant contract from deploy folder`));
+
+    // Load the artifact we want to deploy.
+
+    // Deploy this contract. The returned object will be of a `Contract` type, similarly to ones in `ethers`.
+    // This contract has no constructor arguments.
+    const factoryContract = await hre.deployer.deploy('Constant');
+
+    // Show the contract info.
+    const contractAddress = await factoryContract.getAddress();
+    console.info(chalk.green(`Constant was deployed to ${contractAddress}!`));
+};
+
+export default deployScript;

--- a/examples/download-with-compiler-origin/hardhat.config.ts
+++ b/examples/download-with-compiler-origin/hardhat.config.ts
@@ -2,40 +2,42 @@ import '@matterlabs/hardhat-zksync-deploy';
 import '@matterlabs/hardhat-zksync-solc';
 
 import { HardhatUserConfig } from 'hardhat/config';
+require('dotenv').config(); 
 
 const config: HardhatUserConfig = {
     zksolc: {
         compilerSource: 'binary',
         settings: {
+            compilerPath: process.env.ZKSOLC_PATH,
             enableEraVMExtensions: true,
             optimizer: {
                 enabled: true,
             },
         }
     },
-    defaultNetwork:'dockerizedNode',
+    deployerAccounts: {
+        'ZKsyncNetwork': 1
+    },
+    defaultNetwork: "ZKsyncNetwork",
     networks: {
         hardhat: {
             zksync: true,
         },
-        dockerizedNode: {
-            url: "http://0.0.0.0:3050",
-            ethNetwork: "http://0.0.0.0:8545",
+        ethNetwork: {
+            url: 'http://0.0.0.0:8545',
+        },
+        ZKsyncNetwork: {
+            url: 'http://0.0.0.0:3050',
+            ethNetwork: 'ethNetwork',
             zksync: true,
-          },
+            accounts: ['0xac1e735be8536c6534bb4f17f06f6afc73b2b5ba84ac2cfb12f7461b20c0bbe3', '0x28a574ab2de8a00364d5dd4b07c4f2f574ef7fcc2a86a197f65abaec836d1959'],
+        },
     },
     // Docker image only works for solidity ^0.8.0.
     // For earlier versions you need to use binary releases of zksolc.
     solidity: {
-        compilers: [
-            {
-                version: '0.8.17',
-                eraVersion: '1.0.0'
-            },
-            {
-                version: '0.7.6',
-            }
-        ]}
+        version: '0.8.17',
+    },
 };
 
 export default config;

--- a/examples/download-with-compiler-origin/package.json
+++ b/examples/download-with-compiler-origin/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "hardhat-zksync-example-compiler-origin",
+  "version": "0.1.0",
+  "author": "Matter Labs",
+  "license": "MIT",
+  "scripts": {
+    "lint": "pnpm eslint",
+    "prettier:check": "pnpm prettier --check",
+    "lint:fix": "pnpm eslint --fix",
+    "fmt": "pnpm prettier --write",
+    "eslint": "eslint deploy/*.ts",
+    "prettier": "prettier deploy/*.ts",
+    "test": "mocha test/tests.ts --exit",
+    "build": "tsc --build .",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.17",
+    "@typescript-eslint/eslint-plugin": "^7.12.0",
+    "@typescript-eslint/parser": "^7.12.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-no-only-tests": "^3.1.0",
+    "eslint-plugin-prettier": "^5.0.1",
+    "prettier": "3.3.0",
+    "rimraf": "^5.0.7",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.0",
+    "dotenv": "^16.4.5"
+  },
+  "dependencies": {
+    "@matterlabs/hardhat-zksync-deploy": "workspace:^",
+    "@matterlabs/hardhat-zksync-solc": "workspace:^",
+    "chalk": "^4.1.2",
+    "hardhat": "^2.22.5",
+    "ethers": "^6.12.2",
+    "zksync-ethers": "^6.8.0"
+  },
+  "prettier": {
+    "tabWidth": 4,
+    "printWidth": 120,
+    "parser": "typescript",
+    "singleQuote": true,
+    "bracketSpacing": true
+  }
+}

--- a/examples/download-with-compiler-origin/tsconfig.json
+++ b/examples/download-with-compiler-origin/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": [
+    "./hardhat.config.ts",
+    "./scripts",
+    "./test",
+    "typechain/**/*",
+    "deploy/*",
+    "deploy-ZKsync/*"
+  ]
+}

--- a/packages/hardhat-zksync-solc/src/constants.ts
+++ b/packages/hardhat-zksync-solc/src/constants.ts
@@ -10,6 +10,7 @@ export const DETECT_MISSING_LIBRARY_MODE_COMPILER_VERSION = '1.3.14';
 export const USER_AGENT =
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 export const TASK_UPDATE_SOLIDITY_COMPILERS = 'compile:update-solidity-compilers';
+export const TASK_DOWNLOAD_ZKSOLC = 'compile:zksolc:download';
 
 export const ZKSOLC_COMPILER_PATH_VERSION = 'local_or_remote';
 

--- a/packages/hardhat-zksync-solc/src/utils.ts
+++ b/packages/hardhat-zksync-solc/src/utils.ts
@@ -135,7 +135,7 @@ export function updateBreakableCompilerConfig(
 }
 
 export function isBreakableCompilerVersion(zksolcVersion: string): boolean {
-    return semver.gte(zksolcVersion, ZKSOLC_COMPILER_MIN_VERSION_BREAKABLE_CHANGE);
+    return zksolcVersion === 'latest' || semver.gte(zksolcVersion, ZKSOLC_COMPILER_MIN_VERSION_BREAKABLE_CHANGE);
 }
 
 export function zeroxlify(hex: string): string {

--- a/packages/hardhat-zksync-solc/src/utils.ts
+++ b/packages/hardhat-zksync-solc/src/utils.ts
@@ -128,7 +128,11 @@ export function updateBreakableCompilerConfig(
         .find((updater) => updater.suituble(userConfigCompilers, solcConfigData.file))
         ?.update(compiler, latestEraVersion, zksolc, userConfigCompilers, solcConfigData.file);
 
-    if (compiler.eraVersion && semver.lt(zksolc.version, ZKSOLC_COMPILER_VERSION_MIN_VERSION_WITH_ZKVM_COMPILER)) {
+    if (
+        zksolc.version !== 'latest' &&
+        compiler.eraVersion &&
+        semver.lt(zksolc.version, ZKSOLC_COMPILER_VERSION_MIN_VERSION_WITH_ZKVM_COMPILER)
+    ) {
         console.warn(chalk.blue(COMPILER_ZKSOLC_VERSION_WITH_ZKVM_SOLC_WARN));
         compiler.eraVersion = undefined;
     }

--- a/packages/hardhat-zksync-solc/src/utils.ts
+++ b/packages/hardhat-zksync-solc/src/utils.ts
@@ -64,7 +64,7 @@ export function filterSupportedOutputSelections(
     return filteredOutputSelection;
 }
 
-export function updateCompilerConf(solcConfigData: SolcConfigData, zksolc: ZkSolcConfig) {
+export function updateDefaultCompilerConfig(solcConfigData: SolcConfigData, zksolc: ZkSolcConfig) {
     const compiler = solcConfigData.compiler;
 
     const settings = compiler.settings || {};
@@ -83,12 +83,6 @@ export function updateCompilerConf(solcConfigData: SolcConfigData, zksolc: ZkSol
     if (zksolc.settings.forceEvmla !== undefined) {
         console.warn(chalk.blue(COMPILER_ZKSOLC_FORCE_EVMLA_USE));
         delete zksolc.settings.forceEvmla;
-    }
-
-    if (isBreakableCompilerVersion(zksolc.version)) {
-        compiler.settings.detectMissingLibraries = false;
-        compiler.settings.forceEVMLA = zksolc.settings.forceEVMLA;
-        compiler.settings.enableEraVMExtensions = zksolc.settings.enableEraVMExtensions;
     }
 
     const [major, minor] = getVersionComponents(compiler.version);
@@ -116,29 +110,32 @@ const solcUpdaters: SolcUserConfigUpdater[] = [
     new CompilerSolcUserConfigUpdater(),
 ];
 
-export function updateCompilerWithEraVersion(
+export function updateBreakableCompilerConfig(
     solcConfigData: SolcConfigData,
     zksolc: ZkSolcConfig,
     latestEraVersion: string,
     userConfigCompilers: SolcUserConfig[] | Map<string, SolcUserConfig>,
 ) {
     const compiler = solcConfigData.compiler;
+
+    if (isBreakableCompilerVersion(zksolc.version)) {
+        compiler.settings.detectMissingLibraries = false;
+        compiler.settings.forceEVMLA = zksolc.settings.forceEVMLA;
+        compiler.settings.enableEraVMExtensions = zksolc.settings.enableEraVMExtensions;
+    }
+
     solcUpdaters
         .find((updater) => updater.suituble(userConfigCompilers, solcConfigData.file))
         ?.update(compiler, latestEraVersion, zksolc, userConfigCompilers, solcConfigData.file);
 
-    if (
-        zksolc.version !== 'latest' &&
-        compiler.eraVersion &&
-        semver.lt(zksolc.version, ZKSOLC_COMPILER_VERSION_MIN_VERSION_WITH_ZKVM_COMPILER)
-    ) {
+    if (compiler.eraVersion && semver.lt(zksolc.version, ZKSOLC_COMPILER_VERSION_MIN_VERSION_WITH_ZKVM_COMPILER)) {
         console.warn(chalk.blue(COMPILER_ZKSOLC_VERSION_WITH_ZKVM_SOLC_WARN));
         compiler.eraVersion = undefined;
     }
 }
 
 export function isBreakableCompilerVersion(zksolcVersion: string): boolean {
-    return zksolcVersion === 'latest' || semver.gte(zksolcVersion, ZKSOLC_COMPILER_MIN_VERSION_BREAKABLE_CHANGE);
+    return semver.gte(zksolcVersion, ZKSOLC_COMPILER_MIN_VERSION_BREAKABLE_CHANGE);
 }
 
 export function zeroxlify(hex: string): string {

--- a/packages/hardhat-zksync-solc/test/tests/config-update.test.ts
+++ b/packages/hardhat-zksync-solc/test/tests/config-update.test.ts
@@ -98,7 +98,7 @@ describe('CompilerSolcUserConfigUpdater', () => {
             const compiler: SolcConfig = { version: '0.8.17', settings: { forceEVMLA: true } };
             const userConfigCompilers = [{ version: '0.8.17' }, { version: '0.6.0' }];
             const file = undefined;
-            const zksolc: ZkSolcConfig = { version: 'latest', settings: {} };
+            const zksolc: ZkSolcConfig = { version: '1.5.0', settings: {} };
 
             updater.update(compiler, '1.0.0', zksolc, userConfigCompilers, file);
 

--- a/packages/hardhat-zksync-solc/test/tests/tests.ts
+++ b/packages/hardhat-zksync-solc/test/tests/tests.ts
@@ -121,7 +121,7 @@ describe('zksolc plugin', async function () {
 
             jobs.forEach((job: any) => {
                 const solidityConfig = job.solidityConfig;
-                assert.equal(solidityConfig.version, '0.8.17');
+                assert.equal(solidityConfig.version, process.env.SOLC_VERSION || '0.8.17');
                 assert.equal(solidityConfig.zksolc.version, 'latest');
                 assert.equal(solidityConfig.zksolc.settings.compilerPath, '');
                 // assert.equal(solidityConfig.zksolc.settings.libraries, {});
@@ -156,7 +156,7 @@ describe('zksolc plugin', async function () {
 
             jobs.forEach((job: any) => {
                 const solidityConfig = job.solidityConfig;
-                assert.equal(solidityConfig.version, '0.8.17');
+                assert.equal(solidityConfig.version, process.env.SOLC_VERSION || '0.8.17');
                 assert.equal(solidityConfig.zksolc.version, 'latest');
                 assert.equal(solidityConfig.zksolc.settings.compilerPath, '');
                 assert.equal(

--- a/packages/hardhat-zksync-verify/src/constants.ts
+++ b/packages/hardhat-zksync-verify/src/constants.ts
@@ -15,6 +15,9 @@ export const TASK_VERIFY_GET_MINIMUM_BUILD = 'verify:get-minimum-build';
 export const TASK_VERIFY_VERIFY_MINIMUM_BUILD = 'zk:verify:verify-minimum-build';
 export const TASK_VERIFY_GET_CONTRACT_INFORMATION = 'verify:get-contract-information';
 
+export const USING_COMPILER_PATH_ERROR =
+    'Using a compilrPath in the setting without compile is not supported. Please run verify without --no-compile flag or specify a official compiler version.';
+
 export const CONST_ARGS_ARRAY_ERROR = `
 Wrong constructor arguments format:
 

--- a/packages/hardhat-zksync-verify/src/constants.ts
+++ b/packages/hardhat-zksync-verify/src/constants.ts
@@ -16,7 +16,7 @@ export const TASK_VERIFY_VERIFY_MINIMUM_BUILD = 'zk:verify:verify-minimum-build'
 export const TASK_VERIFY_GET_CONTRACT_INFORMATION = 'verify:get-contract-information';
 
 export const USING_COMPILER_PATH_ERROR =
-    'Using a compilrPath in the setting without compile is not supported. Please run verify without --no-compile flag or specify a official compiler version.';
+    'Using a compilerPath in the setting without compile is not supported. Please run verify without --no-compile flag or specify a official compiler version.';
 
 export const CONST_ARGS_ARRAY_ERROR = `
 Wrong constructor arguments format:

--- a/packages/hardhat-zksync-verify/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify/src/task-actions.ts
@@ -4,6 +4,7 @@ import { parseFullyQualifiedName } from 'hardhat/utils/contract-names';
 import chalk from 'chalk';
 import path from 'path';
 import { getLatestEraVersion } from '@matterlabs/hardhat-zksync-solc/dist/src/utils';
+import { ZKSOLC_COMPILER_PATH_VERSION } from '@matterlabs/hardhat-zksync-solc/dist/src/constants';
 import { getSupportedCompilerVersions, verifyContractRequest } from './zksync-block-explorer/service';
 
 import {
@@ -24,6 +25,7 @@ import {
     CONSTRUCTOR_MODULE_IMPORTING_ERROR,
     BUILD_INFO_NOT_FOUND_ERROR,
     COMPILATION_ERRORS,
+    USING_COMPILER_PATH_ERROR,
 } from './constants';
 
 import { encodeArguments, extractModule, normalizeCompilerVersions, retrieveContractBytecode } from './utils';
@@ -104,6 +106,10 @@ export async function getCompilerVersions(
 
     const userSolidityConfig = hre.userConfig.solidity;
     const zkSolcConfig = hre.config.zksolc;
+
+    if (zkSolcConfig.version === ZKSOLC_COMPILER_PATH_VERSION) {
+        throw new ZkSyncVerifyPluginError(USING_COMPILER_PATH_ERROR);
+    }
 
     const extractedConfigs = extractors
         .find((extractor) => extractor.suitable(userSolidityConfig))

--- a/packages/hardhat-zksync-verify/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify/src/task-actions.ts
@@ -182,11 +182,11 @@ export async function verifyContract(
     const deployedBytecodeHex = await retrieveContractBytecode(address, hre);
     const deployedBytecode = new Bytecode(deployedBytecodeHex);
 
-    const compilerVersions: string[] = await hre.run(TASK_VERIFY_GET_COMPILER_VERSIONS);
-
     if (!noCompile) {
         await hre.run(TASK_COMPILE, { quiet: true });
     }
+
+    const compilerVersions: string[] = await hre.run(TASK_VERIFY_GET_COMPILER_VERSIONS);
 
     const contractInformation: ContractInformation = await hre.run(TASK_VERIFY_GET_CONTRACT_INFORMATION, {
         contractFQN,

--- a/packages/hardhat-zksync-verify/test/tests/task-actions.test.ts
+++ b/packages/hardhat-zksync-verify/test/tests/task-actions.test.ts
@@ -196,8 +196,8 @@ describe('verifyContract', async function () {
 
         await verifyContract(args, hre as any, runSuperStub as any);
         expect(runSuperStub.calledOnce).to.equal(false);
-        expect(hre.run.firstCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
-        expect(hre.run.secondCall.args[0]).to.equal(TASK_COMPILE);
+        expect(hre.run.firstCall.args[0]).to.equal(TASK_COMPILE);
+        expect(hre.run.secondCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
         expect(hre.run.thirdCall.args[0]).to.equal(TASK_VERIFY_GET_CONTRACT_INFORMATION);
         expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
         expect(hre.run.getCall(4).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
@@ -299,8 +299,8 @@ describe('verifyContract', async function () {
 
         await verifyContract(args, hre as any, runSuperStub as any);
         expect(runSuperStub.calledOnce).to.equal(false);
-        expect(hre.run.firstCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
-        expect(hre.run.secondCall.args[0]).to.equal(TASK_COMPILE);
+        expect(hre.run.firstCall.args[0]).to.equal(TASK_COMPILE);
+        expect(hre.run.secondCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
         expect(hre.run.thirdCall.args[0]).to.equal(TASK_VERIFY_GET_CONTRACT_INFORMATION);
         expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
         expect(hre.run.getCall(4).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
@@ -402,8 +402,8 @@ describe('verifyContract', async function () {
 
         await verifyContract(args, hre as any, runSuperStub as any);
         expect(runSuperStub.calledOnce).to.equal(false);
-        expect(hre.run.firstCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
-        expect(hre.run.secondCall.args[0]).to.equal(TASK_COMPILE);
+        expect(hre.run.firstCall.args[0]).to.equal(TASK_COMPILE);
+        expect(hre.run.secondCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
         expect(hre.run.thirdCall.args[0]).to.equal(TASK_VERIFY_GET_CONTRACT_INFORMATION);
         expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
         expect(hre.run.getCall(4).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
@@ -506,8 +506,8 @@ describe('verifyContract', async function () {
 
         await verifyContract(args, hre as any, runSuperStub as any);
         expect(runSuperStub.calledOnce).to.equal(false);
-        expect(hre.run.firstCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
-        expect(hre.run.secondCall.args[0]).to.equal(TASK_COMPILE);
+        expect(hre.run.firstCall.args[0]).to.equal(TASK_COMPILE);
+        expect(hre.run.secondCall.args[0]).to.equal(TASK_VERIFY_GET_COMPILER_VERSIONS);
         expect(hre.run.thirdCall.args[0]).to.equal(TASK_VERIFY_GET_CONTRACT_INFORMATION);
         expect(hre.run.getCall(3).args[0]).to.equal(TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH);
         expect(hre.run.getCall(4).args[0]).to.equal(TASK_CHECK_VERIFICATION_STATUS);
@@ -542,7 +542,7 @@ describe('getCompilerVersions', async function () {
             },
             config: {
                 zksolc: {
-                    version: 'latest',
+                    version: '1.5.0',
                 },
                 solidity: {
                     compilers: [{ version: '0.8.0' }, { version: '0.7.0' }],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,67 @@ importers:
         specifier: ^5.3.0
         version: 5.4.5
 
+  examples/download-with-compiler-origin:
+    dependencies:
+      '@matterlabs/hardhat-zksync-deploy':
+        specifier: workspace:^
+        version: link:../../packages/hardhat-zksync-deploy
+      '@matterlabs/hardhat-zksync-solc':
+        specifier: workspace:^
+        version: link:../../packages/hardhat-zksync-solc
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+      ethers:
+        specifier: ^6.12.2
+        version: 6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      hardhat:
+        specifier: ^2.22.5
+        version: 2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)
+      zksync-ethers:
+        specifier: ^6.8.0
+        version: 6.8.0(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+    devDependencies:
+      '@types/node':
+        specifier: ^18.11.17
+        version: 18.19.33
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.12.0
+        version: 7.12.0(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser':
+        specifier: ^7.12.0
+        version: 7.12.0(eslint@8.57.0)(typescript@5.4.5)
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.0
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.0)
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.29.1(@typescript-eslint/parser@7.12.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)
+      eslint-plugin-no-only-tests:
+        specifier: ^3.1.0
+        version: 3.1.0
+      eslint-plugin-prettier:
+        specifier: ^5.0.1
+        version: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.0)
+      prettier:
+        specifier: 3.3.0
+        version: 3.3.0
+      rimraf:
+        specifier: ^5.0.7
+        version: 5.0.7
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@18.19.33)(typescript@5.4.5)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.4.5
+
   examples/mixed-example:
     dependencies:
       '@matterlabs/hardhat-zksync-solc':
@@ -3002,6 +3063,10 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==, tarball: https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz}
     engines: {node: '>=6.0.0'}
+
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==, tarball: https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz}
+    engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==, tarball: https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz}
@@ -6853,6 +6918,8 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dotenv@16.4.5: {}
 
   eastasianwidth@0.2.0: {}
 


### PR DESCRIPTION
# What :computer: 
* Compiler path issue with compiler breakable changes

# Why :hand:
* With the new compiler, the compiler version is needed before the compilation process, requiring the compiler to be downloaded first. This ensures that the plugin can update all settings properly based on the new compiler. Additionally, downloading the compiler from a remote or origin source needs to be addressed with this change.