### PR TITLE
fix: make compilationJobs argument optional at TASK_COMPILE_SOLIDITY_…

### DIFF
--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -389,10 +389,9 @@ subtask(
                 longVersion: '',
             };
         }
+        const compiler = args.compilationJob?.getSolcConfig();
 
-        const compiler = args.compilationJob.getSolcConfig();
-
-        if (compiler.eraVersion) {
+        if (compiler && compiler.eraVersion) {
             const compilersCache = await getCompilersDir();
             let path: string = '';
             let version: string = '';

--- a/packages/hardhat-zksync-solc/test/tests/tests.ts
+++ b/packages/hardhat-zksync-solc/test/tests/tests.ts
@@ -19,6 +19,7 @@ import { ZksolcCompilerDownloader } from '../../src/compile/downloader';
 import { useEnvironment } from '../helpers';
 import { ZkSyncArtifact } from '../../src/types';
 import { TASK_DOWNLOAD_ZKSOLC } from '../../src/constants';
+import { ZkVmSolcCompilerDownloader } from '../../src/compile/zkvm-solc-downloader';
 
 chai.use(sinonChai);
 
@@ -262,6 +263,11 @@ describe('zksolc plugin', async function () {
                     longVersion: 'solc/solc-version-0-long',
                     isSolcJs: false,
                 });
+                sandbox
+                    .stub(ZkVmSolcCompilerDownloader.prototype, 'isCompilerDownloaded')
+                    .returns(isCompilerDownloaded());
+                sandbox.stub(ZkVmSolcCompilerDownloader.prototype, 'getCompilerPath').returns('zkvmsolc/0.8.17-1.0.0');
+                sandbox.stub(ZkVmSolcCompilerDownloader.prototype, 'getVersion').returns('0.8.17-1.0.0');
             });
 
             afterEach(() => {
@@ -283,6 +289,38 @@ describe('zksolc plugin', async function () {
                             };
                         },
                     },
+                });
+
+                assert.equal(build.compilerPath, 'solc/solc-version-0');
+                assert.equal(build.isSolcJs, false);
+                assert.equal(build.version, '0.8.17');
+                assert.equal(build.longVersion, 'solc/solc-version-0-long');
+            });
+
+            it('Should get solc build for binary compiler with era version', async function () {
+                const build = await this.env.run(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, {
+                    quiet: true,
+                    solcVersion: '0.8.17',
+                    compilationJob: {
+                        getSolcConfig: () => {
+                            return {
+                                version: '0.8.17',
+                                eraVersion: '1.0.0',
+                            };
+                        },
+                    },
+                });
+
+                assert.equal(build.compilerPath, 'zkvmsolc/0.8.17-1.0.0');
+                assert.equal(build.isSolcJs, false);
+                assert.equal(build.version, '0.8.17-1.0.0');
+                assert.equal(build.longVersion, 'zkVM-0.8.17-1.0.0');
+            });
+
+            it('Should get solc build for binary compiler without compilation job', async function () {
+                const build = await this.env.run(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, {
+                    quiet: true,
+                    solcVersion: '0.8.17',
                 });
 
                 assert.equal(build.compilerPath, 'solc/solc-version-0');


### PR DESCRIPTION
…GET_SOLC_BUILD subtask

# What :computer: 
* Make compilationJobs argument optional at TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD subtask

# Why :hand:
* Some users do not use the extended Hardhat subtask, so we will make this additional argument optional. This way, the compilation process will not default to using the forked Era Solidity compiler. When used in this manner, there may be differences in bytecode because, with the argument enabled, the forked Solidity compiler is used; otherwise, the native compiler will be utilized.

Opened to fix and replace this PR #1301 