### PR TITLE
fix: update deployContract function

### DIFF
--- a/packages/hardhat-zksync-ethers/src/helpers.ts
+++ b/packages/hardhat-zksync-ethers/src/helpers.ts
@@ -193,7 +193,7 @@ export async function getContractAtFromArtifact(
 export async function deployContract(
     hre: HardhatRuntimeEnvironment,
     artifactOrContractName: ZkSyncArtifact | string,
-    constructorArguments?: any[],
+    constructorArguments: any[] = [],
     wallet?: Wallet,
     overrides?: ethers.Overrides,
     additionalFactoryDeps?: ethers.BytesLike[],
@@ -218,7 +218,7 @@ export async function deployContract(
     const { customData, ..._overrides } = overrides ?? {};
 
     // Encode and send the deploy transaction providing factory dependencies.
-    const contract = await factory.deploy(...(constructorArguments ?? []), {
+    const contract = await factory.deploy(...constructorArguments, {
         ..._overrides,
         customData: {
             ...customData,

--- a/packages/hardhat-zksync-ethers/src/index.ts
+++ b/packages/hardhat-zksync-ethers/src/index.ts
@@ -45,12 +45,20 @@ extendEnvironment((hre) => {
             extractFactoryDeps: (artifact: ZkSyncArtifact) => extractFactoryDeps(hre, artifact),
             loadArtifact: (name: string) => loadArtifact(hre, name),
             deployContract: (
-                artifact: ZkSyncArtifact,
-                constructorArguments: any[],
+                artifactOrContractName: ZkSyncArtifact | string,
+                constructorArguments?: any[],
                 wallet?: Wallet,
                 overrides?: ethers.Overrides,
                 additionalFactoryDeps?: ethers.BytesLike[],
-            ) => deployContract(hre, artifact, constructorArguments, wallet, overrides, additionalFactoryDeps),
+            ) =>
+                deployContract(
+                    hre,
+                    artifactOrContractName,
+                    constructorArguments,
+                    wallet,
+                    overrides,
+                    additionalFactoryDeps,
+                ),
         };
     });
 });

--- a/packages/hardhat-zksync-ethers/src/types.ts
+++ b/packages/hardhat-zksync-ethers/src/types.ts
@@ -53,8 +53,8 @@ export interface HardhatZksyncEthersHelpers {
     extractFactoryDeps: (artifact: ZkSyncArtifact) => Promise<string[]>;
     loadArtifact: (name: string) => Promise<ZkSyncArtifact>;
     deployContract: (
-        artifact: ZkSyncArtifact,
-        constructorArguments: any[],
+        artifactOrContractName: ZkSyncArtifact | string,
+        constructorArguments?: any[],
         wallet?: Wallet,
         overrides?: ethers.Overrides,
         additionalFactoryDeps?: ethers.BytesLike[],

--- a/packages/hardhat-zksync-ethers/test/fixture-projects/simple/hardhat.config.ts
+++ b/packages/hardhat-zksync-ethers/test/fixture-projects/simple/hardhat.config.ts
@@ -16,8 +16,8 @@ const config: HardhatUserConfig = {
         },
         zkSyncNetwork: {
             allowUnlimitedContractSize: true,
-            url: 'http://0.0.0.0:15100',
-            ethNetwork: 'http://0.0.0.0:15045',
+            url: 'http://0.0.0.0:3050',
+            ethNetwork: 'http://0.0.0.0:8545',
             zksync: true,
         },
         zkSyncTestnet: {

--- a/packages/hardhat-zksync-ethers/test/fixture-projects/simple/hardhat.config.ts
+++ b/packages/hardhat-zksync-ethers/test/fixture-projects/simple/hardhat.config.ts
@@ -16,8 +16,8 @@ const config: HardhatUserConfig = {
         },
         zkSyncNetwork: {
             allowUnlimitedContractSize: true,
-            url: 'http://0.0.0.0:3050',
-            ethNetwork: 'http://0.0.0.0:8545',
+            url: 'http://0.0.0.0:15100',
+            ethNetwork: 'http://0.0.0.0:15045',
             zksync: true,
         },
         zkSyncTestnet: {

--- a/packages/hardhat-zksync-ethers/test/tests.ts
+++ b/packages/hardhat-zksync-ethers/test/tests.ts
@@ -97,6 +97,18 @@ describe('Plugin tests', async function () {
                 assert.isDefined(contract);
                 assert.equal((await contract.getAddress()).length, 42);
             });
+            it('should deploy with wallet using contract name', async function () {
+                const contract: Contract = await this.env.zksyncEthers.deployContract('Greeter', []);
+
+                assert.isDefined(contract);
+                assert.equal((await contract.getAddress()).length, 42);
+            });
+            it('should deploy with wallet using contract name without constructor arguments', async function () {
+                const contract: Contract = await this.env.zksyncEthers.deployContract('Greeter');
+
+                assert.isDefined(contract);
+                assert.equal((await contract.getAddress()).length, 42);
+            });
             it('should allow to use the call method', async function () {
                 const wallet = await this.env.zksyncEthers.getWallet();
 

--- a/packages/hardhat-zksync-ethers/test/tests.ts
+++ b/packages/hardhat-zksync-ethers/test/tests.ts
@@ -56,7 +56,7 @@ describe('Plugin tests', async function () {
             });
         });
 
-        describe('wallet', function () {
+        describe.only('wallet', function () {
             it('get default wallet', async function () {
                 const wallet = await this.env.zksyncEthers.getWallet();
 

--- a/packages/hardhat-zksync-ethers/test/tests.ts
+++ b/packages/hardhat-zksync-ethers/test/tests.ts
@@ -56,7 +56,7 @@ describe('Plugin tests', async function () {
             });
         });
 
-        describe.only('wallet', function () {
+        describe('wallet', function () {
             it('get default wallet', async function () {
                 const wallet = await this.env.zksyncEthers.getWallet();
 


### PR DESCRIPTION
# What :computer: 
Updated deployContract function to also accept contract name as an argument and removed mandatory constructor arguments.

# Why :hand:
In order to have similar interface as hardhat-ethers plugin.