### PR TITLE
break: update deploy and upgrade functionality

### DIFF
--- a/e2e/fixture-projects/upgradeable/scripts/deploy-box-proxy.ts
+++ b/e2e/fixture-projects/upgradeable/scripts/deploy-box-proxy.ts
@@ -13,7 +13,7 @@ async function main() {
     const deployer = new Deployer(hre, zkWallet);
 
     const contract = await deployer.loadArtifact(contractName);
-    const box = await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [42], { initializer: 'initialize' });
+    const box = await hre.zkUpgrades.deployProxy(contract, [42], { initializer: 'initialize' },deployer.zkWallet);
 
     await box.waitForDeployment();
 

--- a/e2e/fixture-projects/upgradeable/scripts/deploy-box-proxy.ts
+++ b/e2e/fixture-projects/upgradeable/scripts/deploy-box-proxy.ts
@@ -13,7 +13,7 @@ async function main() {
     const deployer = new Deployer(hre, zkWallet);
 
     const contract = await deployer.loadArtifact(contractName);
-    const box = await hre.zkUpgrades.deployProxy(contract, [42], { initializer: 'initialize' },deployer.zkWallet);
+    const box = await hre.zkUpgrades.deployProxy(deployer.zkWallet,contract, [42], { initializer: 'initialize' });
 
     await box.waitForDeployment();
 

--- a/examples/integrations-example/.eslintrc.js
+++ b/examples/integrations-example/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: [`${__dirname}/../../config/eslint/eslintrc.cjs`],
+  parserOptions: {
+    project: `${__dirname}/tsconfig.json`,
+    sourceType: "module",
+  },
+};

--- a/examples/integrations-example/README.md
+++ b/examples/integrations-example/README.md
@@ -1,0 +1,67 @@
+# ZKsync Era integrations example
+
+This project demonstrates how to compile and deploy upgradable smart contracts in ZKsync Era using the hardhat-zksync-ethers plugins.
+
+## Prerequisites
+
+- node.js 14.x or later.
+- yarn.
+
+## Configuration
+
+Plugin configuration is located in [`hardhat.config.ts`](./hardhat.config.ts).
+You should only change the ZKsync network configuration.
+
+`hardhat.config.ts` example with ZKsync network configured with the name `zkTestnet` and `sepolia` used as the underlying layer 1 network:
+```ts
+import '@matterlabs/hardhat-zksync-solc';
+import '@matterlabs/hardhat-zksync-deploy';
+import '@matterlabs/hardhat-zksync-upgradable';
+
+import { HardhatUserConfig } from 'hardhat/types';
+
+const config: HardhatUserConfig = {
+    networks: {
+        sepolia: {
+            url: 'https://sepolia.infura.io/v3/<API_KEY>' // you can use either the URL of the Ethereum Web3 RPC, or the identifier of the network (e.g. `mainnet` or `rinkeby`)
+        },
+        zkTestnet: {
+            url: 'https://sepolia.era.zksync.dev', // you should use the URL of the ZKsync network RPC
+            ethNetwork: 'sepolia',
+            zksync: true
+        },
+    }
+};
+
+export default config;
+```
+
+If you don't specify ZKsync network (`--network`), `local-setup` with <http://localhost:8545> (Ethereum RPC URL) and <http://localhost:3050> (ZKsync RPC URL) will be used.
+
+## Usage
+
+Before using plugins, you need to build them first
+
+```sh
+# Run the following in the *root* of the repo.
+yarn
+yarn build
+```
+
+After that you should be able to run plugins:
+
+```sh
+# Run the following in `examples/upgradable-example` folder.
+yarn
+yarn hardhat compile
+```
+
+- `yarn hardhat compile`: compiles all the contracts in the `contracts` folder.
+
+To run a specific end-to-end script in the `scripts` folder, use the following command
+
+```
+yarn hardhat run ./scripts/<SCRIPT_NAME>
+```
+
+- Example: `yarn hardhat run ./scripts/deploy-box-proxy.ts`

