### PR TITLE
fix: add gnu toolchain for linux as default from compiler version 1.5.4

### DIFF
--- a/packages/hardhat-zksync-vyper/src/constants.ts
+++ b/packages/hardhat-zksync-vyper/src/constants.ts
@@ -37,6 +37,8 @@ export const DEFAULT_COMPILER_VERSION_INFO_CACHE_PERIOD = 24 * 60 * 60 * 1000; /
 
 export const ZKVYPER_COMPILER_MIN_VERSION_WITH_FALLBACK_OZ = '1.3.15';
 
+export const COMPILER_MIN_LINUX_VERSION_WITH_GNU_TOOLCHAIN = '1.5.4';
+
 export const COMPILER_VERSION_INFO_FILE_NOT_FOUND_ERROR =
     'Could not find zkvyper compiler version info file. Please check your internet connection and try again.';
 export const COMPILER_VERSION_INFO_FILE_DOWNLOAD_ERROR =

--- a/packages/hardhat-zksync-vyper/src/utils.ts
+++ b/packages/hardhat-zksync-vyper/src/utils.ts
@@ -9,7 +9,12 @@ import type { Dispatcher } from 'undici';
 import { MultiVyperConfig } from '@nomiclabs/hardhat-vyper/dist/src/types';
 
 import { CompilerVersionInfo } from './compile/downloader';
-import { DEFAULT_TIMEOUT_MILISECONDS, UNSUPPORTED_VYPER_VERSIONS, VYPER_VERSION_ERROR } from './constants';
+import {
+    COMPILER_MIN_LINUX_VERSION_WITH_GNU_TOOLCHAIN,
+    DEFAULT_TIMEOUT_MILISECONDS,
+    UNSUPPORTED_VYPER_VERSIONS,
+    VYPER_VERSION_ERROR,
+} from './constants';
 import { ZkSyncVyperPluginError } from './errors';
 
 const TEMP_FILE_PREFIX = 'tmp-';
@@ -22,8 +27,11 @@ export function zeroxlify(hex: string): string {
 export function getZkvyperUrl(repo: string, version: string, isRelease: boolean = true): string {
     // @ts-ignore
     const platform = { darwin: 'macosx', linux: 'linux', win32: 'windows' }[process.platform];
-    // @ts-ignore
-    const toolchain = { linux: '-musl', win32: '-gnu', darwin: '' }[process.platform];
+    const toolchain = semver.lt(version, COMPILER_MIN_LINUX_VERSION_WITH_GNU_TOOLCHAIN)
+        ? // @ts-ignore
+          { linux: '-musl', win32: '-gnu', darwin: '' }[process.platform]
+        : // @ts-ignore
+          { linux: '-gnu', win32: '-gnu', darwin: '' }[process.platform];
     const arch = process.arch === 'x64' ? 'amd64' : process.arch;
     const ext = process.platform === 'win32' ? '.exe' : '';
 


### PR DESCRIPTION
# What :computer: 
* add gnu toolchain for linux as default from compiler version 1.5.3

# Why :hand:
* ML compiler team managed to make static builds for Linux without musl by linking static glibc. This executable has much better performance, as musl memory manager is much slower.