### PR TITLE
fix: update verify vyper-verify plugin to correctly evaluate versions and determine latest

### DIFF
--- a/packages/hardhat-zksync-verify-vyper/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify-vyper/src/task-actions.ts
@@ -83,14 +83,25 @@ export async function verifyContract(
     const vyperVersion = contractCache.vyperConfig.version;
 
     const compilerPossibleVersions = await getSupportedCompilerVersions(hre.network.verifyURL, CompilerType.VYPER);
-    if (!compilerPossibleVersions.includes(vyperVersion)) {
+    const isVyperVersionSupported = compilerPossibleVersions.some((version) => version.trim() === vyperVersion.trim());
+    if (!isVyperVersionSupported) {
         throw new ZkSyncVerifyPluginError(COMPILER_VERSION_NOT_SUPPORTED);
     }
 
-    const zkVyperVersion = `v${hre.config.zkvyper.version}`;
-
     const zkCompilerPossibleVersions = await getSupportedCompilerVersions(hre.network.verifyURL, CompilerType.ZKVYPER);
-    if (!zkCompilerPossibleVersions.includes(zkVyperVersion)) {
+    let zkVyperVersion;
+    if (hre.config.zkvyper.version === 'latest') {
+        zkVyperVersion = `${zkCompilerPossibleVersions[zkCompilerPossibleVersions.length - 1]}`;
+    } else {
+        zkVyperVersion = `v${hre.config.zkvyper.version}`;
+    }
+
+    // Use Array.prototype.some() for comparison of zkvyper versions
+    const isZkVyperVersionSupported = zkCompilerPossibleVersions.some(
+        (version) => version.trim() === zkVyperVersion.trim(),
+    );
+
+    if (!isZkVyperVersionSupported) {
         throw new ZkSyncVerifyPluginError(ZK_COMPILER_VERSION_NOT_SUPPORTED);
     }
 


### PR DESCRIPTION
# What :computer: 
* update verify vyper-verify plugin to correctly evaluate versions and determine latest

# Why :hand:
* When testing 0.4.0 vyper compiler it kept evaluating false even though the compiler is supported
* When using `latest` in the config it would attempt to evaluate the string latest to the supported versions

# Evidence :camera:
Include screenshots, screen recordings, or `console` output here demonstrating that your changes work as intended
- https://sepolia.explorer.zksync.io/address/0x05105Cf0aeBA4c46Db44542a666429996393D3a5#contract
- https://zksync2-mainnet-explorer.zksync.io/contract_verification/vyper_versions
<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?