--- a/examples/integrations-example/contracts/Box.sol
+++ b/examples/integrations-example/contracts/Box.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+contract Box is Initializable {
+    uint256 private value;
+    uint256 private secondValue;
+    uint256 private thirdValue;
+
+    function initialize(uint256 initValue) public initializer {
+        value = initValue;
+    }
+
+    // Reads the last stored value
+    function retrieve() public view returns (uint256) {
+        return value;
+    }
+
+    // Stores a new value in the contract
+    function store(uint256 newValue) public {
+        value = newValue;
+        emit ValueChanged(newValue);
+    }
+    // Emitted when the stored value changes
+    event ValueChanged(uint256 newValue);
+}

--- a/examples/integrations-example/contracts/BoxUups.sol
+++ b/examples/integrations-example/contracts/BoxUups.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+
+contract BoxUups is Initializable, UUPSUpgradeable, OwnableUpgradeable {
+    uint256 private value;
+    uint256 private secondValue;
+    uint256 private thirdValue;
+
+    function initialize(uint256 initValue) public initializer {
+        value = initValue;
+        __Ownable_init();
+        __UUPSUpgradeable_init();
+    }
+
+    // Reads the last stored value
+    function retrieve() public view returns (uint256) {
+        return value;
+    }
+
+    // Stores a new value in the contract
+    function store(uint256 newValue) public {
+        value = newValue;
+        emit ValueChanged(newValue);
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    // Emitted when the stored value changes
+    event ValueChanged(uint256 newValue);
+}

--- a/examples/integrations-example/contracts/BoxUupsV2.sol
+++ b/examples/integrations-example/contracts/BoxUupsV2.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+
+contract BoxUupsV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable {
+    uint256 private value;
+    uint256 private secondValue;
+    uint256 private thirdValue;
+
+    function initialize(uint256 initValue) public initializer {
+        value = initValue;
+    }
+
+    // Reads the last stored value and returns it with a prefix
+    function retrieve() public view returns (string memory) {
+        return string(abi.encodePacked('V2: ', uint2str(value)));
+    }
+
+    // Converts a uint to a string
+    function uint2str(uint _i) internal pure returns (string memory) {
+        if (_i == 0) {
+            return '0';
+        }
+        uint j = _i;
+        uint len;
+        while (j != 0) {
+            len++;
+            j /= 10;
+        }
+        bytes memory bstr = new bytes(len);
+        uint k = len;
+        while (_i != 0) {
+            k = k - 1;
+            uint8 temp = (48 + uint8(_i - (_i / 10) * 10));
+            bytes1 b1 = bytes1(temp);
+            bstr[k] = b1;
+            _i /= 10;
+        }
+        return string(bstr);
+    }
+
+    // Stores a new value in the contract
+    function store(uint256 newValue) public {
+        value = newValue;
+        emit ValueChanged(newValue);
+    }
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    // Emitted when the stored value changes
+    event ValueChanged(uint256 newValue);
+}

--- a/examples/integrations-example/contracts/BoxV2.sol
+++ b/examples/integrations-example/contracts/BoxV2.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+contract BoxV2 is Initializable{
+    uint256 private value;
+    uint256 private secondValue;
+    uint256 private thirdValue;
+
+    // Emitted when the stored value changes
+    event ValueChanged(uint256 newValue);
+
+    function initialize(uint256 initValue) public initializer {
+        value = initValue;
+    }
+
+    // Stores a new value in the contract
+    function store(uint256 newValue) public {
+        value = newValue;
+        emit ValueChanged(newValue);
+    }
+
+    // Reads the last stored value and returns it with a prefix
+    function retrieve() public view returns (string memory) {
+        return string(abi.encodePacked("V2: ", uint2str(value)));
+    }
+
+    // Converts a uint to a string
+    function uint2str(uint _i) internal pure returns (string memory) {
+        if (_i == 0) {
+            return "0";
+        }
+        uint j = _i;
+        uint len;
+        while (j != 0) {
+            len++;
+            j /= 10;
+        }
+        bytes memory bstr = new bytes(len);
+        uint k = len;
+        while (_i != 0) {
+            k = k - 1;
+            uint8 temp = (48 + uint8(_i - (_i / 10) * 10));
+            bytes1 b1 = bytes1(temp);
+            bstr[k] = b1;
+            _i /= 10;
+        }
+        return string(bstr);
+    }
+}

--- a/examples/integrations-example/contracts/Greeter.sol
+++ b/examples/integrations-example/contracts/Greeter.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+pragma abicoder v2;
+
+contract Greeter {
+    string greeting;
+
+    function greet() public view returns (string memory) {
+        return greeting;
+    }
+
+    function setGreeting(string memory _greeting) public {
+        greeting = _greeting;
+    }
+}

--- a/examples/integrations-example/hardhat.config.ts
+++ b/examples/integrations-example/hardhat.config.ts
@@ -1,0 +1,39 @@
+import '@matterlabs/hardhat-zksync-solc';
+import '@matterlabs/hardhat-zksync-deploy';
+import '@matterlabs/hardhat-zksync-verify';
+import '@matterlabs/hardhat-zksync-upgradable';
+import '@matterlabs/hardhat-zksync-ethers';
+
+import { HardhatUserConfig } from 'hardhat/config';
+
+const config: HardhatUserConfig = {
+    zksolc: {
+        version: 'latest',
+        compilerSource: 'binary',
+        settings: {
+            optimizer: {
+                enabled: true,
+            },
+        },
+    },
+    defaultNetwork:'zkSyncNetwork',
+    networks: {
+        hardhat: {
+            zksync: true,
+        },
+        eth: {
+            zksync: true,
+            url: 'http://0.0.0.0:8545',
+        },
+        zkSyncNetwork: {
+            zksync: true,
+            ethNetwork: 'eth',
+            url: 'http://0.0.0.0:3050',
+        },
+    },
+    solidity: {
+        version: '0.8.20',
+    },
+};
+
+export default config;

--- a/examples/integrations-example/package.json
+++ b/examples/integrations-example/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "hardhat-zksync-integrations-example",
+  "version": "0.1.0",
+  "author": "Matter Labs",
+  "license": "MIT",
+  "scripts": {
+    "lint": "pnpm eslint",
+    "prettier:check": "pnpm prettier --check",
+    "lint:fix": "pnpm eslint --fix",
+    "fmt": "pnpm prettier --write",
+    "eslint": "eslint scripts/*.ts",
+    "prettier": "prettier scripts/*.ts",
+    "test": "mocha test/tests.ts --exit",
+    "build": "tsc --build .",
+    "clean": "rimraf dist"
+  },
+  "devDependencies": {
+    "@openzeppelin/contracts": "^4.9.2",
+    "@types/node": "^18.11.17",
+    "@typescript-eslint/eslint-plugin": "6.13.1",
+    "@typescript-eslint/parser": "6.13.1",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-no-only-tests": "^3.1.0",
+    "eslint-plugin-prettier": "^5.0.1",
+    "prettier": "^3.3.0",
+    "rimraf": "^5.0.7",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.0"
+  },
+  "dependencies": {
+    "ethers": "^6.12.2",
+    "zksync-ethers": "^6.8.0",
+    "hardhat": "^2.22.5",
+    "@matterlabs/hardhat-zksync-deploy": "workspace:^",
+    "@matterlabs/hardhat-zksync-solc": "workspace:^",
+    "@matterlabs/hardhat-zksync-upgradable": "workspace:^",
+    "@matterlabs/hardhat-zksync-verify": "workspace:^",
+    "@matterlabs/hardhat-zksync-ethers": "workspace:^",
+    "chalk": "^4.1.2",
+    "@openzeppelin/contracts-upgradeable": "^4.9.2",
+    "zksync": "^0.13.1"
+  },
+  "prettier": {
+    "tabWidth": 4,
+    "printWidth": 120,
+    "parser": "typescript",
+    "singleQuote": true,
+    "bracketSpacing": true
+  }
+}

