### PR TITLE
fix: download zkvyper if needed before compilation

### DIFF
--- a/packages/hardhat-zksync-vyper/src/constants.ts
+++ b/packages/hardhat-zksync-vyper/src/constants.ts
@@ -6,7 +6,7 @@ export const ZKVYPER_BIN_REPOSITORY = 'https://github.com/matter-labs/zkvyper-bi
 export const DEFAULT_TIMEOUT_MILISECONDS = 30000;
 export const TASK_COMPILE_VYPER_CHECK_ERRORS = 'compile:vyper:check-errors';
 export const TASK_COMPILE_VYPER_LOG_COMPILATION_ERRORS = 'compile:vyper:log:compilation-errors';
-export const TASK_DOWNLOAD_ZKVYPER = 'compile:zkvyper:download'
+export const TASK_DOWNLOAD_ZKVYPER = 'compile:zkvyper:download';
 export const ZKVYPER_COMPILER_PATH_VERSION = 'local_or_remote';
 
 // User agent of MacOSX Chrome 120.0.0.0

--- a/packages/hardhat-zksync-vyper/src/constants.ts
+++ b/packages/hardhat-zksync-vyper/src/constants.ts
@@ -6,7 +6,7 @@ export const ZKVYPER_BIN_REPOSITORY = 'https://github.com/matter-labs/zkvyper-bi
 export const DEFAULT_TIMEOUT_MILISECONDS = 30000;
 export const TASK_COMPILE_VYPER_CHECK_ERRORS = 'compile:vyper:check-errors';
 export const TASK_COMPILE_VYPER_LOG_COMPILATION_ERRORS = 'compile:vyper:log:compilation-errors';
-
+export const TASK_DOWNLOAD_ZKVYPER = 'compile:zkvyper:download'
 export const ZKVYPER_COMPILER_PATH_VERSION = 'local_or_remote';
 
 // User agent of MacOSX Chrome 120.0.0.0

