### PR TITLE
typo fix Update README.md

### DIFF
--- a/packages/hardhat-zksync/README.md
+++ b/packages/hardhat-zksync/README.md
@@ -41,7 +41,7 @@ This plugin enables access to all commands available for each specific plugin, m
 
 For certain tasks present in the plugins encompassed by this plugin, it overrides them with new features and parameters. These tasks streamline common functionalities into a simplified workflow.
 
-Here is a list of overriden tasks where this plugin adds new optional parameter `--verify`:
+Here is a list of overridden tasks where this plugin adds new optional parameter `--verify`:
 
 - `deploy-zksync:contract`
 - `deploy-zksync:proxy` 


### PR DESCRIPTION
### **Title**:  
Fix typo in `README.md`

### **Description**:  
This pull request corrects a typo in the `README.md` file of the `hardhat-zksync` repository. The word "overriden" was changed to "overridden" for accuracy.

### **Changes Made**:  
- Corrected the typo from `overriden` to `overridden` in the following line:  
  From: `Here is a list of overriden tasks where this plugin adds new optional parameter \`--verify\`:`  
  To: `Here is a list of overridden tasks where this plugin adds new optional parameter \`--verify\`:`

### **Testing/Validation**:  
- No testing required, as this is a documentation fix.

### **Related Issues**:  
- No related issues.

### **Checklist**:  
- [x] Code follows the project's coding style
- [x] Documentation has been updated
- [x] PR is ready for review
