### PR TITLE
fix: add gnu toolchain for linux as default from compiler version 1.5.3

### DIFF
--- a/packages/hardhat-zksync-solc/src/constants.ts
+++ b/packages/hardhat-zksync-solc/src/constants.ts
@@ -50,6 +50,8 @@ export const DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD = 24 * 60 * 60 * 1000; /
 
 export const COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR = 'Could not find zksolc compiler version info file.';
 
+export const COMPILER_MIN_LINUX_VERSION_WITH_GNU_TOOLCHAIN = '1.5.3';
+
 export const COMPILER_VERSION_RANGE_ERROR = (version: string, minVersion: string, latestVersion: string) =>
     `The zksolc compiler version (${version}) in the hardhat config file is not within the allowed range. Please use versions ${minVersion} to ${latestVersion}.`;
 export const COMPILER_VERSION_WARNING = (version: string, latestVersion: string) =>

--- a/packages/hardhat-zksync-solc/src/utils.ts
+++ b/packages/hardhat-zksync-solc/src/utils.ts
@@ -23,6 +23,7 @@ import {
     USER_AGENT,
     COMPILER_ZKSOLC_IS_SYSTEM_USE,
     COMPILER_ZKSOLC_FORCE_EVMLA_USE,
+    COMPILER_MIN_LINUX_VERSION_WITH_GNU_TOOLCHAIN,
 } from './constants';
 import { ZkSyncSolcPluginError } from './errors';
 import {
@@ -167,8 +168,11 @@ export function saltFromUrl(url: string): string {
 export function getZksolcUrl(repo: string, version: string, isRelease: boolean = true): string {
     // @ts-ignore
     const platform = { darwin: 'macosx', linux: 'linux', win32: 'windows' }[process.platform];
-    // @ts-ignore
-    const toolchain = { linux: '-musl', win32: '-gnu', darwin: '' }[process.platform];
+    const toolchain = semver.lt(version, COMPILER_MIN_LINUX_VERSION_WITH_GNU_TOOLCHAIN)
+        ? // @ts-ignore
+          { linux: '-musl', win32: '-gnu', darwin: '' }[process.platform]
+        : // @ts-ignore
+          { linux: '-gnu', win32: '-gnu', darwin: '' }[process.platform];
     const arch = process.arch === 'x64' ? 'amd64' : process.arch;
     const ext = process.platform === 'win32' ? '.exe' : '';
 


### PR DESCRIPTION
# What :computer: 
* add gnu toolchain for linux as default from compiler version 1.5.3

# Why :hand:
* ML compiler team managed to make static builds for Linux without musl by linking static glibc. This executable has much better performance, as musl memory manager is much slower.