### PR TITLE
fix: noop commit to trigger release

### DIFF
--- a/packages/hardhat-zksync-node/README.md
+++ b/packages/hardhat-zksync-node/README.md
@@ -63,7 +63,7 @@ In addition to the [hardhat-zksync-node](https://docs.zksync.io/build/tooling/ha
 
 Contributions are always welcome! Feel free to open any issue or send a pull request.
 
-Go to [CONTRIBUTING.md](https://github.com/matter-labs/hardhat-zksync/blob/main/.github/CONTRIBUTING.md) to learn about steps and best practices for contributing to ZKsync hardhat tooling base repository.  
+Go to [CONTRIBUTING.md](https://github.com/matter-labs/hardhat-zksync/blob/main/.github/CONTRIBUTING.md) to learn about steps and best practices for contributing to ZKsync hardhat tooling base repository.
 
 
 ## 🙌 Feedback, help and news


### PR DESCRIPTION
# What :computer: 
* Trigger a patch release for https://www.npmjs.com/package/@matterlabs/hardhat-zksync-node

# Why :hand:
* The current released package is using hardhat-zksync-solc@v1.4.0
<img width="766" height="1098" alt="image" src="https://github.com/user-attachments/assets/3c757c54-f219-4702-8727-e6c0065bbec7" />


