### PR TITLE
fix: add suppressed errors and warnings

### DIFF
--- a/packages/hardhat-zksync-solc/README.md
+++ b/packages/hardhat-zksync-solc/README.md
@@ -36,6 +36,8 @@ zksolc: {
         mode: '3' // optional. 3 by default, z to optimize bytecode size
         fallback_to_optimizing_for_size: false, // optional. Try to recompile with optimizer mode "z" if the bytecode is too large
       },
+      suppressedWarnings: ['txorigin', 'sendtransfer'], // Suppress specified warnings. Currently supported: txorigin, sendtransfer
+      suppressedErrors: ['txorigin', 'sendtransfer'], // Suppress specified errors. Currently supported: txorigin, sendtransfer
       experimental: {
         dockerImage: '', // deprecated
         tag: ''   // deprecated
@@ -59,6 +61,8 @@ Starting from zksolc version 1.5.0, the ZKsync Era Solidity compiler will be use
 | enableEraVMExtensions                    | Required if contracts use enables Yul instructions available only for ZKsync system contracts and libraries. In the older versions of the plugin known as 'isSystem' flag          |
 | forceEVMLA                  | Compile with EVM legacy assembly codegen. If the zksolc version is below 1.5.0, this argument will act as a 'forceEvmla' flag in the older versions of the plugin, attempting to fallback to EVM legacy assembly if there is a bug with Yul.                        |
 | optimizer                   | Compiler optimizations (enabled: true (default) or false), mode: 3 (default), fallback_to_optimizing_for_size: false (default) recommended for most projects.          |
+| suppressedWarnings          | Suppress specified warnings. Currently supported: txorigin, sendtransfer                                                                                                       |
+| suppressedErrors            | Suppress specified errors. Currently supported: txorigin, sendtransfer                                                                                                       |
 | metadata                    | Metadata settings. If the option is omitted, the metadata hash appends by default: bytecodeHash. Can only be none.   |
 | dockerImage                 | (deprecated) option used to identify the name of the compiler docker image.                                          |
 

--- a/packages/hardhat-zksync-solc/src/index.ts
+++ b/packages/hardhat-zksync-solc/src/index.ts
@@ -13,6 +13,7 @@ import {
     TASK_COMPILE_SOLIDITY_LOG_RUN_COMPILER_END,
     TASK_COMPILE_SOLIDITY_EMIT_ARTIFACTS,
     TASK_COMPILE,
+    TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT,
 } from 'hardhat/builtin-tasks/task-names';
 import { extendEnvironment, extendConfig, subtask, task } from 'hardhat/internal/core/config/config-env';
 import { getCompilersDir } from 'hardhat/internal/util/global-dir';
@@ -65,7 +66,7 @@ import {
     SolcStringUserConfigExtractor,
     SolcUserConfigExtractor,
 } from './config-extractor';
-import { FactoryDeps } from './types';
+import { FactoryDeps, ZkSyncCompilerInput } from './types';
 
 const logDebug = debug('hardhat:core:tasks:compile');
 
@@ -553,6 +554,23 @@ subtask(TASK_COMPILE_SOLIDITY_EMIT_ARTIFACTS).setAction(
         return { artifactsEmittedPerFile };
     },
 );