--- a/packages/hardhat-zksync-vyper/src/index.ts
+++ b/packages/hardhat-zksync-vyper/src/index.ts
@@ -3,6 +3,7 @@ import {
     TASK_COMPILE_VYPER_GET_BUILD,
     TASK_COMPILE_VYPER_LOG_COMPILATION_RESULT,
     TASK_COMPILE_VYPER_LOG_DOWNLOAD_COMPILER_START,
+    TASK_COMPILE_VYPER,
 } from '@nomiclabs/hardhat-vyper/dist/src/task-names';
 import {
     TASK_COMPILE_SOLIDITY_LOG_COMPILATION_RESULT,
@@ -13,7 +14,7 @@ import { getCompilersDir } from 'hardhat/internal/util/global-dir';
 import { Mutex } from 'hardhat/internal/vendor/await-semaphore';
 import './type-extensions';
 import chalk from 'chalk';
-import { CompilationJob } from 'hardhat/types';
+import { CompilationJob, TaskArguments } from 'hardhat/types';
 import { PROXY_NAME, ProxtContractOutput, ZkArtifacts, proxyNames } from './artifacts';
 import { compile } from './compile';
 import { checkSupportedVyperVersions, pluralize } from './utils';
@@ -22,9 +23,12 @@ import {
     defaultZkVyperConfig,
     TASK_COMPILE_VYPER_CHECK_ERRORS,
     TASK_COMPILE_VYPER_LOG_COMPILATION_ERRORS,
+    TASK_DOWNLOAD_ZKVYPER,
     ZKVYPER_COMPILER_PATH_VERSION,
 } from './constants';
 import { ZkVyperCompilerDownloader } from './compile/downloader';
+
+const zkVyperCompilerDownloaderMutex = new Mutex();
 
 extendConfig((config, userConfig) => {
     defaultZkVyperConfig.version = userConfig.zkvyper?.settings?.compilerPath
@@ -59,6 +63,39 @@ extendEnvironment((hre) => {
         hre.config.paths.cache = cachePath;
         (hre as any).artifacts = new ZkArtifacts(artifactsPath);
     }
+});
+
+subtask(TASK_COMPILE_VYPER)
+  .setAction(
+    async (args: TaskArguments, hre, runSuper) => {
+        if(hre.network.zksync) {
+            await hre.run(TASK_DOWNLOAD_ZKVYPER)
+        }
+        
+        await runSuper(args);
+  });
+
+  subtask(TASK_DOWNLOAD_ZKVYPER, async (_args, hre) => {
+    if (!hre.network.zksync) {
+        return;
+    }
+
+    const compilersCache = await getCompilersDir();
+
+    await zkVyperCompilerDownloaderMutex.use(async () => {
+        const zkvyperDownloader = await ZkVyperCompilerDownloader.getDownloaderWithVersionValidated(
+            hre.config.zkvyper.version,
+            hre.config.zkvyper.settings.compilerPath ?? '',
+            compilersCache,
+        );
+
+        const isZksolcDownloaded = await zkvyperDownloader.isCompilerDownloaded();
+        if (!isZksolcDownloaded) {
+            await zkvyperDownloader.downloadCompiler();
+        }
+        hre.config.zkvyper.settings.compilerPath = zkvyperDownloader.getCompilerPath();
+        hre.config.zkvyper.version = zkvyperDownloader.getVersion();
+    });
 });
 
 // If there're no .sol files to compile - that's ok.
@@ -117,23 +154,6 @@ subtask(TASK_COMPILE_VYPER_GET_BUILD, async (args: { vyperVersion: string }, hre
     }
 
     const vyperBuild = await runSuper(args);
-    const compilersCache = await getCompilersDir();
-
-    const mutex = new Mutex();
-    await mutex.use(async () => {
-        const zkvyperDownloader = await ZkVyperCompilerDownloader.getDownloaderWithVersionValidated(
-            hre.config.zkvyper.version,
-            hre.config.zkvyper.settings.compilerPath ?? '',
-            compilersCache,
-        );
-
-        const isZksolcDownloaded = await zkvyperDownloader.isCompilerDownloaded();
-        if (!isZksolcDownloaded) {
-            await zkvyperDownloader.downloadCompiler();
-        }
-        hre.config.zkvyper.settings.compilerPath = zkvyperDownloader.getCompilerPath();
-        hre.config.zkvyper.version = zkvyperDownloader.getVersion();
-    });
 
     console.info(chalk.yellow(COMPILING_INFO_MESSAGE(hre.config.zkvyper.version, args.vyperVersion)));
 

--- a/packages/hardhat-zksync-vyper/src/index.ts
+++ b/packages/hardhat-zksync-vyper/src/index.ts
@@ -65,17 +65,15 @@ extendEnvironment((hre) => {
     }
 });
 
-subtask(TASK_COMPILE_VYPER)
-  .setAction(
-    async (args: TaskArguments, hre, runSuper) => {
-        if(hre.network.zksync) {
-            await hre.run(TASK_DOWNLOAD_ZKVYPER)
-        }
-        
-        await runSuper(args);
-  });
+subtask(TASK_COMPILE_VYPER).setAction(async (args: TaskArguments, hre, runSuper) => {
+    if (hre.network.zksync) {
+        await hre.run(TASK_DOWNLOAD_ZKVYPER);
+    }
 
-  subtask(TASK_DOWNLOAD_ZKVYPER, async (_args, hre) => {
+    await runSuper(args);
+});
+
+subtask(TASK_DOWNLOAD_ZKVYPER, async (_args, hre) => {
     if (!hre.network.zksync) {
         return;
     }
@@ -118,6 +116,8 @@ subtask(TASK_COMPILE_VYPER_RUN_BINARY, async (args: { inputPaths: string[]; vype
 
     delete compilerOutput.zk_version;
     delete compilerOutput.long_version;
+    delete compilerOutput.project_metadata;
+    delete compilerOutput.extra_data;
 
     proxyNames.forEach((proxyName) => {
         if (compilerOutput[proxyName]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -735,9 +735,6 @@ importers:
       ethers:
         specifier: ^6.12.2
         version: 6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      hardhat:
-        specifier: ^2.22.5
-        version: 2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)
       zksync-ethers:
         specifier: ^6.11.2
         version: 6.11.2(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -735,6 +735,9 @@ importers:
       ethers:
         specifier: ^6.12.2
         version: 6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      hardhat:
+        specifier: ^2.22.5
+        version: 2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)
       zksync-ethers:
         specifier: ^6.11.2
         version: 6.11.2(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))


### PR DESCRIPTION
# What :computer: 
* Download zkvyper if needed before compilation

# Why :hand:
* It will make the compilation process similar to solc and help the verification plugin resolve the correct zkvyper version.