### PR TITLE
fix: add warnings for deprecated versions

### DIFF
--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -76,7 +76,7 @@ export class ZksolcCompilerDownloader {
                 console.info(chalk.yellow(COMPILER_ZKSOLC_LATEST_DEPRECATION));
             }
 
-            if (version !== 'latest' && isVersionForDeprecation(version)) {
+            if (version !== 'latest' && version !== ZKSOLC_COMPILER_PATH_VERSION && isVersionForDeprecation(version)) {
                 console.info(chalk.yellow(COMPILER_ZKSOLC_DEPRECATION_FOR_SOLC_VERSION(version)));
             }
 

--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -11,6 +11,7 @@ import {
     saltFromUrl,
     saveDataToFile,
     getLatestRelease,
+    isVersionForDeprecation,
 } from '../utils';
 import {
     COMPILER_BINARY_CORRUPTION_ERROR,
@@ -26,6 +27,8 @@ import {
     USER_AGENT,
     ZKSOLC_COMPILER_PATH_VERSION,
     fallbackLatestZkSolcVersion,
+    COMPILER_ZKSOLC_LATEST_DEPRECATION,
+    COMPILER_ZKSOLC_DEPRECATION_FOR_SOLC_VERSION,
 } from '../constants';
 import { ZkSyncSolcPluginError } from './../errors';
 
@@ -67,6 +70,14 @@ export class ZksolcCompilerDownloader {
                 throw new ZkSyncSolcPluginError(
                     `The zksolc compiler path is not specified for local or remote origin.`,
                 );
+            }
+
+            if (version === 'latest') {
+                console.info(chalk.yellow(COMPILER_ZKSOLC_LATEST_DEPRECATION));
+            }
+
+            if (version !== 'latest' && isVersionForDeprecation(version)) {
+                console.info(chalk.yellow(COMPILER_ZKSOLC_DEPRECATION_FOR_SOLC_VERSION(version)));
             }
 
             if (version === 'latest' || version === compilerVersionInfo.latest) {

--- a/packages/hardhat-zksync-solc/src/constants.ts
+++ b/packages/hardhat-zksync-solc/src/constants.ts
@@ -88,3 +88,9 @@ export const SOLCJS_EXECUTABLE_CODE = `#!/usr/bin/env node
 
 export const fallbackLatestZkSolcVersion = '1.5.12';
 export const fallbackLatestEraCompilerVersion = 'x.x.x-1.0.1';
+
+export const COMPILER_ZKSOLC_LATEST_DEPRECATION = `The 'latest' version specifier is deprecated. Please specify the version of zksolc explicitly.
+To see available versions and changelogs, visit https://github.com/matter-labs/era-compiler-solidity/releases.`;
+
+export const COMPILER_ZKSOLC_DEPRECATION_FOR_SOLC_VERSION = (version: string) =>
+    `The solc version ${version} is deprecated and will be removed for security reasons soon. Please update to v1.4.0 or newer.`;

--- a/packages/hardhat-zksync-solc/src/utils.ts
+++ b/packages/hardhat-zksync-solc/src/utils.ts
@@ -223,6 +223,10 @@ export function isVersionInRange(version: string, versionInfo: CompilerVersionIn
     return semver.gte(version, minVersion) && semver.lte(version, latest);
 }
 
+export function isVersionForDeprecation(version: string): boolean {
+    return semver.lt(version, '1.4.0');
+}
+
 // Generate SolcJS executable code
 export function generateSolcJSExecutableCode(solcJsPath: string, workingDir: string): string {
     return SOLCJS_EXECUTABLE_CODE.replace(/SOLCJS_PATH/g, solcJsPath).replace(/WORKING_DIR/g, workingDir);

--- a/packages/hardhat-zksync-vyper/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/downloader.ts
@@ -80,7 +80,7 @@ export class ZkVyperCompilerDownloader {
                 console.info(chalk.yellow(COMPILER_ZKVYPER_LATEST_DEPRECATION));
             }
 
-            if (version !== 'latest' && isVersionForDeprecation(version)) {
+            if (version !== 'latest' && version !== ZKVYPER_COMPILER_PATH_VERSION && isVersionForDeprecation(version)) {
                 console.info(chalk.yellow(COMPILER_ZKVYPER_DEPRECATION_FOR_VYPER_VERSION(version)));
             }
 

--- a/packages/hardhat-zksync-vyper/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-vyper/src/compile/downloader.ts
@@ -8,6 +8,7 @@ import {
     getLatestRelease,
     getZkvyperUrl,
     isURL,
+    isVersionForDeprecation,
     isVersionInRange,
     saltFromUrl,
     saveDataToFile,
@@ -26,6 +27,8 @@ import {
     ZKVYPER_BIN_REPOSITORY_NAME,
     ZKVYPER_COMPILER_PATH_VERSION,
     ZKVYPER_COMPILER_VERSION_MIN_VERSION,
+    COMPILER_ZKVYPER_LATEST_DEPRECATION,
+    COMPILER_ZKVYPER_DEPRECATION_FOR_VYPER_VERSION,
 } from '../constants';
 import { ZkSyncVyperPluginError } from '../errors';
 
@@ -71,6 +74,14 @@ export class ZkVyperCompilerDownloader {
                 throw new ZkSyncVyperPluginError(
                     `The zkvyper compiler path is not specified for local or remote origin.`,
                 );
+            }
+
+            if (version === 'latest') {
+                console.info(chalk.yellow(COMPILER_ZKVYPER_LATEST_DEPRECATION));
+            }
+
+            if (version !== 'latest' && isVersionForDeprecation(version)) {
+                console.info(chalk.yellow(COMPILER_ZKVYPER_DEPRECATION_FOR_VYPER_VERSION(version)));
             }
 
             if (version === 'latest' || version === compilerVersionInfo.latest) {

--- a/packages/hardhat-zksync-vyper/src/constants.ts
+++ b/packages/hardhat-zksync-vyper/src/constants.ts
@@ -55,3 +55,9 @@ export const COMPILING_INFO_MESSAGE = (zksolcVersion: string, solcVersion: strin
 
 export const VYPER_VERSION_ERROR =
     'Vyper versions 0.3.4 to 0.3.7 are not supported by zkvyper. Please use vyper 0.3.3 or >=0.3.8 in your hardhat.config file instead.';
+
+export const COMPILER_ZKVYPER_LATEST_DEPRECATION = `The 'latest' version specifier is deprecated. Please specify the version of zkvyper explicitly.
+To see available versions and changelogs, visit https://github.com/matter-labs/era-compiler-vyper/releases.`;
+
+export const COMPILER_ZKVYPER_DEPRECATION_FOR_VYPER_VERSION = (version: string) =>
+    `The vyper version ${version} is deprecated and will be removed for security reasons soon. Please update to v1.4.0 or newer.`;

--- a/packages/hardhat-zksync-vyper/src/utils.ts
+++ b/packages/hardhat-zksync-vyper/src/utils.ts
@@ -77,6 +77,10 @@ export function isVersionInRange(version: string, versionInfo: CompilerVersionIn
     return semver.gte(version, minVersion) && semver.lte(version, latest);
 }
 
+export function isVersionForDeprecation(version: string): boolean {
+    return semver.lt(version, '1.4.0');
+}
+
 export function checkSupportedVyperVersions(vyper: MultiVyperConfig) {
     vyper.compilers.forEach((compiler) => {
         if (UNSUPPORTED_VYPER_VERSIONS.includes(compiler.version)) {


### PR DESCRIPTION
# What :computer: 
Add warnings for deprecate versions for security reasons.

# Why :hand:
Remove usage of old versions of the compilers.

fixes: https://github.com/matter-labs/hardhat-zksync/issues/1732, https://github.com/matter-labs/hardhat-zksync/issues/1733

<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

# Notes :memo:
* Any notes/thoughts that the reviewers should know prior to reviewing the code?