### PR TITLE
fix: verify contract params format

### DIFF
--- a/packages/hardhat-zksync-verify/src/explorers/zksync-block-explorer/service.ts
+++ b/packages/hardhat-zksync-verify/src/explorers/zksync-block-explorer/service.ts
@@ -1,7 +1,11 @@
+import { ChainConfig } from '@nomicfoundation/hardhat-verify/types';
 import axios from 'axios';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { ChainConfig } from '@nomicfoundation/hardhat-verify/types';
+import { COMPILATION_ERRORS, NO_MATCHING_CONTRACT } from '../../constants';
+import { ZkSyncVerifyPluginError } from '../../errors';
+import { ContractInformation } from '../../solc/types';
 import { extractQueryParams, handleAxiosError } from '../../utils';
+import { ZksyncContractVerificationInvalidStatusCodeError } from '../errors';
 import {
     ContractVerifyDataInfo,
     VerificationService,
@@ -9,12 +13,8 @@ import {
     VerificationServiceVerificationIdResponse,
 } from '../service';
 import { ZkSyncExplorerVerifyRequest } from '../verify-contract-request';
-import { ZkSyncVerifyPluginError } from '../../errors';
-import { ContractInformation } from '../../solc/types';
-import { COMPILATION_ERRORS, NO_MATCHING_CONTRACT } from '../../constants';
-import { ZksyncContractVerificationInvalidStatusCodeError } from '../errors';
-import { ZksyncBlockExplorerResponse } from './verification-status-response';
 import { builtinChains } from './chain-config';
+import { ZksyncBlockExplorerResponse } from './verification-status-response';
 
 export class ZkSyncExplorerService extends VerificationService<
     number,
@@ -89,7 +89,7 @@ export class ZkSyncExplorerService extends VerificationService<
         try {
             const [verifyUrl, params] = extractQueryParams(this.verifyUrl);
             const request = this.generateRequest(req);
-            const response = await axios.post(verifyUrl, request, params);
+            const response = await axios.post(verifyUrl, request, { params });
             const zkSyncBlockExplorerResponse = new ZkSyncBlockExplorerVerificationIdResponse(response);
 
             if (!zkSyncBlockExplorerResponse.isOk()) {


### PR DESCRIPTION
# What :computer: 
fix verify contract params format

# Why :hand:
cannot pass through the request params in `POST` method