### PR TITLE
fix: don't check for assignment if variable is immutable

### DIFF
--- a/packages/hardhat-zksync-upgradable/src/core/validate.ts
+++ b/packages/hardhat-zksync-upgradable/src/core/validate.ts
@@ -253,18 +253,6 @@ function* getStateVariableErrors(
 ): Generator<ValidationErrorWithName> {
     for (const varDecl of contractDef.nodes) {
         if (isNodeType('VariableDeclaration', varDecl)) {
-            if (!varDecl.constant && !isNullish(varDecl.value)) {
-                if (
-                    !skipCheck('state-variable-assignment', contractDef) &&
-                    !skipCheck('state-variable-assignment', varDecl)
-                ) {
-                    yield {
-                        kind: 'state-variable-assignment',
-                        name: varDecl.name,
-                        src: decodeSrc(varDecl),
-                    };
-                }
-            }
             if (varDecl.mutability === 'immutable') {
                 if (
                     !skipCheck('state-variable-immutable', contractDef) &&
@@ -272,6 +260,17 @@ function* getStateVariableErrors(
                 ) {
                     yield {
                         kind: 'state-variable-immutable',
+                        name: varDecl.name,
+                        src: decodeSrc(varDecl),
+                    };
+                }
+            } else if (!varDecl.constant && !isNullish(varDecl.value)) {
+                if (
+                    !skipCheck('state-variable-assignment', contractDef) &&
+                    !skipCheck('state-variable-assignment', varDecl)
+                ) {
+                    yield {
+                        kind: 'state-variable-assignment',
                         name: varDecl.name,
                         src: decodeSrc(varDecl),
                     };


### PR DESCRIPTION
# What :computer: 
* Do not check for `state-variable-assignment` if the variable is immutable

# Why :hand:
* `immutable` variables have their own separate check with `state-variable-immutable`, but adding an exception by annotating an immutable variable with `@custom:oz-upgrades-unsafe-allow state-variable-immutable` still triggers `state-variable-assignment`
* OZ's [`UUPSUpgradeable` contract on v5](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/dbb6104ce834628e473d2173bbc9d47f81a9eec3/contracts/proxy/utils/UUPSUpgradeable.sol#L21) uses an immutable variable annotated with `@custom:oz-upgrades-unsafe-allow state-variable-immutable` that passes validation with the OZ plugin but fails it with the zkSync one.
* This is the behavior of the original upgradeable plugin: https://github.com/OpenZeppelin/openzeppelin-upgrades/blob/742415c28f8858fe93c0c21bc979414d90ed2ce6/packages/core/src/validate/run.ts#L513

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended

`cache/validations.json` before:
```json
        "errors": [
          {
            "kind": "delegatecall",
            "src": "@openzeppelin/contracts/utils/Address.sol:105"
          },
          {
            "kind": "state-variable-assignment",
            "name": "__self",
            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:22"
          }
       ]
```

`cache/validations.json` after:
```json
        "errors": [
          {
            "kind": "delegatecall",
            "src": "@openzeppelin/contracts/utils/Address.sol:105"
          }
        ]
```