### PR TITLE
feat: show contract logs while running tests and scripts with zksync hardhat node [DO NOT MERGE]

### DIFF
--- a/packages/hardhat-zksync-node/src/core/global-interceptor.ts
+++ b/packages/hardhat-zksync-node/src/core/global-interceptor.ts
@@ -32,7 +32,7 @@ async function wrapTaskWithNode(taskArgs: TaskArguments, env: any, runSuper: Run
         return await runSuper(taskArgs);
     }
     const zkSyncGlobal = global as ZKSyncTasksWithWrappedNode;
-    const { commandArgs, server, port } = await startServer();
+    const { commandArgs, server, port } = await startServer(undefined, false, { quiet: true });
     try {
         await server.listen(commandArgs, false);
         await waitForNodeToBeReady(port);

--- a/packages/hardhat-zksync-node/src/core/script-runner.ts
+++ b/packages/hardhat-zksync-node/src/core/script-runner.ts
@@ -19,7 +19,7 @@ export async function runScript(
         ...extraNodeArgs,
     ];
 
-    const { commandArgs, server, port } = await startServer();
+    const { commandArgs, server, port } = await startServer(undefined, false, { showNodeConfig: false, showTxSummary: false });
     await server.listen(commandArgs, false);
     await waitForNodeToBeReady(port);
 

--- a/packages/hardhat-zksync-node/src/index.ts
+++ b/packages/hardhat-zksync-node/src/index.ts
@@ -113,6 +113,10 @@ task(TASK_NODE, 'Start a ZKSync Node')
         types.string,
     )
     .addOptionalParam(
+        'showEventLogs',
+        'Show event logs',
+    )
+    .addOptionalParam(
         'showStorageLogs',
         'Show storage log information (none, read, write, all) - default: none',
         undefined,
@@ -174,6 +178,10 @@ task(TASK_NODE_ZKSYNC, 'Starts a JSON-RPC server for ZKsync node')
         types.string,
     )
     .addOptionalParam(
+        'showEventLogs',
+        'Show event logs',
+    )
+    .addOptionalParam(
         'showStorageLogs',
         'Show storage log information (none, read, write, all) - default: none',
         undefined,
@@ -208,6 +216,10 @@ task(TASK_NODE_ZKSYNC, 'Starts a JSON-RPC server for ZKsync node')
     .addOptionalParam('forkBlockNumber', 'Fork at the specified block height', undefined, types.int)
     .addOptionalParam('replayTx', 'Transaction hash to replay', undefined, types.string)
     .addOptionalParam('tag', 'Specified node release for use', undefined)
+    .addOptionalParam(
+        'quite',
+        'Disables logs',
+    )
     // .addFlag('force', 'Force download even if the binary already exists')
     .setAction(
         async (
@@ -219,6 +231,7 @@ task(TASK_NODE_ZKSYNC, 'Starts a JSON-RPC server for ZKsync node')
                 cacheDir,
                 resetCache,
                 showCalls,
+                showEventLogs,
                 showStorageLogs,
                 showVmDetails,
                 showGasDetails,
@@ -228,6 +241,7 @@ task(TASK_NODE_ZKSYNC, 'Starts a JSON-RPC server for ZKsync node')
                 forkBlockNumber,
                 replayTx,
                 tag,
+                quiet,
             }: {
                 port: number;
                 log: string;
@@ -236,6 +250,7 @@ task(TASK_NODE_ZKSYNC, 'Starts a JSON-RPC server for ZKsync node')
                 cacheDir: string;
                 resetCache: boolean;
                 showCalls: string;
+                showEventLogs: boolean;
                 showStorageLogs: string;
                 showVmDetails: string;
                 showGasDetails: string;
@@ -245,6 +260,7 @@ task(TASK_NODE_ZKSYNC, 'Starts a JSON-RPC server for ZKsync node')
                 forkBlockNumber: number;
                 replayTx: string;
                 tag: string;
+                quiet: boolean;
             },
             { run },
         ) => {
@@ -256,6 +272,7 @@ task(TASK_NODE_ZKSYNC, 'Starts a JSON-RPC server for ZKsync node')
                 cacheDir,
                 resetCache,
                 showCalls,
+                showEventLogs,
                 showStorageLogs,
                 showVmDetails,
                 showGasDetails,
@@ -264,6 +281,7 @@ task(TASK_NODE_ZKSYNC, 'Starts a JSON-RPC server for ZKsync node')
                 fork,
                 forkBlockNumber,
                 replayTx,
+                quiet,
             });
 
             // Download the binary
