### PR TITLE
fix: remove the old URL format

### DIFF
--- a/packages/hardhat-zksync-solc/src/compile/downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/downloader.ts
@@ -140,23 +140,22 @@ export class ZksolcCompilerDownloader {
     private async _downloadCompiler(): Promise<string> {
         const downloadPath = this.getCompilerPath();
 
-        const url = this._getCompilerUrl(true);
+        const url = this._getCompilerUrl();
         try {
             await this._attemptDownload(url, downloadPath);
         } catch (e: any) {
             if (!this._isCompilerPathURL) {
-                const fallbackUrl = this._getCompilerUrl(false);
-                await this._attemptDownload(fallbackUrl, downloadPath);
+                await this._attemptDownload(url, downloadPath);
             }
         }
         return downloadPath;
     }
 
-    private _getCompilerUrl(useGithubRelease: boolean): string {
+    private _getCompilerUrl(): string {
         if (this._isCompilerPathURL) {
             return this._configCompilerPath;
         }
-        return getZksolcUrl(ZKSOLC_BIN_REPOSITORY, this._version, useGithubRelease);
+        return getZksolcUrl(ZKSOLC_BIN_REPOSITORY, this._version);
     }
 
     private async _attemptDownload(url: string, downloadPath: string): Promise<void> {

--- a/packages/hardhat-zksync-solc/src/compile/zkvm-solc-downloader.ts
+++ b/packages/hardhat-zksync-solc/src/compile/zkvm-solc-downloader.ts
@@ -87,18 +87,13 @@ export class ZkVmSolcCompilerDownloader {
     private async _downloadCompiler(): Promise<string> {
         const downloadPath = this.getCompilerPath();
 
-        const url = this._getCompilerUrl(true);
-        try {
-            await this._attemptDownload(url, downloadPath);
-        } catch (e: any) {
-            const fallbackUrl = this._getCompilerUrl(false);
-            await this._attemptDownload(fallbackUrl, downloadPath);
-        }
+        const url = this._getCompilerUrl();
+        await this._attemptDownload(url, downloadPath);
         return downloadPath;
     }
 
-    private _getCompilerUrl(useGithubRelease: boolean): string {
-        return getZkVmSolcUrl(ZKVM_SOLC_BIN_REPOSITORY, this.version, useGithubRelease);
+    private _getCompilerUrl(): string {
+        return getZkVmSolcUrl(ZKVM_SOLC_BIN_REPOSITORY, this.version);
     }
 
     private async _attemptDownload(url: string, downloadPath: string): Promise<void> {

--- a/packages/hardhat-zksync-solc/src/utils.ts
+++ b/packages/hardhat-zksync-solc/src/utils.ts
@@ -167,7 +167,7 @@ export function saltFromUrl(url: string): string {
     return sha1(url);
 }
 
-export function getZksolcUrl(repo: string, version: string, isRelease: boolean = true): string {
+export function getZksolcUrl(repo: string, version: string): string {
     // @ts-ignore
     const platform = { darwin: 'macosx', linux: 'linux', win32: 'windows' }[process.platform];
     const toolchain = semver.lt(version, COMPILER_MIN_LINUX_VERSION_WITH_GNU_TOOLCHAIN)
@@ -178,24 +178,17 @@ export function getZksolcUrl(repo: string, version: string, isRelease: boolean =
     const arch = process.arch === 'x64' ? 'amd64' : process.arch;
     const ext = process.platform === 'win32' ? '.exe' : '';
 
-    if (isRelease) {
-        return `${repo}/releases/download/${version}/zksolc-${platform}-${arch}${toolchain}-v${version}${ext}`;
-    }
-
-    return `${repo}/raw/main/${platform}-${arch}/zksolc-${platform}-${arch}${toolchain}-v${version}${ext}`;
+    return `${repo}/releases/download/${version}/zksolc-${platform}-${arch}${toolchain}-v${version}${ext}`;
 }
 
-export function getZkVmSolcUrl(repo: string, version: string, isRelease: boolean = true): string {
+export function getZkVmSolcUrl(repo: string, version: string): string {
     // @ts-ignore
     const platform = { darwin: 'macosx', linux: 'linux', win32: 'windows' }[process.platform];
     // @ts-ignore
     const arch = process.arch === 'x64' ? 'amd64' : process.arch;
     const ext = process.platform === 'win32' ? '.exe' : '';
-    if (isRelease) {
-        return `${repo}/releases/download/${version}/solc-${platform}-${arch}-${version}${ext}`;
-    }
-
-    return `${repo}/raw/main/${platform}-${arch}/solc-${platform}-${arch}-${version}${ext}`;
+    
+    return `${repo}/releases/download/${version}/solc-${platform}-${arch}-${version}${ext}`;
 }
 
 export function pluralize(n: number, singular: string, plural?: string) {

--- a/packages/hardhat-zksync-solc/test/tests/utils.test.ts
+++ b/packages/hardhat-zksync-solc/test/tests/utils.test.ts
@@ -367,7 +367,7 @@ describe('Utils', () => {
 describe('getZksolcUrl', () => {
     const platformStub = sinon.stub(process, 'platform');
 
-    it('should return the release URL when isRelease is true', () => {
+    it('should return the release URL', () => {
         platformStub.value('linux'); // Mock the process.platform property
         const archStub = sinon.stub(process, 'arch');
         archStub.value('x64');
@@ -375,34 +375,14 @@ describe('getZksolcUrl', () => {
         const version = '1.0.0';
         let expectedUrl = 'example/repo/releases/download/1.0.0/zksolc-linux-amd64-musl-v1.0.0';
 
-        const url = getZksolcUrl(repo, version, true);
+        const url = getZksolcUrl(repo, version);
 
         expect(url).to.equal(expectedUrl);
 
         platformStub.value('darwin'); // Mock the process.platform property
         expectedUrl = 'example/repo/releases/download/1.0.0/zksolc-macosx-amd64-v1.0.0';
 
-        const urlMac = getZksolcUrl(repo, version, true);
-
-        expect(urlMac).to.equal(expectedUrl);
-    });
-
-    it('should return the raw URL when isRelease is false', () => {
-        platformStub.value('linux'); // Mock the process.platform property
-        const archStub = sinon.stub(process, 'arch');
-        archStub.value('x64');
-        const repo = 'example/repo';
-        const version = '1.0.0';
-        let expectedUrl = 'example/repo/raw/main/linux-amd64/zksolc-linux-amd64-musl-v1.0.0';
-
-        const url = getZksolcUrl(repo, version, false);
-
-        expect(url).to.equal(expectedUrl);
-
-        platformStub.value('darwin'); // Mock the process.platform property
-        expectedUrl = 'example/repo/raw/main/macosx-amd64/zksolc-macosx-amd64-v1.0.0';
-
-        const urlMac = getZksolcUrl(repo, version, false);
+        const urlMac = getZksolcUrl(repo, version);
 
         expect(urlMac).to.equal(expectedUrl);
     });


### PR DESCRIPTION
# What :computer: 

Removes the old zksolc-bin-like URL format.

# Why :hand:

It caused unexpected falling back to the old URL in some environments for some reason.