### PR TITLE
fix: use openzepplin/contracts as alias and remove unvalid peer depen…

### DIFF
--- a/packages/hardhat-zksync-upgradable/package.json
+++ b/packages/hardhat-zksync-upgradable/package.json
@@ -36,6 +36,7 @@
     "@matterlabs/hardhat-zksync-deploy": "workspace:^",
     "@matterlabs/hardhat-zksync-solc": "workspace:^",
     "@openzeppelin/upgrades-core": "^1.31.3",
+    "@openzeppelin/contracts-hardhat-zksync-upgradable": "npm:@openzeppelin/contracts@^4.9.2",
     "chalk": "^4.1.2",
     "hardhat": "^2.22.5",
     "fs-extra": "^11.2.0",
@@ -44,10 +45,10 @@
     "zksync-ethers": "^6.8.0",
     "solidity-ast": "^0.4.56",
     "proper-lockfile": "^4.1.2",
+    "semver": "^7.6.2",
     "compare-versions": "^6.1.0"
   },
   "devDependencies": {
-    "@openzeppelin/contracts-upgradeable": "^4.9.2",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^18.11.17",
     "@types/proper-lockfile": "^4.1.2",
@@ -66,7 +67,6 @@
     "c8": "^8.0.1"
   },
   "peerDependencies": {
-    "@openzeppelin/contracts-upgradeable": "^4.9.2"
   },
   "prettier": {
     "tabWidth": 4,

--- a/packages/hardhat-zksync-upgradable/src/constants.ts
+++ b/packages/hardhat-zksync-upgradable/src/constants.ts
@@ -59,4 +59,4 @@ export const verifiableContracts = {
     proxyAdmin: { event: 'OwnershipTransferred(address,address)' },
 };
 
-export const OZ_CONTRACTS_VERISION_INCOMPATIBLE_ERROR = `The @matterlabs/hardhat-zksync-upgradable plugin utilizes the @openzeppelin/contracts dependency for proxy contracts, compatible with versions between 4.6.1 and 4.9.6. Please update the dependecy to a version within this range for optimal functionality.`;
+export const OZ_CONTRACTS_VERISION_INCOMPATIBLE_ERROR = `The @matterlabs/hardhat-zksync-upgradable plugin utilizes the @openzeppelin/contracts dependency for proxy contracts, compatible with versions between 4.6.0 and 4.9.6. Please update the dependecy to a version within this range for optimal functionality.`;

--- a/packages/hardhat-zksync-upgradable/src/constants.ts
+++ b/packages/hardhat-zksync-upgradable/src/constants.ts
@@ -13,13 +13,25 @@ export const MANIFEST_DEFAULT_DIR = '.upgradable';
 export const ZKSOLC_ARTIFACT_FORMAT_VERSION = 'hh-zksolc-artifact-1';
 export const ZKVYPER_ARTIFACT_FORMAT_VERSION = 'hh-zkvyper-artifact-1';
 
-export const PROXY_SOURCE_NAMES = [
-    '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol',
-    '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol',
-    '@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol',
-    '@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol',
-    '@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol',
-];
+export const UPGRADEABLE_CONTRACTS_FROM_ALLIAS = {
+    TransparentUpgradeableProxy:
+        '@openzeppelin/contracts-hardhat-zksync-upgradable/proxy/transparent/TransparentUpgradeableProxy.sol',
+    ITransparentUpgradeableProxy:
+        '@openzeppelin/contracts-hardhat-zksync-upgradable/proxy/transparent/ITransparentUpgradeableProxy.sol',
+    ProxyAdmin: '@openzeppelin/contracts-hardhat-zksync-upgradable/proxy/transparent/ProxyAdmin.sol',
+    BeaconProxy: '@openzeppelin/contracts-hardhat-zksync-upgradable/proxy/beacon/BeaconProxy.sol',
+    UpgradeableBeacon: '@openzeppelin/contracts-hardhat-zksync-upgradable/proxy/beacon/UpgradeableBeacon.sol',
+    ERC1967Proxy: '@openzeppelin/contracts-hardhat-zksync-upgradable/proxy/ERC1967/ERC1967Proxy.sol',
+};
+
+export const UPGRADEABLE_CONTRACTS_FROM_CONTRACTS = {
+    TransparentUpgradeableProxy: '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol',
+    ITransparentUpgradeableProxy: '@openzeppelin/contracts/proxy/transparent/ITransparentUpgradeableProxy.sol',
+    ProxyAdmin: '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol',
+    BeaconProxy: '@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol',
+    UpgradeableBeacon: '@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol',
+    ERC1967Proxy: '@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol',
+};
 
 export const UPGRADE_VERIFY_ERROR =
     'The verify plugin must be imported before the hardhat-upgrades plugin.' +
@@ -46,3 +58,5 @@ export const verifiableContracts = {
     transparentUpgradeableProxy: { event: 'AdminChanged(address,address)' },
     proxyAdmin: { event: 'OwnershipTransferred(address,address)' },
 };
+
+export const OZ_CONTRACTS_VERISION_INCOMPATIBLE_ERROR = `The @matterlabs/hardhat-zksync-upgradable plugin utilizes the @openzeppelin/contracts dependency for proxy contracts, compatible with versions between 4.6.1 and 4.9.6. Please update the dependecy to a version within this range for optimal functionality.`;

--- a/packages/hardhat-zksync-upgradable/src/constants.ts
+++ b/packages/hardhat-zksync-upgradable/src/constants.ts
@@ -13,7 +13,7 @@ export const MANIFEST_DEFAULT_DIR = '.upgradable';
 export const ZKSOLC_ARTIFACT_FORMAT_VERSION = 'hh-zksolc-artifact-1';
 export const ZKVYPER_ARTIFACT_FORMAT_VERSION = 'hh-zkvyper-artifact-1';
 
-export const UPGRADEABLE_CONTRACTS_FROM_ALLIAS = {
+export const UPGRADEABLE_CONTRACTS_FROM_ALIAS = {
     TransparentUpgradeableProxy:
         '@openzeppelin/contracts-hardhat-zksync-upgradable/proxy/transparent/TransparentUpgradeableProxy.sol',
     ITransparentUpgradeableProxy:

--- a/packages/hardhat-zksync-upgradable/src/gas-estimation/estimate-gas-beacon-proxy.ts
+++ b/packages/hardhat-zksync-upgradable/src/gas-estimation/estimate-gas-beacon-proxy.ts
@@ -8,6 +8,7 @@ import { ZkSyncUpgradablePluginError } from '../errors';
 import { convertGasPriceToEth } from '../utils/utils-general';
 import { BEACON_PROXY_JSON } from '../constants';
 
+import { getUpgradableContracts } from '../utils';
 import { getMockedBeaconData } from './estimate-gas-beacon';
 
 export type EstimateBeaconGasFunction = (
@@ -27,7 +28,7 @@ export function makeEstimateGasBeaconProxy(hre: HardhatRuntimeEnvironment): Esti
         const { mockedBeaconAddress, data } = await getMockedBeaconData(deployer, hre, args, opts);
 
         const beaconProxyPath = (await hre.artifacts.getArtifactPaths()).find((artifactPath) =>
-            artifactPath.includes(path.sep + BEACON_PROXY_JSON),
+            artifactPath.includes(path.sep + getUpgradableContracts().BeaconProxy + path.sep + BEACON_PROXY_JSON),
         );
         assert(beaconProxyPath, 'Beacon proxy artifact not found');
         const beaconProxyContract = await import(beaconProxyPath);

--- a/packages/hardhat-zksync-upgradable/src/gas-estimation/estimate-gas-beacon.ts
+++ b/packages/hardhat-zksync-upgradable/src/gas-estimation/estimate-gas-beacon.ts
@@ -12,6 +12,7 @@ import { UPGRADABLE_BEACON_JSON } from '../constants';
 
 import { getAdminArtifact } from '../proxy-deployment/deploy-proxy-admin';
 import { getChainId } from '../core/provider';
+import { getUpgradableContracts } from '../utils';
 
 export type EstimateGasFunction = (
     deployer: Deployer,
@@ -75,7 +76,7 @@ export function makeEstimateGasBeacon(hre: HardhatRuntimeEnvironment): EstimateG
         }
 
         const upgradableBeaconPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
-            x.includes(path.sep + UPGRADABLE_BEACON_JSON),
+            x.includes(path.sep + getUpgradableContracts().UpgradeableBeacon + path.sep + UPGRADABLE_BEACON_JSON),
         );
         assert(upgradableBeaconPath, 'Upgradable beacon artifact not found');
         const upgradeableBeaconContract = await import(upgradableBeaconPath);

--- a/packages/hardhat-zksync-upgradable/src/gas-estimation/estimate-gas-proxy.ts
+++ b/packages/hardhat-zksync-upgradable/src/gas-estimation/estimate-gas-proxy.ts
@@ -12,6 +12,7 @@ import { convertGasPriceToEth, getInitializerData } from '../utils/utils-general
 import { getChainId } from '../core/provider';
 import { ERC1967_PROXY_JSON, TUP_JSON } from '../constants';
 import { getAdminArtifact } from '../proxy-deployment/deploy-proxy-admin';
+import { getUpgradableContracts } from '../utils';
 
 export type EstimateProxyGasFunction = (
     deployer: Deployer,
@@ -109,7 +110,7 @@ async function estimateGasUUPS(
     quiet: boolean = false,
 ): Promise<bigint> {
     const ERC1967ProxyPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
-        x.includes(path.sep + ERC1967_PROXY_JSON),
+        x.includes(path.sep + getUpgradableContracts().ERC1967Proxy + path.sep + ERC1967_PROXY_JSON),
     );
     assert(ERC1967ProxyPath, 'ERC1967Proxy artifact not found');
     const proxyContract = await import(ERC1967ProxyPath);
@@ -151,7 +152,9 @@ async function estimateGasTransparent(
         );
     }
 
-    const TUPPath = (await hre.artifacts.getArtifactPaths()).find((x) => x.includes(path.sep + TUP_JSON));
+    const TUPPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
+        x.includes(path.sep + getUpgradableContracts().TransparentUpgradeableProxy + path.sep + TUP_JSON),
+    );
     assert(TUPPath, 'TUP artifact not found');
     const TUPContract = await import(TUPPath);
 

--- a/packages/hardhat-zksync-upgradable/src/index.ts
+++ b/packages/hardhat-zksync-upgradable/src/index.ts
@@ -12,7 +12,6 @@ import { lazyObject } from 'hardhat/plugins';
 import { HardhatUpgrades, RunCompilerArgs } from './interfaces';
 import { extendCompilerOutputSelection, isFullZkSolcOutput } from './utils/utils-general';
 import { validate } from './core/validate';
-import { makeChangeProxyAdmin, makeGetInstanceFunction, makeTransferProxyAdminOwnership } from './admin';
 import {
     TASK_DEPLOY_ZKSYNC_BEACON,
     TASK_DEPLOY_ZKSYNC_PROXY,
@@ -20,7 +19,7 @@ import {
     TASK_UPGRADE_ZKSYNC_PROXY,
 } from './task-names';
 import { deployZkSyncBeacon, deployZkSyncProxy, upgradeZkSyncBeacon, upgradeZkSyncProxy } from './task-actions';
-import { PROXY_SOURCE_NAMES } from './constants';
+import { checkOpenzeppelinVersions, getUpgradableContracts } from './utils';
 
 extendEnvironment((hre) => {
     hre.zkUpgrades = lazyObject((): HardhatUpgrades => {
@@ -34,23 +33,24 @@ extendEnvironment((hre) => {
         const { makeEstimateGasProxy } = require('./gas-estimation/estimate-gas-proxy');
         const { makeEstimateGasBeacon } = require('./gas-estimation/estimate-gas-beacon');
         const { makeEstimateGasBeaconProxy } = require('./gas-estimation/estimate-gas-beacon-proxy');
+        const { makeGetInstanceFunction, makeChangeProxyAdmin, makeTransferProxyAdminOwnership } = require('./admin');
         return {
-            deployProxy: makeDeployProxy(hre),
-            upgradeProxy: makeUpgradeProxy(hre),
-            validateImplementation: makeValidateImplementation(hre),
-            deployBeacon: makeDeployBeacon(hre),
-            deployBeaconProxy: makeDeployBeaconProxy(hre),
-            upgradeBeacon: makeUpgradeBeacon(hre),
-            deployProxyAdmin: makeDeployProxyAdmin(hre),
+            deployProxy: checkOpenzeppelinVersions(makeDeployProxy(hre)),
+            upgradeProxy: checkOpenzeppelinVersions(makeUpgradeProxy(hre)),
+            validateImplementation: checkOpenzeppelinVersions(makeValidateImplementation(hre)),
+            deployBeacon: checkOpenzeppelinVersions(makeDeployBeacon(hre)),
+            deployBeaconProxy: checkOpenzeppelinVersions(makeDeployBeaconProxy(hre)),
+            upgradeBeacon: checkOpenzeppelinVersions(makeUpgradeBeacon(hre)),
+            deployProxyAdmin: checkOpenzeppelinVersions(makeDeployProxyAdmin(hre)),
             admin: {
-                getInstance: makeGetInstanceFunction(hre),
-                changeProxyAdmin: makeChangeProxyAdmin(hre),
-                transferProxyAdminOwnership: makeTransferProxyAdminOwnership(hre),
+                getInstance: checkOpenzeppelinVersions(makeGetInstanceFunction(hre)),
+                changeProxyAdmin: checkOpenzeppelinVersions(makeChangeProxyAdmin(hre)),
+                transferProxyAdminOwnership: checkOpenzeppelinVersions(makeTransferProxyAdminOwnership(hre)),
             },
             estimation: {
-                estimateGasProxy: makeEstimateGasProxy(hre),
-                estimateGasBeacon: makeEstimateGasBeacon(hre),
-                estimateGasBeaconProxy: makeEstimateGasBeaconProxy(hre),
+                estimateGasProxy: checkOpenzeppelinVersions(makeEstimateGasProxy(hre)),
+                estimateGasBeacon: checkOpenzeppelinVersions(makeEstimateGasBeacon(hre)),
+                estimateGasBeaconProxy: checkOpenzeppelinVersions(makeEstimateGasBeaconProxy(hre)),
             },
         };
     });
@@ -135,7 +135,18 @@ subtask(TASK_COMPILE_SOLIDITY_COMPILE, async (args: RunCompilerArgs, hre, runSup
 
 subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES, async (args: RunCompilerArgs, _, runSuper) => {
     const sourceNames = await runSuper();
-    return [...sourceNames, ...PROXY_SOURCE_NAMES];
+
+    const upgradableContracts = getUpgradableContracts();
+    return [
+        ...sourceNames,
+        ...[
+            upgradableContracts.ProxyAdmin,
+            upgradableContracts.TransparentUpgradeableProxy,
+            upgradableContracts.BeaconProxy,
+            upgradableContracts.UpgradeableBeacon,
+            upgradableContracts.ERC1967Proxy,
+        ],
+    ];
 });
 
 subtask('verify:verify').setAction(async (args, hre, runSuper) => {

--- a/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-beacon-proxy.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-beacon-proxy.ts
@@ -18,6 +18,7 @@ import { DeployBeaconProxyOptions } from '../utils/options';
 import { BEACON_PROXY_JSON } from '../constants';
 import { ZkSyncUpgradablePluginError } from '../errors';
 import { Manifest } from '../core/manifest';
+import { getUpgradableContracts } from '../utils';
 import { deploy, DeployTransaction } from './deploy';
 
 export interface DeployBeaconProxyFunction {
@@ -85,7 +86,7 @@ export function makeDeployBeaconProxy(hre: HardhatRuntimeEnvironment): DeployBea
         }
 
         const beaconProxyPath = (await hre.artifacts.getArtifactPaths()).find((artifactPath) =>
-            artifactPath.includes(path.sep + BEACON_PROXY_JSON),
+            artifactPath.includes(path.sep + getUpgradableContracts().BeaconProxy + path.sep + BEACON_PROXY_JSON),
         );
         assert(beaconProxyPath, 'Beacon proxy artifact not found');
         const beaconProxyContract = await import(beaconProxyPath);

--- a/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-beacon.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-beacon.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import { UPGRADABLE_BEACON_JSON } from '../constants';
 import { DeployBeaconOptions } from '../utils/options';
 import { extractFactoryDeps } from '../utils/utils-general';
+import { getUpgradableContracts } from '../utils';
 import { deployBeaconImpl } from './deploy-impl';
 import { deploy, DeployTransaction } from './deploy';
 
@@ -39,7 +40,7 @@ export function makeDeployBeacon(hre: HardhatRuntimeEnvironment): DeployBeaconFu
         }
 
         const upgradableBeaconPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
-            x.includes(path.sep + UPGRADABLE_BEACON_JSON),
+            x.includes(path.sep + getUpgradableContracts().UpgradeableBeacon + path.sep + UPGRADABLE_BEACON_JSON),
         );
         assert(upgradableBeaconPath, 'Upgradable beacon artifact not found');
         const upgradeableBeaconContract = await import(upgradableBeaconPath);

--- a/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-proxy-admin.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-proxy-admin.ts
@@ -6,6 +6,7 @@ import { ZkSyncArtifact } from '@matterlabs/hardhat-zksync-deploy/src/types';
 import { DeployProxyAdminOptions } from '../utils/options';
 import { PROXY_ADMIN_JSON } from '../constants';
 import { fetchOrDeployAdmin } from '../core/impl-store';
+import { getUpgradableContracts } from '../utils';
 import { deploy } from './deploy';
 
 export type DeployAdminFunction = (wallet?: zk.Wallet, opts?: DeployProxyAdminOptions) => Promise<string>;
@@ -19,7 +20,7 @@ export function makeDeployProxyAdmin(hre: HardhatRuntimeEnvironment): any {
 
 export async function getAdminArtifact(hre: HardhatRuntimeEnvironment): Promise<ZkSyncArtifact> {
     const proxyAdminPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
-        x.includes(path.sep + PROXY_ADMIN_JSON),
+        x.includes(path.sep + getUpgradableContracts().ProxyAdmin + path.sep + PROXY_ADMIN_JSON),
     );
     assert(proxyAdminPath, 'Proxy admin artifact not found');
     return await import(proxyAdminPath);

--- a/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-proxy.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-deployment/deploy-proxy.ts
@@ -8,10 +8,11 @@ import { ZkSyncArtifact } from '@matterlabs/hardhat-zksync-deploy/src/types';
 
 import assert from 'assert';
 import { extractFactoryDeps, getInitializerData } from '../utils/utils-general';
-import { ERC1967_PROXY_JSON, TUP_JSON } from '../constants';
+import { TUP_JSON, ERC1967_PROXY_JSON } from '../constants';
 import { Manifest, ProxyDeployment } from '../core/manifest';
 import { DeployProxyOptions } from '../utils/options';
 import { ZkSyncUpgradablePluginError } from '../errors';
+import { getUpgradableContracts } from '../utils';
 import { deployProxyImpl } from './deploy-impl';
 import { DeployTransaction, deploy } from './deploy';
 
@@ -80,7 +81,7 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
 
             case 'uups': {
                 const ERC1967ProxyPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
-                    x.includes(path.sep + ERC1967_PROXY_JSON),
+                    x.includes(path.sep + getUpgradableContracts().ERC1967Proxy + path.sep + ERC1967_PROXY_JSON),
                 );
                 assert(ERC1967ProxyPath, 'ERC1967Proxy artifact not found');
                 const proxyContract = await import(ERC1967ProxyPath);
@@ -104,7 +105,9 @@ export function makeDeployProxy(hre: HardhatRuntimeEnvironment): DeployFunction 
                     console.info(chalk.green(`Admin was deployed to ${adminAddress}`));
                 }
 
-                const TUPPath = (await hre.artifacts.getArtifactPaths()).find((x) => x.includes(path.sep + TUP_JSON));
+                const TUPPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
+                    x.includes(path.sep + getUpgradableContracts().TransparentUpgradeableProxy + path.sep + TUP_JSON),
+                );
                 assert(TUPPath, 'TUP artifact not found');
                 const TUPContract = await import(TUPPath);
 

--- a/packages/hardhat-zksync-upgradable/src/proxy-upgrade/upgrade-beacon.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-upgrade/upgrade-beacon.ts
@@ -9,6 +9,7 @@ import { ContractAddressOrInstance, extractFactoryDeps, getContractAddress } fro
 import { UpgradeBeaconOptions } from '../utils/options';
 import { deployBeaconImpl } from '../proxy-deployment/deploy-impl';
 import { UPGRADABLE_BEACON_JSON } from '../constants';
+import { getUpgradableContracts } from '../utils';
 
 export type UpgradeBeaconFunction = (
     wallet: zk.Wallet,
@@ -43,7 +44,7 @@ export function makeUpgradeBeacon(hre: HardhatRuntimeEnvironment): UpgradeBeacon
         }
 
         const upgradableBeaconPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
-            x.includes(path.sep + UPGRADABLE_BEACON_JSON),
+            x.includes(path.sep + getUpgradableContracts().UpgradeableBeacon + path.sep + UPGRADABLE_BEACON_JSON),
         );
         assert(upgradableBeaconPath, 'Upgradable beacon artifact not found');
         const upgradeableBeaconContract = await import(upgradableBeaconPath);

--- a/packages/hardhat-zksync-upgradable/src/proxy-upgrade/upgrade-proxy.ts
+++ b/packages/hardhat-zksync-upgradable/src/proxy-upgrade/upgrade-proxy.ts
@@ -14,6 +14,7 @@ import { extractFactoryDeps, getContractAddress } from '../utils/utils-general';
 import { deployProxyImpl } from '../proxy-deployment/deploy-impl';
 import { Manifest } from '../core/manifest';
 import { ITUP_JSON, PROXY_ADMIN_JSON } from '../constants';
+import { getUpgradableContracts } from '../utils';
 
 export type UpgradeFunction = (
     wallet: zk.Wallet,
@@ -66,7 +67,9 @@ export function makeUpgradeProxy(hre: HardhatRuntimeEnvironment): UpgradeFunctio
         const adminBytecode = await getCode(provider, adminAddress);
 
         if (isEmptySlot(adminAddress) || adminBytecode === '0x') {
-            const TUPPath = (await hre.artifacts.getArtifactPaths()).find((x) => x.includes(path.sep + ITUP_JSON));
+            const TUPPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
+                x.includes(path.sep + getUpgradableContracts().TransparentUpgradeableProxy + path.sep + ITUP_JSON),
+            );
             assert(TUPPath, 'Transparent upgradeable proxy artifact not found');
             const transparentUpgradeableProxyContract = await import(TUPPath);
 
@@ -82,7 +85,7 @@ export function makeUpgradeProxy(hre: HardhatRuntimeEnvironment): UpgradeFunctio
             const manifest = await Manifest.forNetwork(provider);
 
             const proxyAdminPath = (await hre.artifacts.getArtifactPaths()).find((x) =>
-                x.includes(path.sep + PROXY_ADMIN_JSON),
+                x.includes(path.sep + getUpgradableContracts().ProxyAdmin + path.sep + PROXY_ADMIN_JSON),
             );
             assert(proxyAdminPath, 'Proxy admin artifact not found');
             const proxyAdminContract = await import(proxyAdminPath);

--- a/packages/hardhat-zksync-upgradable/src/utils.ts
+++ b/packages/hardhat-zksync-upgradable/src/utils.ts
@@ -2,6 +2,13 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { Wallet } from 'zksync-ethers';
 import { getNetworkAccount, getWallet as getRealWallet } from '@matterlabs/hardhat-zksync-deploy/dist/plugin';
 import { Providers, createProviders } from '@matterlabs/hardhat-zksync-deploy/dist/deployer-helper';
+import semver from 'semver';
+import chalk from 'chalk';
+import {
+    OZ_CONTRACTS_VERISION_INCOMPATIBLE_ERROR,
+    UPGRADEABLE_CONTRACTS_FROM_ALLIAS,
+    UPGRADEABLE_CONTRACTS_FROM_CONTRACTS,
+} from './constants';
 
 export async function getWallet(hre: HardhatRuntimeEnvironment, privateKeyOrIndex?: string | number): Promise<Wallet> {
     const { ethWeb3Provider, zkWeb3Provider }: Providers = createProviders(hre.config.networks, hre.network);
@@ -10,4 +17,38 @@ export async function getWallet(hre: HardhatRuntimeEnvironment, privateKeyOrInde
         .connect(zkWeb3Provider)
         .connectToL1(ethWeb3Provider);
     return wallet;
+}
+
+export function checkOpenzeppelinVersions<T>(wrappedFunction: (...args: any) => T): (...args: any) => T {
+    return function (...args: any): T {
+        try {
+            if (!isOpenzeppelinContractsVersionValid()) {
+                throw new Error(OZ_CONTRACTS_VERISION_INCOMPATIBLE_ERROR);
+            }
+        } catch (e: any) {
+            console.warn(chalk.yellow(e.message));
+        }
+        return wrappedFunction(...args);
+    };
+}
+
+export function isOpenzeppelinContractsVersionValid(): boolean {
+    try {
+        // eslint-disable-next-line import/no-extraneous-dependencies
+        const versionContracts = require('@openzeppelin/contracts/package.json').version;
+        if (!versionContracts || semver.lt(versionContracts, '4.6.1') || semver.gt(versionContracts, '5.0.0')) {
+            return false;
+        }
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
+export function getUpgradableContracts() {
+    if (isOpenzeppelinContractsVersionValid()) {
+        return UPGRADEABLE_CONTRACTS_FROM_CONTRACTS;
+    }
+
+    return UPGRADEABLE_CONTRACTS_FROM_ALLIAS;
 }

--- a/packages/hardhat-zksync-upgradable/src/utils.ts
+++ b/packages/hardhat-zksync-upgradable/src/utils.ts
@@ -6,7 +6,7 @@ import semver from 'semver';
 import chalk from 'chalk';
 import {
     OZ_CONTRACTS_VERISION_INCOMPATIBLE_ERROR,
-    UPGRADEABLE_CONTRACTS_FROM_ALLIAS,
+    UPGRADEABLE_CONTRACTS_FROM_ALIAS,
     UPGRADEABLE_CONTRACTS_FROM_CONTRACTS,
 } from './constants';
 
@@ -50,5 +50,5 @@ export function getUpgradableContracts() {
         return UPGRADEABLE_CONTRACTS_FROM_CONTRACTS;
     }
 
-    return UPGRADEABLE_CONTRACTS_FROM_ALLIAS;
+    return UPGRADEABLE_CONTRACTS_FROM_ALIAS;
 }

--- a/packages/hardhat-zksync-upgradable/src/utils.ts
+++ b/packages/hardhat-zksync-upgradable/src/utils.ts
@@ -36,7 +36,7 @@ export function isOpenzeppelinContractsVersionValid(): boolean {
     try {
         // eslint-disable-next-line import/no-extraneous-dependencies
         const versionContracts = require('@openzeppelin/contracts/package.json').version;
-        if (!versionContracts || semver.lt(versionContracts, '4.6.1') || semver.gt(versionContracts, '5.0.0')) {
+        if (!versionContracts || semver.lt(versionContracts, '4.6.0') || semver.gt(versionContracts, '5.0.0')) {
             return false;
         }
         return true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1245,6 +1245,9 @@ importers:
       '@matterlabs/hardhat-zksync-solc':
         specifier: workspace:^
         version: link:../hardhat-zksync-solc
+      '@openzeppelin/contracts-hardhat-zksync-upgradable':
+        specifier: npm:@openzeppelin/contracts@^4.9.2
+        version: '@openzeppelin/contracts@4.9.6'
       '@openzeppelin/upgrades-core':
         specifier: ^1.31.3
         version: 1.33.1
@@ -1269,6 +1272,9 @@ importers:
       proper-lockfile:
         specifier: ^4.1.2
         version: 4.1.2
+      semver:
+        specifier: ^7.6.2
+        version: 7.6.2
       solidity-ast:
         specifier: ^0.4.56
         version: 0.4.56
@@ -1276,9 +1282,6 @@ importers:
         specifier: ^6.8.0
         version: 6.8.0(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))
     devDependencies:
-      '@openzeppelin/contracts-upgradeable':
-        specifier: ^4.9.2
-        version: 4.9.6
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4


### PR DESCRIPTION
…dencies

# What :computer: 
* Use openzeppelin/contracts alias for proper plugin work if host is using different version.
* Remove unvalid peer dependencies and add openzeppelin/contracts alias as normal dependency 

# Why :hand:
* hardhat plugin shouldn't dictate which smart contract library the project should use. But for proper work plugin need proxy contracts from oz/contracts dependency greater than 4.6.1, so plugin will use in this case alias versioned contracts.