### PR TITLE
feat: implement the get solc task in a hardhat-compatible way

### DIFF
--- a/packages/hardhat-zksync-solc/test/tests/tests.ts
+++ b/packages/hardhat-zksync-solc/test/tests/tests.ts
@@ -276,13 +276,6 @@ describe('zksolc plugin', async function () {
                 const build = await this.env.run(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, {
                     quiet: true,
                     solcVersion: '0.8.17',
-                    compilationJob: {
-                        getSolcConfig: () => {
-                            return {
-                                version: '0.8.17',
-                            };
-                        },
-                    },
                 });
 
                 assert.equal(build.compilerPath, 'solc/solc-version-0');


### PR DESCRIPTION
# What :computer: 
This PR adjusts the get solc job to be implemented in a hardhat compatible manner wrt job params:
https://github.com/NomicFoundation/hardhat/blob/93b30d531d1bb1d766bdf2105cd04fa50fef12aa/packages/hardhat-core/src/builtin-tasks/compile.ts#L561-L563
The original job only accepts `quiet` and `solcVersion` params, so there's a discrepancy between hardhat and hardhat-zksync


# Why :hand:
This is to make it easier to use when someone needs to obtain the solc build when compiling in zksync mode. In the Safe project, we do quite a few compilations from strings for tests, e.g:
```
        const source = `
        contract Test {
            function sendAndReturnBalance(address payable target, uint256 amount) public returns (uint256) {
                (bool success,) = target.call{ value: amount }("");
                require(success, "Transfer failed");
                return target.balance;
            }
        }`;
 ```
and the difference between evm/zkvm behaviours makes us write hacky code

# Evidence :camera:
The tests passed on my computer; however, the runs seem to be non-deterministic, and every third or so run fails. I'm not sure if it's related to my changes

