### PR TITLE
fix: support partial match verification for contracts with keccak metadata

### DIFF
--- a/e2e/fixture-projects/compatability-check/hardhat.config.ts
+++ b/e2e/fixture-projects/compatability-check/hardhat.config.ts
@@ -5,6 +5,7 @@ import '@matterlabs/hardhat-zksync-upgradable';
 
 const config = {
     zksolc: {
+        verstion: "1.4.3",
         compilerSource: 'binary',
         settings: {
             isSystem: true,

--- a/e2e/fixture-projects/compatability-check/hardhat.config.ts
+++ b/e2e/fixture-projects/compatability-check/hardhat.config.ts
@@ -5,7 +5,7 @@ import '@matterlabs/hardhat-zksync-upgradable';
 
 const config = {
     zksolc: {
-        verstion: "1.4.3",
+        verstion: "latest",
         compilerSource: 'binary',
         settings: {
             isSystem: true,

--- a/e2e/fixture-projects/compatability-check/preprocess.sh
+++ b/e2e/fixture-projects/compatability-check/preprocess.sh
@@ -39,7 +39,7 @@ cat <<EOF > "$SCRIPT_DIR/package.json"
     },
     "dependencies": {
         "@matterlabs/hardhat-zksync-deploy": "0.8.0",
-        "@matterlabs/hardhat-zksync-solc": "1.1.4",
+        "@matterlabs/hardhat-zksync-solc": "1.2.6",
         "@matterlabs/hardhat-zksync-node": "0.1.0",
         "@matterlabs/hardhat-zksync-upgradable": "0.3.1",
         "hardhat": "^2.22.5",

--- a/e2e/fixture-projects/mixed/preprocess.sh
+++ b/e2e/fixture-projects/mixed/preprocess.sh
@@ -39,7 +39,7 @@ cat <<EOF > "$SCRIPT_DIR/package.json"
     },
     "dependencies": {
       "@matterlabs/hardhat-zksync-deploy": "1.2.1",
-      "@matterlabs/hardhat-zksync-solc": "1.1.4",
+      "@matterlabs/hardhat-zksync-solc": "1.2.6",
       "@matterlabs/hardhat-zksync-node":"1.0.2",
       "@matterlabs/hardhat-zksync-upgradable":"1.3.1",
       "@matterlabs/hardhat-zksync-vyper": "1.1.1",

--- a/e2e/fixture-projects/node/test.sh
+++ b/e2e/fixture-projects/node/test.sh
@@ -10,9 +10,7 @@ pnpm hardhat node-zksync --port 8012 &
 
 sleep 10
 
-LOG_FILE="./era_test_node.log"
-
-if grep -q "Listening on 0.0.0.0:8012" "$LOG_FILE"; then
+if lsof -n -i | grep 8012; then
     echo "ZKsync node started successfully."
 else
     echo "Failed to start ZKsync node. Exiting with code 1."

--- a/e2e/fixture-projects/upgradeable/preprocess.sh
+++ b/e2e/fixture-projects/upgradeable/preprocess.sh
@@ -45,7 +45,7 @@ cat <<EOF > "$SCRIPT_DIR/package.json"
   ],
   "dependencies": {
     "@matterlabs/hardhat-zksync-deploy": "^1.4.0",
-    "@matterlabs/hardhat-zksync-solc": "^1.1.4",
+    "@matterlabs/hardhat-zksync-solc": "^1.2.6",
     "@openzeppelin/upgrades-core": "^1.31.3",
     "chalk": "^4.1.2",
     "hardhat": "^2.22.5",

--- a/examples/vyper-example/hardhat.config.ts
+++ b/examples/vyper-example/hardhat.config.ts
@@ -5,7 +5,8 @@ import { HardhatUserConfig } from 'hardhat/config';
 
 const config: HardhatUserConfig = {
     zkvyper: {
-        version: 'latest',
+        // Since version from 1.5.8 doesn't produce the correct output where deployment fails, we use 1.5.7
+        version: '1.5.7',
         compilerSource: 'binary',
     },
     defaultNetwork:'inMemoryNode',

--- a/packages/hardhat-zksync-verify/src/solc/bytecode.ts
+++ b/packages/hardhat-zksync-verify/src/solc/bytecode.ts
@@ -99,10 +99,17 @@ export async function compareBytecode(
         runtimeBytecodeSymbols,
     );
 
-    if (
-        normalizedBytecode.slice(0, deployedExecutableSection.length) ===
-        referenceBytecode.slice(0, deployedExecutableSection.length)
-    ) {
+    // If we don't have metadata detected, it could still have keccak metadata hash.
+    // We cannot check that here, so we will assume that it's present. If not, it will be caught
+    // during verification.
+    // Keccak hash is 32 bytes, but given that we're working with hex strings, it's 64 characters.
+    const bytecodeLength = deployedBytecode.hasMetadata()
+        ? deployedExecutableSection.length
+        : deployedExecutableSection.length > 64
+          ? deployedExecutableSection.length - 64
+          : deployedExecutableSection.length;
+
+    if (normalizedBytecode.slice(0, bytecodeLength) === referenceBytecode.slice(0, bytecodeLength)) {
         // The bytecode matches
         return {
             normalizedBytecode,

--- a/packages/hardhat-zksync-verify/src/solc/metadata.ts
+++ b/packages/hardhat-zksync-verify/src/solc/metadata.ts
@@ -24,7 +24,7 @@ export function inferSolcVersion(bytecode: Buffer): MetadataDescription {
         solcMetadata = metadata.decoded.solc;
     } catch {
         // The decoding failed. Unfortunately, our only option is to assume that this bytecode was emitted by an old version.
-        // Technically, this bytecode could have been emitted by a compiler for another language altogether.
+        // This could also mean that contract has keccak metadata instead of ipfs.
 
         log('Could not decode metadata.');
         return {

--- a/packages/hardhat-zksync-verify/src/task-actions.ts
+++ b/packages/hardhat-zksync-verify/src/task-actions.ts
@@ -264,28 +264,28 @@ export async function verifyContract(
 }
 
 export async function getContractInfo(
-    { contractFQN, deployedBytecode, matchingCompilerVersions, libraries }: TaskArguments,
+    { contract, deployedBytecode, matchingCompilerVersions, libraries }: TaskArguments,
     hre: HardhatRuntimeEnvironment,
     runSuper: RunSuperFunction<TaskArguments>,
 ): Promise<any> {
     if (!hre.network.zksync) {
-        return await runSuper({ contractFQN, deployedBytecode, matchingCompilerVersions, libraries });
+        return await runSuper({ contract, deployedBytecode, matchingCompilerVersions, libraries });
     }
 
     const artifacts = hre.artifacts;
     let contractInformation;
 
-    if (contractFQN !== undefined) {
-        const _ = checkContractName(artifacts, contractFQN);
+    if (contract !== undefined) {
+        const _ = checkContractName(artifacts, contract);
 
         // Process BuildInfo here to check version and throw an error if unexpected version is found.
-        const buildInfo: any = await artifacts.getBuildInfo(contractFQN);
+        const buildInfo: any = await artifacts.getBuildInfo(contract);
 
         if (buildInfo === undefined) {
-            throw new ZkSyncVerifyPluginError(BUILD_INFO_NOT_FOUND_ERROR(contractFQN));
+            throw new ZkSyncVerifyPluginError(BUILD_INFO_NOT_FOUND_ERROR(contract));
         }
 
-        const { sourceName, contractName } = parseFullyQualifiedName(contractFQN);
+        const { sourceName, contractName } = parseFullyQualifiedName(contract);
         contractInformation = await extractMatchingContractInformation(
             sourceName,
             contractName,

--- a/packages/hardhat-zksync-verify/test/tests/task-actions.test.ts
+++ b/packages/hardhat-zksync-verify/test/tests/task-actions.test.ts
@@ -297,7 +297,7 @@ describe('getContractInfo', async function () {
 
     it('should call runSuper if zksync is false', async function () {
         const args = {
-            contractFQN: 'Contract',
+            contract: 'Contract',
             deployedBytecode: '0x1234567890',
             matchingCompilerVersions: [],
             libraries: {},
@@ -317,7 +317,7 @@ describe('getContractInfo', async function () {
 
     it('should throw an error if contractFQN is undefined', async function () {
         const args = {
-            contractFQN: undefined,
+            contract: undefined,
             deployedBytecode: '0x1234567890',
             matchingCompilerVersions: [],
             libraries: {},
@@ -341,7 +341,7 @@ describe('getContractInfo', async function () {
 
     it('should throw an error if contractFQN is undefined', async function () {
         const args = {
-            contractFQN: 'Greeter',
+            contract: 'Greeter',
             deployedBytecode: '0x1234567890',
             matchingCompilerVersions: [],
             libraries: {},
@@ -364,7 +364,7 @@ describe('getContractInfo', async function () {
 
     it('should throw an error if no matching contract is found', async function () {
         const args = {
-            contractFQN: 'contracts/Contract2.sol:Contract2',
+            contract: 'contracts/Contract2.sol:Contract2',
             deployedBytecode: '0x1234567890',
             matchingCompilerVersions: [],
             libraries: {},
@@ -406,7 +406,7 @@ describe('getContractInfo', async function () {
 
     it('should return contract information if contractFQN is defined and matching contract is found', async function () {
         const args = {
-            contractFQN: 'contracts/Contract.sol:Contract',
+            contract: 'contracts/Contract.sol:Contract',
             deployedBytecode: '0x1234567890',
             matchingCompilerVersions: [],
             libraries: {},


### PR DESCRIPTION
fixes #1666

1. Fix passing `--contract` argument (looks like the argument name was changed)
2. Fix processing of [keccak metadata](https://matter-labs.github.io/era-compiler-solidity/latest/02-command-line-interface.html#--metadata-hash)