--- a/examples/integrations-example/scripts/deploy-box-beacon.ts
+++ b/examples/integrations-example/scripts/deploy-box-beacon.ts
@@ -13,11 +13,11 @@ async function main() {
 
     const deployer = new Deployer(hre, zkWallet);
 
-    const boxContract = await deployer.loadArtifact(contractName);
-    const beacon = await hre.zkUpgrades.deployBeacon(boxContract,{},deployer.zkWallet);
+    const boxFactory = await hre.zksyncEthers.getContractFactory(contractName);
+    const beacon = await hre.zkUpgrades.deployBeacon(boxFactory,{},deployer.zkWallet);
     await beacon.waitForDeployment();
 
-    const box = await hre.zkUpgrades.deployBeaconProxy(await beacon.getAddress(), boxContract, [42],{},deployer.zkWallet);
+    const box = await hre.zkUpgrades.deployBeaconProxy(await beacon.getAddress(), boxFactory, [42], {}, deployer.zkWallet);
     await box.waitForDeployment();
 
     box.connect(zkWallet);

--- a/examples/integrations-example/scripts/deploy-box-proxy.ts
+++ b/examples/integrations-example/scripts/deploy-box-proxy.ts
@@ -13,11 +13,9 @@ async function main() {
 
     const deployer = new Deployer(hre, zkWallet);
 
-    const boxContract = await deployer.loadArtifact(contractName);
-    const beacon = await hre.zkUpgrades.deployBeacon(boxContract,{},deployer.zkWallet);
-    await beacon.waitForDeployment();
+    const boxFactory = await hre.zksyncEthers.getContractFactory('Box');
+    const box = await hre.zkUpgrades.deployProxy(boxFactory, [42], { initializer: 'store' },deployer.zkWallet);
 
-    const box = await hre.zkUpgrades.deployBeaconProxy(await beacon.getAddress(), boxContract, [42],{},deployer.zkWallet);
     await box.waitForDeployment();
 
     box.connect(zkWallet);

--- a/examples/integrations-example/scripts/deploy-box-uups.ts
+++ b/examples/integrations-example/scripts/deploy-box-uups.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import * as hre from 'hardhat';
 
 async function main() {
-    const contractName = 'Box';
+    const contractName = 'BoxUups';
     console.info(chalk.yellow(`Deploying ${contractName}...`));
 
     const testMnemonic = 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
@@ -13,11 +13,9 @@ async function main() {
 
     const deployer = new Deployer(hre, zkWallet);
 
-    const boxContract = await deployer.loadArtifact(contractName);
-    const beacon = await hre.zkUpgrades.deployBeacon(boxContract,{},deployer.zkWallet);
-    await beacon.waitForDeployment();
+    const boxFactory = await hre.zksyncEthers.getContractFactory('BoxUups');
+    const box = await hre.zkUpgrades.deployProxy(boxFactory, [42], { initializer: 'initialize' },deployer.zkWallet);
 
-    const box = await hre.zkUpgrades.deployBeaconProxy(await beacon.getAddress(), boxContract, [42],{},deployer.zkWallet);
     await box.waitForDeployment();
 
     box.connect(zkWallet);

--- a/examples/integrations-example/scripts/upgrade-box-uups.ts
+++ b/examples/integrations-example/scripts/upgrade-box-uups.ts
@@ -8,25 +8,26 @@ async function main() {
     const testMnemonic = 'stuff slice staff easily soup parent arm payment cotton trade scatter struggle';
     const zkWallet = Wallet.fromMnemonic(testMnemonic);
     const deployer = new Deployer(hre, zkWallet);
-    // deploy proxy
-    const contractName = 'Box';
 
-    const contract = await deployer.loadArtifact(contractName);
-    const box = await hre.zkUpgrades.deployProxy(contract, [42], { initializer: 'store' },deployer.zkWallet);
+    // deploy proxy
+    const contractName = 'BoxUups';
+
+    const boxFactory = await hre.zksyncEthers.getContractFactory(contractName);
+    const box = await hre.zkUpgrades.deployProxy(boxFactory, [42], { initializer: 'initialize' },deployer.zkWallet);
 
     await box.waitForDeployment();
 
     // upgrade proxy implementation
 
-    const BoxV2 = await deployer.loadArtifact('BoxV2');
-    const upgradedBox = await hre.zkUpgrades.upgradeProxy(await box.getAddress(), BoxV2,deployer.zkWallet);
-    console.info(chalk.green('Successfully upgraded Box to BoxV2'));
+    const BoxUupsV2Factory = await hre.zksyncEthers.getContractFactory("BoxUupsV2");
+    const upgradedBox = await hre.zkUpgrades.upgradeProxy(await box.getAddress(), BoxUupsV2Factory,deployer.zkWallet);
+    console.info(chalk.green('Successfully upgraded BoxUups to BoxUupsV2'));
 
     upgradedBox.connect(zkWallet);
     // wait some time before the next call
     await new Promise((resolve) => setTimeout(resolve, 2000));
     const value = await upgradedBox.retrieve();
-    console.info(chalk.cyan('Box value is', value));
+    console.info(chalk.cyan('BoxUups value is', value));
 }
 
 main().catch((error) => {

--- a/examples/integrations-example/scripts/upgrade-box.ts
+++ b/examples/integrations-example/scripts/upgrade-box.ts
@@ -11,15 +11,15 @@ async function main() {
     // deploy proxy
     const contractName = 'Box';
 
-    const contract = await deployer.loadArtifact(contractName);
-    const box = await hre.zkUpgrades.deployProxy(contract, [42], { initializer: 'store' },deployer.zkWallet);
+    const boxFactory = await hre.zksyncEthers.getContractFactory(contractName);
+    const box = await hre.zkUpgrades.deployProxy(boxFactory, [42], { initializer: 'store' },deployer.zkWallet);
 
     await box.waitForDeployment();
 
     // upgrade proxy implementation
 
-    const BoxV2 = await deployer.loadArtifact('BoxV2');
-    const upgradedBox = await hre.zkUpgrades.upgradeProxy(await box.getAddress(), BoxV2,deployer.zkWallet);
+    const boxV2Factory = await hre.zksyncEthers.getContractFactory('BoxV2');
+    const upgradedBox = await hre.zkUpgrades.upgradeProxy(await box.getAddress(), boxV2Factory,deployer.zkWallet);
     console.info(chalk.green('Successfully upgraded Box to BoxV2'));
 
     upgradedBox.connect(zkWallet);

--- a/examples/integrations-example/tsconfig.json
+++ b/examples/integrations-example/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": [
+    "./hardhat.config.ts",
+    "./scripts",
+    "scripts",
+    "./test",
+    "typechain/**/*"
+  ]
+}

--- a/examples/upgradable-example/scripts/deploy-box-proxy.ts
+++ b/examples/upgradable-example/scripts/deploy-box-proxy.ts
@@ -14,7 +14,7 @@ async function main() {
     const deployer = new Deployer(hre, zkWallet);
 
     const contract = await deployer.loadArtifact(contractName);
-    const box = await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [42], { initializer: 'store' });
+    const box = await hre.zkUpgrades.deployProxy(contract, [42], { initializer: 'store' },deployer.zkWallet);
 
     await box.waitForDeployment();
 

--- a/examples/upgradable-example/scripts/deploy-box-uups.ts
+++ b/examples/upgradable-example/scripts/deploy-box-uups.ts
@@ -14,7 +14,7 @@ async function main() {
     const deployer = new Deployer(hre, zkWallet);
 
     const contract = await deployer.loadArtifact(contractName);
-    const box = await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [42], { initializer: 'initialize' });
+    const box = await hre.zkUpgrades.deployProxy(contract, [42], { initializer: 'initialize' },deployer.zkWallet);
 
     await box.waitForDeployment();
 

--- a/examples/upgradable-example/scripts/upgrade-box-uups.ts
+++ b/examples/upgradable-example/scripts/upgrade-box-uups.ts
@@ -13,14 +13,14 @@ async function main() {
     const contractName = 'BoxUups';
 
     const contract = await deployer.loadArtifact(contractName);
-    const box = await hre.zkUpgrades.deployProxy(deployer.zkWallet, contract, [42], { initializer: 'initialize' });
+    const box = await hre.zkUpgrades.deployProxy(contract, [42], { initializer: 'initialize' },deployer.zkWallet);
 
     await box.waitForDeployment();
 
     // upgrade proxy implementation
 
     const BoxUupsV2 = await deployer.loadArtifact('BoxUupsV2');
-    const upgradedBox = await hre.zkUpgrades.upgradeProxy(deployer.zkWallet, await box.getAddress(), BoxUupsV2);
+    const upgradedBox = await hre.zkUpgrades.upgradeProxy(await box.getAddress(), BoxUupsV2,deployer.zkWallet);
     console.info(chalk.green('Successfully upgraded BoxUups to BoxUupsV2'));
 
     upgradedBox.connect(zkWallet);

--- a/packages/hardhat-zksync-upgradable/src/plugin.ts
+++ b/packages/hardhat-zksync-upgradable/src/plugin.ts
@@ -36,14 +36,17 @@ export async function deployBeacon(
     const deployer = new Deployer(hre, wallet);
 
     const contract = await deployer.loadArtifact(taskArgs.contractName);
-    const beacon = await hre.zkUpgrades.deployBeacon(wallet, contract, {
-        deploymentType: taskArgs.deploymentTypeImpl,
-        salt: taskArgs.saltImpl,
-    });
+    const beacon = await hre.zkUpgrades.deployBeacon(
+        contract,
+        {
+            deploymentType: taskArgs.deploymentTypeImpl,
+            salt: taskArgs.saltImpl,
+        },
+        wallet,
+    );
     await beacon.waitForDeployment();
 
     const proxy = await hre.zkUpgrades.deployBeaconProxy(
-        deployer.zkWallet,
         await beacon.getAddress(),
         contract,
         constructorArguments,
@@ -52,6 +55,7 @@ export async function deployBeacon(
             salt: taskArgs.saltProxy,
             initializer: taskArgs.initializer,
         },
+        deployer.zkWallet,
     );
     await proxy.waitForDeployment();
 
@@ -89,13 +93,18 @@ export async function deployProxy(
 
     const contract = await deployer.loadArtifact(taskArgs.contractName);
 
-    const proxy = await hre.zkUpgrades.deployProxy(wallet, contract, constructorArguments, {
-        deploymentTypeImpl: taskArgs.deploymentTypeImpl,
-        saltImpl: taskArgs.saltImpl,
-        deploymentTypeProxy: taskArgs.deploymentTypeProxy,
-        saltProxy: taskArgs.saltProxy,
-        initializer: taskArgs.initializer,
-    });
+    const proxy = await hre.zkUpgrades.deployProxy(
+        contract,
+        constructorArguments,
+        {
+            deploymentTypeImpl: taskArgs.deploymentTypeImpl,
+            saltImpl: taskArgs.saltImpl,
+            deploymentTypeProxy: taskArgs.deploymentTypeProxy,
+            saltProxy: taskArgs.saltProxy,
+            initializer: taskArgs.initializer,
+        },
+        wallet,
+    );
 
     await proxy.waitForDeployment();
 
@@ -121,7 +130,7 @@ export async function upgradeBeacon(
 
     const contractV2 = await deployer.loadArtifact(taskArgs.contractName);
 
-    const beaconUpgrade = await hre.zkUpgrades.upgradeBeacon(wallet, taskArgs.beaconAddress, contractV2, {
+    const beaconUpgrade = await hre.zkUpgrades.upgradeBeacon(taskArgs.beaconAddress, contractV2, wallet, {
         deploymentType: taskArgs.deploymentType,
         salt: taskArgs.salt,
     });
@@ -150,7 +159,7 @@ export async function upgradeProxy(
 
     const contractV2 = await deployer.loadArtifact(taskArgs.contractName);
 
-    const proxyUpgrade = await hre.zkUpgrades.upgradeProxy(wallet, taskArgs.proxyAddress, contractV2, {
+    const proxyUpgrade = await hre.zkUpgrades.upgradeProxy(taskArgs.proxyAddress, contractV2, wallet, {
         deploymentType: taskArgs.deploymentType,
         salt: taskArgs.salt,
     });

--- a/packages/hardhat-zksync-upgradable/src/utils/utils-general.ts
+++ b/packages/hardhat-zksync-upgradable/src/utils/utils-general.ts
@@ -1,5 +1,5 @@
 import { keccak256 } from 'ethereumjs-util';
-import { Interface, ethers } from 'ethers';
+import { ContractRunner, Interface, ethers } from 'ethers';
 import chalk from 'chalk';
 import * as zk from 'zksync-ethers';
 import { HardhatRuntimeEnvironment, SolcConfig } from 'hardhat/types';
@@ -183,4 +183,12 @@ export async function extractFactoryDepsRecursive(
     }
 
     return factoryDeps;
+}
+
+export function getWallet(runner?: null | ContractRunner, wallet?: zk.Wallet | undefined): zk.Wallet | undefined {
+    if (runner && 'getAddress' in runner) {
+        return runner as zk.Wallet;
+    } else {
+        return wallet;
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,82 @@ importers:
         specifier: ^5.3.0
         version: 5.4.5
 
+  examples/integrations-example:
+    dependencies:
+      '@matterlabs/hardhat-zksync-deploy':
+        specifier: workspace:^
+        version: link:../../packages/hardhat-zksync-deploy
+      '@matterlabs/hardhat-zksync-ethers':
+        specifier: workspace:^
+        version: link:../../packages/hardhat-zksync-ethers
+      '@matterlabs/hardhat-zksync-solc':
+        specifier: workspace:^
+        version: link:../../packages/hardhat-zksync-solc
+      '@matterlabs/hardhat-zksync-upgradable':
+        specifier: workspace:^
+        version: link:../../packages/hardhat-zksync-upgradable
+      '@matterlabs/hardhat-zksync-verify':
+        specifier: workspace:^
+        version: link:../../packages/hardhat-zksync-verify
+      '@openzeppelin/contracts-upgradeable':
+        specifier: ^4.9.2
+        version: 4.9.6
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+      ethers:
+        specifier: ^6.12.2
+        version: 6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      hardhat:
+        specifier: ^2.22.5
+        version: 2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)
+      zksync:
+        specifier: ^0.13.1
+        version: 0.13.1(@ethersproject/logger@5.7.0)(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      zksync-ethers:
+        specifier: ^6.8.0
+        version: 6.8.0(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+    devDependencies:
+      '@openzeppelin/contracts':
+        specifier: ^4.9.2
+        version: 4.9.6
+      '@types/node':
+        specifier: ^18.11.17
+        version: 18.19.33
+      '@typescript-eslint/eslint-plugin':
+        specifier: 6.13.1
+        version: 6.13.1(@typescript-eslint/parser@6.13.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
+      '@typescript-eslint/parser':
+        specifier: 6.13.1
+        version: 6.13.1(eslint@8.57.0)(typescript@5.4.5)
+      eslint:
+        specifier: ^8.56.0
+        version: 8.57.0
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@8.57.0)
+      eslint-plugin-import:
+        specifier: ^2.29.1
+        version: 2.29.1(@typescript-eslint/parser@6.13.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)
+      eslint-plugin-no-only-tests:
+        specifier: ^3.1.0
+        version: 3.1.0
+      eslint-plugin-prettier:
+        specifier: ^5.0.1
+        version: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.0)
+      prettier:
+        specifier: ^3.3.0
+        version: 3.3.0
+      rimraf:
+        specifier: ^5.0.7
+        version: 5.0.7
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@18.19.33)(typescript@5.4.5)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.4.5
+
   examples/mixed-example:
     dependencies:
       '@matterlabs/hardhat-zksync-solc':


### PR DESCRIPTION
# What :computer: 
Updated deploy and upgrade functions to accept ContractFactory and rearranged the arguments so it has more intuitive order. 

# Why :hand:
In order to have similar interface as openzeppelin/hardhat-upgrades plugin.