+
+subtask(TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT, async (taskArgs, hre, runSuper) => {
+    const compilerInput: ZkSyncCompilerInput = await runSuper(taskArgs);
+    if (hre.network.zksync !== true) {
+        return compilerInput;
+    }
+
+    if (hre.config.zksolc.settings.suppressedErrors && hre.config.zksolc.settings.suppressedErrors.length > 0) {
+        compilerInput.suppressedErrors = hre.config.zksolc.settings.suppressedErrors;
+    }
+
+    if (hre.config.zksolc.settings.suppressedWarnings && hre.config.zksolc.settings.suppressedWarnings.length > 0) {
+        compilerInput.suppressedWarnings = hre.config.zksolc.settings.suppressedWarnings;
+    }
+
+    return compilerInput;
+});
 
 subtask(TASK_COMPILE_REMOVE_OBSOLETE_ARTIFACTS, async (taskArgs, hre, runSuper) => {
     if (hre.network.zksync !== true || !hre.config.zksolc.settings.areLibrariesMissing) {

--- a/packages/hardhat-zksync-solc/src/type-extensions.ts
+++ b/packages/hardhat-zksync-solc/src/type-extensions.ts
@@ -29,6 +29,7 @@ declare module 'hardhat/types/config' {
 
     interface SolcConfig {
         eraVersion?: string;
+        suppressedErrors?: string[];
     }
 
     interface SolcUserConfig {

--- a/packages/hardhat-zksync-solc/src/type-extensions.ts
+++ b/packages/hardhat-zksync-solc/src/type-extensions.ts
@@ -29,7 +29,6 @@ declare module 'hardhat/types/config' {
 
     interface SolcConfig {
         eraVersion?: string;
-        suppressedErrors?: string[];
     }
 
     interface SolcUserConfig {

--- a/packages/hardhat-zksync-solc/src/types.ts
+++ b/packages/hardhat-zksync-solc/src/types.ts
@@ -46,23 +46,18 @@ export interface ZkSolcConfig {
         forceContractsToCompile?: string[];
         // Dump all IR (Yul, EVMLA, LLVM IR, assembly) to files in the specified directory. Only for testing and debugging.
         debugOutputDir?: string;
-        // Suppress specified warnings. Currently supported: TxOrigin, SendTransfer
-        suppressedWarnings?: SuppressedMessageType[];
-        // Suppress specified errors. Currently supported: TxOrigin, SendTransfer
-        suppressedErrors?: SuppressedMessageType[];
+        // Suppress specified warnings. Currently supported: txorigin, sendtransfer
+        suppressedWarnings?: string[];
+        // Suppress specified errors. Currently supported: txorigin, sendtransfer
+        suppressedErrors?: string[];
     };
 }
 
 export interface ZkSyncCompilerInput extends CompilerInput {
-    // Suppress specified warnings. Currently supported: TxOrigin, SendTransfer
-    suppressedWarnings?: SuppressedMessageType[];
-    // Suppress specified errors. Currently supported: TxOrigin, SendTransfer
-    suppressedErrors?: SuppressedMessageType[];
-}
-
-export enum SuppressedMessageType {
-    TxOrigin = 'TxOrigin',
-    SendTransfer = 'SendTransfer',
+    // Suppress specified warnings. Currently supported: txorigin, sendtransfer
+    suppressedWarnings?: string[];
+    // Suppress specified errors. Currently supported: txorigin, sendtransfer
+    suppressedErrors?: string[];
 }
 
 export interface CompilerOutputSelection {

--- a/packages/hardhat-zksync-solc/src/types.ts
+++ b/packages/hardhat-zksync-solc/src/types.ts
@@ -1,4 +1,4 @@
-import { Artifact } from 'hardhat/types';
+import { Artifact, CompilerInput } from 'hardhat/types';
 
 export interface ZkSolcConfig {
     version: string; // Currently ignored.
@@ -46,7 +46,23 @@ export interface ZkSolcConfig {
         forceContractsToCompile?: string[];
         // Dump all IR (Yul, EVMLA, LLVM IR, assembly) to files in the specified directory. Only for testing and debugging.
         debugOutputDir?: string;
+        // Suppress specified warnings. Currently supported: TxOrigin, SendTransfer
+        suppressedWarnings?: SuppressedMessageType[];
+        // Suppress specified errors. Currently supported: TxOrigin, SendTransfer
+        suppressedErrors?: SuppressedMessageType[];
     };
+}
+
+export interface ZkSyncCompilerInput extends CompilerInput {
+    // Suppress specified warnings. Currently supported: TxOrigin, SendTransfer
+    suppressedWarnings?: SuppressedMessageType[];
+    // Suppress specified errors. Currently supported: TxOrigin, SendTransfer
+    suppressedErrors?: SuppressedMessageType[];
+}
+
+export enum SuppressedMessageType {
+    TxOrigin = 'TxOrigin',
+    SendTransfer = 'SendTransfer',
 }
 
 export interface CompilerOutputSelection {

--- a/packages/hardhat-zksync-solc/test/fixture-projects/suppresed-warnings-errors/contracts/Greeter.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/suppresed-warnings-errors/contracts/Greeter.sol
@@ -10,7 +10,7 @@ contract Greeter {
         greeting = _greeting;
     }
 
-    function payGreet(address payable a) public payable returns (bool memory) {
+    function payGreet(address payable a) public payable returns (bool) {
         require(a != address(0), "Invalid address");
         bool success = a.send(1);
         return success;

--- a/packages/hardhat-zksync-solc/test/fixture-projects/suppresed-warnings-errors/contracts/Greeter.sol
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/suppresed-warnings-errors/contracts/Greeter.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.4.22 <0.9.0;
+
+contract Greeter {
+
+    string greeting;
+    string bad;
+    constructor(string memory _greeting) {
+        greeting = _greeting;
+    }
+
+    function payGreet(address payable a) public payable returns (bool memory) {
+        require(a != address(0), "Invalid address");
+        bool success = a.send(1);
+        return success;
+    }
+
+}

--- a/packages/hardhat-zksync-solc/test/fixture-projects/suppresed-warnings-errors/hardhat.config.ts
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/suppresed-warnings-errors/hardhat.config.ts
@@ -1,0 +1,23 @@
+import '../../../src/index';
+import { HardhatUserConfig } from 'hardhat/config';
+import { SuppressedMessageType } from '../../../src/types';
+
+const config: HardhatUserConfig = {
+    zksolc: {
+        compilerSource: 'binary',
+        settings: {
+            suppressedErrors: [SuppressedMessageType.SendTransfer],
+            suppressedWarnings: [SuppressedMessageType.TxOrigin],
+        },
+    },
+    networks: {
+        hardhat: {
+            zksync: true,
+        },
+    },
+    solidity: {
+        version: process.env.SOLC_VERSION || '0.8.17',
+    },
+};
+
+export default config;

--- a/packages/hardhat-zksync-solc/test/fixture-projects/suppresed-warnings-errors/hardhat.config.ts
+++ b/packages/hardhat-zksync-solc/test/fixture-projects/suppresed-warnings-errors/hardhat.config.ts
@@ -1,13 +1,12 @@
 import '../../../src/index';
 import { HardhatUserConfig } from 'hardhat/config';
-import { SuppressedMessageType } from '../../../src/types';
 
 const config: HardhatUserConfig = {
     zksolc: {
         compilerSource: 'binary',
         settings: {
-            suppressedErrors: [SuppressedMessageType.SendTransfer],
-            suppressedWarnings: [SuppressedMessageType.TxOrigin],
+            suppressedErrors: ['sendtransfer'],
+            suppressedWarnings: ['txorigin'],
         },
     },
     networks: {

--- a/packages/hardhat-zksync-solc/test/tests/tests.ts
+++ b/packages/hardhat-zksync-solc/test/tests/tests.ts
@@ -516,14 +516,6 @@ describe('zksolc plugin', async function () {
                 assert.deepEqual(compilerInput.suppressedWarnings, ['txorigin']);
                 assert.deepEqual(compilerInput.suppressedErrors, ['sendtransfer']);
             });
-
-            it('Should successfully compile a simple contract with suppresed warnings and errors', async function () {
-                await this.env.run(TASK_COMPILE);
-
-                const artifact = this.env.artifacts.readArtifactSync('Greeter') as ZkSyncArtifact;
-
-                assert.equal(artifact.contractName, 'Greeter');
-            });
         });
 
         describe('Missing Library', async function () {

--- a/packages/hardhat-zksync-solc/test/tests/tests.ts
+++ b/packages/hardhat-zksync-solc/test/tests/tests.ts
@@ -1,6 +1,7 @@
 import {
     TASK_COMPILE,
     TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS,
+    TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT,
     TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
     TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD,
     TASK_COMPILE_SOLIDITY_GET_SOURCE_NAMES,
@@ -481,6 +482,39 @@ describe('zksolc plugin', async function () {
                 );
                 assert.equal(fooDepArtifactFromFactoryDeps.bytecode, fooDepArtifact.bytecode, 'Artifacts do not match');
                 assert.deepEqual(fooDepArtifactFromFactoryDeps.abi, fooDepArtifact.abi, 'Artifacts do not match');
+            });
+        });
+
+        describe('Suppresed warnings and errors', async function () {
+            useEnvironment('suppresed-warnings-errors');
+
+            it('Should populate proper compiler input suppresed warnings and errors', async function () {
+                const rootPath = this.env.config.paths.root;
+                const sourceNames: string[] = ['contracts/Greeter.sol'];
+
+                const solidityFilesCachePath = path.join(this.env.config.paths.cache, SOLIDITY_FILES_CACHE_FILENAME);
+
+                const dependencyGraph: DependencyGraph = await this.env.run(
+                    TASK_COMPILE_SOLIDITY_GET_DEPENDENCY_GRAPH,
+                    {
+                        rootPath,
+                        sourceNames,
+                        solidityFilesCachePath,
+                    },
+                );
+
+                const { jobs, _ } = await this.env.run(TASK_COMPILE_SOLIDITY_GET_COMPILATION_JOBS, {
+                    dependencyGraph,
+                    solidityFilesCachePath,
+                });
+
+                assert.equal(1, jobs.length);
+                const compilerInput = await this.env.run(TASK_COMPILE_SOLIDITY_GET_COMPILER_INPUT, {
+                    compilationJob: jobs[0],
+                });
+
+                assert.deepEqual(compilerInput.suppressedWarnings, ['TxOrigin']);
+                assert.deepEqual(compilerInput.suppressedErrors, ['SendTransfer']);
             });
         });
 

--- a/packages/hardhat-zksync-solc/test/tests/tests.ts
+++ b/packages/hardhat-zksync-solc/test/tests/tests.ts
@@ -513,8 +513,16 @@ describe('zksolc plugin', async function () {
                     compilationJob: jobs[0],
                 });
 
-                assert.deepEqual(compilerInput.suppressedWarnings, ['TxOrigin']);
-                assert.deepEqual(compilerInput.suppressedErrors, ['SendTransfer']);
+                assert.deepEqual(compilerInput.suppressedWarnings, ['txorigin']);
+                assert.deepEqual(compilerInput.suppressedErrors, ['sendtransfer']);
+            });
+
+            it('Should successfully compile a simple contract with suppresed warnings and errors', async function () {
+                await this.env.run(TASK_COMPILE);
+
+                const artifact = this.env.artifacts.readArtifactSync('Greeter') as ZkSyncArtifact;
+
+                assert.equal(artifact.contractName, 'Greeter');
             });
         });
 


### PR DESCRIPTION
# What :computer: 
* Add suppressed errors and warnings

# Why :hand:
* zksolc doesn’t suppress those kinds of errors and warnings by default, so users need to configure them in the Hardhat configuration file