@@ -335,7 +353,7 @@ task(
         const binaryPath: string = await run(TASK_NODE_ZKSYNC_DOWNLOAD_BINARY, { force: false });
 
         const currentPort = await getAvailablePort(START_PORT, MAX_PORT_ATTEMPTS);
-        const commandArgs = constructCommandArgs({ port: currentPort });
+        const commandArgs = constructCommandArgs({ port: currentPort, showNodeConfig: false, showTxSummary: false });
 
         const server = new JsonRpcServer(binaryPath);
 

--- a/packages/hardhat-zksync-node/src/server.ts
+++ b/packages/hardhat-zksync-node/src/server.ts
@@ -27,11 +27,7 @@ export class JsonRpcServer implements RpcServer {
                 console.info(chalk.green(`Running command: ${command} ${commandArgs.join(' ')}`));
             }
 
-            let stdioConfig: StdioOptions = 'inherit';
-            if (!blockProcess) {
-                stdioConfig = ['ignore', 'ignore', 'ignore'];
-            }
-            this.serverProcess = spawn(command, commandArgs, { stdio: stdioConfig });
+            this.serverProcess = spawn(command, commandArgs, { stdio: 'inherit' });
 
             this.serverProcess.on('error', (error) => {
                 console.info(chalk.red('Error running the server:', error));

--- a/packages/hardhat-zksync-node/src/types.ts
+++ b/packages/hardhat-zksync-node/src/types.ts
@@ -6,6 +6,7 @@ export interface CommandArguments {
     cacheDir?: string;
     resetCache?: boolean;
     showCalls?: string;
+    showEventLogs?: boolean;
     showStorageLogs?: string;
     showVmDetails?: string;
     showGasDetails?: string;
@@ -14,4 +15,7 @@ export interface CommandArguments {
     fork?: string;
     forkBlockNumber?: number;
     replayTx?: string;
+    showNodeConfig?: boolean;
+    showTxSummary?: boolean;
+    quiet?: boolean;
 }

--- a/packages/hardhat-zksync-node/src/utils.ts
+++ b/packages/hardhat-zksync-node/src/utils.ts
@@ -100,6 +100,22 @@ export function constructCommandArgs(args: CommandArguments): string[] {
         commandArgs.push(`--resolve-hashes`);
     }
 
+    if (args.showEventLogs !== undefined) {
+        commandArgs.push(`--show-event-logs=${args.showEventLogs}`);
+    }
+
+    if (args.showNodeConfig !== undefined) {
+        commandArgs.push(`--show-node-config=${args.showNodeConfig}`);
+    }
+
+    if (args.showTxSummary !== undefined) {
+        commandArgs.push(`--show-tx-summary=${args.showTxSummary}`);
+    }
+
+    if (args.quiet) {
+        commandArgs.push(`--quiet`);
+    }
+
     if (args.devUseLocalContracts) {
         commandArgs.push(`--dev-use-local-contracts`);
     }
@@ -412,7 +428,7 @@ export async function configureNetwork(config: HardhatConfig, network: any, port
     network.provider = await createProvider(config, network.name);
 }
 
-export const startServer = async (tag?: string, force: boolean = false) => {
+export const startServer = async (tag?: string, force: boolean = false, args?: CommandArguments) => {
     const platform = getPlatform();
     if (platform === 'windows' || platform === '') {
         throw new ZkSyncNodePluginError(`Unsupported platform: ${platform}`);
@@ -425,7 +441,7 @@ export const startServer = async (tag?: string, force: boolean = false) => {
     const binaryPath = await downloader.getBinaryPath();
 
     const currentPort = await getAvailablePort(START_PORT, MAX_PORT_ATTEMPTS);
-    const commandArgs = constructCommandArgs({ port: currentPort });
+    const commandArgs = constructCommandArgs({ ...args, port: currentPort });
 
     return {
         commandArgs,

--- a/packages/hardhat-zksync-node/test/tests.ts
+++ b/packages/hardhat-zksync-node/test/tests.ts
@@ -187,18 +187,15 @@ describe('node-zksync plugin', async function () {
                     '--show-gas-details=all',
                     '--show-calls=user',
                     '--resolve-hashes',
+                    "--show-event-logs=true",
+                    "--show-node-config=false",
+                    "--show-tx-summary=false",
+                    "--quiet",
                     '--dev-use-local-contracts',
                     'fork',
                     'mainnet',
                     '--fork-at',
-                    '100',
-                    '--show-event-logs',
-                    'true',
-                    '--show-node-config',
-                    'false',
-                    '--show-tx-summary',
-                    'false',
-                    '--quiet'
+                    '100'
                 ]);
             });
 

--- a/packages/hardhat-zksync-node/test/tests.ts
+++ b/packages/hardhat-zksync-node/test/tests.ts
@@ -168,6 +168,10 @@ describe('node-zksync plugin', async function () {
                     devUseLocalContracts: true,
                     fork: 'mainnet',
                     forkBlockNumber: 100,
+                    showEventLogs: true,
+                    showNodeConfig: false,
+                    showTxSummary: false,
+                    quiet: true
                 };
 
                 const result = constructCommandArgs(args);
@@ -188,6 +192,13 @@ describe('node-zksync plugin', async function () {
                     'mainnet',
                     '--fork-at',
                     '100',
+                    '--show-event-logs',
+                    'true',
+                    '--show-node-config',
+                    'false',
+                    '--show-tx-summary',
+                    'false',
+                    '--quiet'
                 ]);
             });
 


### PR DESCRIPTION
# What :computer: 
- Added flags to show only console.log from contracts when running tests or scripts with zksync hardhat node

# Why :hand:
- It is useful to see the console.log in the same process, this is how hardhat node also works.

# Requires release of [this era-test-node commit](https://github.com/matter-labs/era-test-node/commit/68634048eb197abb472d16c98e308523c4957d48).