### PR TITLE
chore(deps): upgrade OpenZeppelin contracts to v5.4.0

### DIFF
--- a/e2e/fixture-projects/compatability-check/contracts/FactoryUups.sol
+++ b/e2e/fixture-projects/compatability-check/contracts/FactoryUups.sol
@@ -11,7 +11,7 @@ contract FactoryUups is Initializable, UUPSUpgradeable, OwnableUpgradeable  {
     address[] public deployedContracts;
 
     function initialize() public initializer{
-        __Ownable_init(msg.sender);
+        __Ownable_init();
         __UUPSUpgradeable_init();
         deployEmptyContract();
     }

--- a/e2e/fixture-projects/compatability-check/contracts/FactoryUups.sol
+++ b/e2e/fixture-projects/compatability-check/contracts/FactoryUups.sol
@@ -11,7 +11,7 @@ contract FactoryUups is Initializable, UUPSUpgradeable, OwnableUpgradeable  {
     address[] public deployedContracts;
 
     function initialize() public initializer{
-        __Ownable_init();
+        __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
         deployEmptyContract();
     }

--- a/examples/basic-example/hardhat.config.ts
+++ b/examples/basic-example/hardhat.config.ts
@@ -40,6 +40,9 @@ const config: HardhatUserConfig = {
                 version: '0.8.24',
             },
             {
+                version: '0.8.20',
+            },
+            {
                 version: '0.8.17',
             },
             {

--- a/examples/basic-example/hardhat.config.ts
+++ b/examples/basic-example/hardhat.config.ts
@@ -37,6 +37,9 @@ const config: HardhatUserConfig = {
     solidity: {
         compilers: [
             {
+                version: '0.8.24',
+            },
+            {
                 version: '0.8.17',
             },
             {

--- a/examples/basic-example/package.json
+++ b/examples/basic-example/package.json
@@ -37,8 +37,8 @@
     "ethers": "^6.12.2",
     "zksync-ethers": "^6.15.0",
     "@matterlabs/zksync-contracts": "^0.6.1",
-    "@openzeppelin/contracts": "^4.9.6",
-    "@openzeppelin/contracts-upgradeable": "^4.9.6"
+    "@openzeppelin/contracts": "^5.4.0",
+    "@openzeppelin/contracts-upgradeable": "^5.4.0"
   },
   "prettier": {
     "tabWidth": 4,

--- a/examples/basic-example/tsconfig.json
+++ b/examples/basic-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/deploy-example/tsconfig.json
+++ b/examples/deploy-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/download-with-compiler-origin/tsconfig.json
+++ b/examples/download-with-compiler-origin/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/mixed-example/tsconfig.json
+++ b/examples/mixed-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/node-example/tsconfig.json
+++ b/examples/node-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/noninline-libraries-example/package.json
+++ b/examples/noninline-libraries-example/package.json
@@ -36,8 +36,8 @@
       "ethers": "^6.12.2",
       "zksync-ethers": "^6.15.0",
       "@matterlabs/zksync-contracts": "^0.6.1",
-      "@openzeppelin/contracts": "^5.0.2",
-      "@openzeppelin/contracts-upgradeable": "^5.0.2"
+      "@openzeppelin/contracts": "^5.4.0",
+      "@openzeppelin/contracts-upgradeable": "^5.4.0"
     },
     "prettier": {
       "tabWidth": 4,

--- a/examples/noninline-libraries-example/tsconfig.json
+++ b/examples/noninline-libraries-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-      "target": "es5",
+      "target": "es2020",
       "module": "commonjs",
       "strict": true,
       "esModuleInterop": true,

--- a/examples/upgradable-example-l1/hardhat.config.ts
+++ b/examples/upgradable-example-l1/hardhat.config.ts
@@ -28,7 +28,14 @@ const config: HardhatUserConfig = {
         },
     },
     solidity: {
-        version: '0.8.20',
+        compilers: [
+            {
+                version: '0.8.24',
+            },
+            {
+                version: '0.8.20',
+            }
+        ]
     },
 };
 

--- a/examples/upgradable-example-l1/package.json
+++ b/examples/upgradable-example-l1/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "^5.0.2",
+    "@openzeppelin/contracts": "^5.4.0",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "6.13.1",
     "@typescript-eslint/parser": "6.13.1",
@@ -36,7 +36,7 @@
     "@matterlabs/hardhat-zksync-upgradable": "workspace:^",
     "@matterlabs/hardhat-zksync-verify": "workspace:^",
     "@nomicfoundation/hardhat-ethers": "3.0.6",
-    "@openzeppelin/contracts-upgradeable": "^5.0.2",
+    "@openzeppelin/contracts-upgradeable": "^5.4.0",
     "chalk": "^4.1.2",
     "ethers": "^6.12.2",
     "hardhat": "^2.22.5",

--- a/examples/upgradable-example-l1/tsconfig.json
+++ b/examples/upgradable-example-l1/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/upgradable-example/hardhat.config.ts
+++ b/examples/upgradable-example/hardhat.config.ts
@@ -28,7 +28,14 @@ const config: HardhatUserConfig = {
         },
     },
     solidity: {
-        version: '0.8.20',
+        compilers: [
+            {
+                version: '0.8.24',
+            },
+            {
+                version: '0.8.20',
+            }
+        ]
     },
 };
 

--- a/examples/upgradable-example/package.json
+++ b/examples/upgradable-example/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "^5.0.2",
+    "@openzeppelin/contracts": "^5.4.0",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "6.13.1",
     "@typescript-eslint/parser": "6.13.1",
@@ -39,7 +39,7 @@
     "@matterlabs/hardhat-zksync-upgradable": "workspace:^",
     "@matterlabs/hardhat-zksync-verify": "workspace:^",
     "@nomicfoundation/hardhat-ethers": "3.0.6",
-    "@openzeppelin/contracts-upgradeable": "^5.0.2",
+    "@openzeppelin/contracts-upgradeable": "^5.4.0",
     "@openzeppelin/hardhat-upgrades": "^3.2.1",
     "chalk": "^4.1.2",
     "zksync": "^0.13.1"

--- a/examples/upgradable-example/tsconfig.json
+++ b/examples/upgradable-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/verify-example/contracts/BoxUups.sol
+++ b/examples/verify-example/contracts/BoxUups.sol
@@ -11,7 +11,7 @@ contract BoxUups is Initializable, UUPSUpgradeable, OwnableUpgradeable {
 
     function initialize(uint256 initValue) public initializer {
         value = initValue;
-        __Ownable_init();
+        __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
     }
 

--- a/examples/verify-example/contracts/FactoryUups.sol
+++ b/examples/verify-example/contracts/FactoryUups.sol
@@ -11,7 +11,7 @@ contract FactoryUups is Initializable, UUPSUpgradeable, OwnableUpgradeable  {
     address[] public deployedContracts;
 
     function initialize() public initializer{
-        __Ownable_init();
+        __Ownable_init(msg.sender);
         __UUPSUpgradeable_init();
         deployEmptyContract();
     }

--- a/examples/verify-example/tsconfig.json
+++ b/examples/verify-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/verify-vyper-example/tsconfig.json
+++ b/examples/verify-vyper-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/vyper-example/tsconfig.json
+++ b/examples/vyper-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/examples/zksync-ethers-example/tsconfig.json
+++ b/examples/zksync-ethers-example/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/packages/hardhat-zksync-ethers/test/tests.ts
+++ b/packages/hardhat-zksync-ethers/test/tests.ts
@@ -273,8 +273,8 @@ describe('Plugin tests', async function () {
                 );
             });
             it('should return the transaction count of the account', async function () {
-                // we use the second signer because the first one is used in previous tests
-                const [, signer] = await this.env.ethers.getSigners();
+                // we use the third signer because the first and second ones are used in previous tests
+                const [, , signer] = await this.env.ethers.getSigners();
 
                 assert.strictEqual(await this.env.ethers.provider.getTransactionCount(signer), 0);
             });

--- a/packages/hardhat-zksync-upgradable/package.json
+++ b/packages/hardhat-zksync-upgradable/package.json
@@ -37,7 +37,7 @@
     "@matterlabs/hardhat-zksync-solc": "workspace:^",
     "@matterlabs/hardhat-zksync-ethers": "workspace:^",
     "@matterlabs/hardhat-zksync-telemetry": "workspace:^",
-    "@openzeppelin/contracts-hardhat-zksync-upgradable": "npm:@openzeppelin/contracts@^5.0.2",
+    "@openzeppelin/contracts-hardhat-zksync-upgradable": "npm:@openzeppelin/contracts@^5.4.0",
     "@openzeppelin/hardhat-upgrades": "^3.2.1",
     "@openzeppelin/upgrades-core": "^1.37.0",
     "@openzeppelin/defender-sdk-base-client": "^1.10.0",

--- a/packages/hardhat-zksync-upgradable/test/fixture-projects/admin/hardhat.config.ts
+++ b/packages/hardhat-zksync-upgradable/test/fixture-projects/admin/hardhat.config.ts
@@ -35,7 +35,7 @@ const config: HardhatUserConfig = {
         },
     },
     solidity: {
-        version: '0.8.20',
+        compilers: [{ version: "0.8.24" }, { version: "0.8.20" }],
     },
 };
 

--- a/packages/hardhat-zksync-upgradable/test/fixture-projects/beacon-e2e/hardhat.config.ts
+++ b/packages/hardhat-zksync-upgradable/test/fixture-projects/beacon-e2e/hardhat.config.ts
@@ -35,7 +35,7 @@ const config: HardhatUserConfig = {
         },
     },
     solidity: {
-        version: '0.8.20',
+        compilers: [{ version: "0.8.24" }, { version: "0.8.20" }],
     },
 };
 

--- a/packages/hardhat-zksync-upgradable/test/fixture-projects/deployment-gas-estimation/hardhat.config.ts
+++ b/packages/hardhat-zksync-upgradable/test/fixture-projects/deployment-gas-estimation/hardhat.config.ts
@@ -35,7 +35,7 @@ const config: HardhatUserConfig = {
         },
     },
     solidity: {
-        version: '0.8.20',
+        compilers: [{ version: "0.8.24" }, { version: "0.8.20" }],
     },
 };
 

--- a/packages/hardhat-zksync-upgradable/test/fixture-projects/storage-layout-validations/hardhat.config.ts
+++ b/packages/hardhat-zksync-upgradable/test/fixture-projects/storage-layout-validations/hardhat.config.ts
@@ -35,7 +35,7 @@ const config: HardhatUserConfig = {
         },
     },
     solidity: {
-        version: '0.8.20',
+        compilers: [{ version: "0.8.24" }, { version: "0.8.20" }],
     },
 };
 

--- a/packages/hardhat-zksync-upgradable/test/fixture-projects/tup-e2e/hardhat.config.ts
+++ b/packages/hardhat-zksync-upgradable/test/fixture-projects/tup-e2e/hardhat.config.ts
@@ -35,7 +35,7 @@ const config: HardhatUserConfig = {
         },
     },
     solidity: {
-        version: '0.8.20',
+        compilers: [{ version: "0.8.24" }, { version: "0.8.20" }],
     },
 };
 

--- a/packages/hardhat-zksync-upgradable/test/fixture-projects/uups-e2e/hardhat.config.ts
+++ b/packages/hardhat-zksync-upgradable/test/fixture-projects/uups-e2e/hardhat.config.ts
@@ -34,7 +34,7 @@ const config: HardhatUserConfig = {
         },
     },
     solidity: {
-        version: '0.8.20',
+        compilers: [{ version: "0.8.24" }, { version: "0.8.20" }],
     },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,13 +49,13 @@ importers:
         version: link:../../packages/hardhat-zksync-solc
       '@matterlabs/zksync-contracts':
         specifier: ^0.6.1
-        version: 0.6.1(@openzeppelin/contracts-upgradeable@4.9.6)(@openzeppelin/contracts@4.9.6)
+        version: 0.6.1(@openzeppelin/contracts-upgradeable@5.4.0(@openzeppelin/contracts@5.4.0))(@openzeppelin/contracts@5.4.0)
       '@openzeppelin/contracts':
-        specifier: ^4.9.6
-        version: 4.9.6
+        specifier: ^5.4.0
+        version: 5.4.0
       '@openzeppelin/contracts-upgradeable':
-        specifier: ^4.9.6
-        version: 4.9.6
+        specifier: ^5.4.0
+        version: 5.4.0(@openzeppelin/contracts@5.4.0)
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -375,13 +375,13 @@ importers:
         version: link:../../packages/hardhat-zksync-solc
       '@matterlabs/zksync-contracts':
         specifier: ^0.6.1
-        version: 0.6.1(@openzeppelin/contracts-upgradeable@5.0.2(@openzeppelin/contracts@5.0.2))(@openzeppelin/contracts@5.0.2)
+        version: 0.6.1(@openzeppelin/contracts-upgradeable@5.4.0(@openzeppelin/contracts@5.4.0))(@openzeppelin/contracts@5.4.0)
       '@openzeppelin/contracts':
-        specifier: ^5.0.2
-        version: 5.0.2
+        specifier: ^5.4.0
+        version: 5.4.0
       '@openzeppelin/contracts-upgradeable':
-        specifier: ^5.0.2
-        version: 5.0.2(@openzeppelin/contracts@5.0.2)
+        specifier: ^5.4.0
+        version: 5.4.0(@openzeppelin/contracts@5.4.0)
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -453,8 +453,8 @@ importers:
         specifier: 3.0.6
         version: 3.0.6(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@openzeppelin/contracts-upgradeable':
-        specifier: ^5.0.2
-        version: 5.0.2(@openzeppelin/contracts@5.0.2)
+        specifier: ^5.4.0
+        version: 5.4.0(@openzeppelin/contracts@5.4.0)
       '@openzeppelin/hardhat-upgrades':
         specifier: ^3.2.1
         version: 3.4.0(@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)))(@nomicfoundation/hardhat-verify@2.0.8(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10)))(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
@@ -475,8 +475,8 @@ importers:
         version: 6.15.0(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))
     devDependencies:
       '@openzeppelin/contracts':
-        specifier: ^5.0.2
-        version: 5.0.2
+        specifier: ^5.4.0
+        version: 5.4.0
       '@types/node':
         specifier: ^18.11.17
         version: 18.19.33
@@ -535,8 +535,8 @@ importers:
         specifier: 3.0.6
         version: 3.0.6(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))(hardhat@2.22.5(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)(utf-8-validate@5.0.10))
       '@openzeppelin/contracts-upgradeable':
-        specifier: ^5.0.2
-        version: 5.0.2(@openzeppelin/contracts@5.0.2)
+        specifier: ^5.4.0
+        version: 5.4.0(@openzeppelin/contracts@5.4.0)
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -554,8 +554,8 @@ importers:
         version: 6.15.0(ethers@6.12.2(bufferutil@4.0.8)(utf-8-validate@5.0.10))
     devDependencies:
       '@openzeppelin/contracts':
-        specifier: ^5.0.2
-        version: 5.0.2
+        specifier: ^5.4.0
+        version: 5.4.0
       '@types/node':
         specifier: ^18.11.17
         version: 18.19.33
@@ -1437,8 +1437,8 @@ importers:
         specifier: workspace:^
         version: link:../hardhat-zksync-telemetry
       '@openzeppelin/contracts-hardhat-zksync-upgradable':
-        specifier: npm:@openzeppelin/contracts@^5.0.2
-        version: '@openzeppelin/contracts@5.0.2'
+        specifier: npm:@openzeppelin/contracts@^5.4.0
+        version: '@openzeppelin/contracts@5.4.0'
       '@openzeppelin/defender-sdk-base-client':
         specifier: ^1.10.0
         version: 1.14.3
@@ -2498,19 +2498,21 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@openzeppelin/contracts-upgradeable@4.9.6':
-    resolution: {integrity: sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==}
-
   '@openzeppelin/contracts-upgradeable@5.0.2':
     resolution: {integrity: sha512-0MmkHSHiW2NRFiT9/r5Lu4eJq5UJ4/tzlOgYXNAIj/ONkQTVnz22pLxDvp4C4uZ9he7ZFvGn3Driptn1/iU7tQ==}
     peerDependencies:
       '@openzeppelin/contracts': 5.0.2
 
-  '@openzeppelin/contracts@4.9.6':
-    resolution: {integrity: sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==}
+  '@openzeppelin/contracts-upgradeable@5.4.0':
+    resolution: {integrity: sha512-STJKyDzUcYuB35Zub1JpWW58JxvrFFVgQ+Ykdr8A9PGXgtq/obF5uoh07k2XmFyPxfnZdPdBdhkJ/n2YxJ87HQ==}
+    peerDependencies:
+      '@openzeppelin/contracts': 5.4.0
 
   '@openzeppelin/contracts@5.0.2':
     resolution: {integrity: sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA==}
+
+  '@openzeppelin/contracts@5.4.0':
+    resolution: {integrity: sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==}
 
   '@openzeppelin/defender-sdk-base-client@1.14.3':
     resolution: {integrity: sha512-4yG9E8N1c/ZP2jNR+Ah19wi7SBKpauAV/VcYcm7rg1dltDbzbH/oZnnXJlymT7IfjTPXkKHW8TPsaqz3EjS7tA==}
@@ -5934,15 +5936,15 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@matterlabs/zksync-contracts@0.6.1(@openzeppelin/contracts-upgradeable@4.9.6)(@openzeppelin/contracts@4.9.6)':
-    dependencies:
-      '@openzeppelin/contracts': 4.9.6
-      '@openzeppelin/contracts-upgradeable': 4.9.6
-
   '@matterlabs/zksync-contracts@0.6.1(@openzeppelin/contracts-upgradeable@5.0.2(@openzeppelin/contracts@5.0.2))(@openzeppelin/contracts@5.0.2)':
     dependencies:
       '@openzeppelin/contracts': 5.0.2
       '@openzeppelin/contracts-upgradeable': 5.0.2(@openzeppelin/contracts@5.0.2)
+
+  '@matterlabs/zksync-contracts@0.6.1(@openzeppelin/contracts-upgradeable@5.4.0(@openzeppelin/contracts@5.4.0))(@openzeppelin/contracts@5.4.0)':
+    dependencies:
+      '@openzeppelin/contracts': 5.4.0
+      '@openzeppelin/contracts-upgradeable': 5.4.0(@openzeppelin/contracts@5.4.0)
 
   '@metamask/eth-sig-util@4.0.1':
     dependencies:
@@ -6443,15 +6445,17 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
 
-  '@openzeppelin/contracts-upgradeable@4.9.6': {}
-
   '@openzeppelin/contracts-upgradeable@5.0.2(@openzeppelin/contracts@5.0.2)':
     dependencies:
       '@openzeppelin/contracts': 5.0.2
 
-  '@openzeppelin/contracts@4.9.6': {}
+  '@openzeppelin/contracts-upgradeable@5.4.0(@openzeppelin/contracts@5.4.0)':
+    dependencies:
+      '@openzeppelin/contracts': 5.4.0
 
   '@openzeppelin/contracts@5.0.2': {}
+
+  '@openzeppelin/contracts@5.4.0': {}
 
   '@openzeppelin/defender-sdk-base-client@1.14.3':
     dependencies:


### PR DESCRIPTION
# What :computer: 
* Updated @openzeppelin/contracts from 4.9.6/5.0.2 to 5.4.0 across all packages and examples
* Updated @openzeppelin/contracts-upgradeable from 4.9.6/5.0.2 to 5.4.0 for consistency  
* Fixed Ownable initialization calls to use v5.x compatible syntax
* Updated TypeScript configuration target from es5 to es2020 for compatibility
* Updated Solidity compiler configurations to support OpenZeppelin v5.4.0 pragmas (^0.8.20, ^0.8.21, ^0.8.22)
* Regenerated lock files to resolve dependency conflicts

# Why :hand:
* OpenZeppelin v5.4.0 provides security improvements and modern Solidity compatibility
* Previous PR #1825 had incomplete upgrade and lock file conflicts
* Ensures consistent OpenZeppelin versions across the entire monorepo
* Fixes compilation issues caused by outdated TypeScript target settings
* Addresses breaking changes in Ownable contract initialization
* Adds proper Solidity compiler support for newer OpenZeppelin pragma requirements

# Evidence :camera:
- All packages compile successfully with `pnpm build`
- Examples build without TypeScript errors
- Lock file properly resolves v5.4.0 dependencies
- Ownable initialization updated in all affected contracts
- Test fixtures updated with correct Solidity compiler versions
- E2E compatibility tests maintained for older versions

# Notes :memo:
* This supersedes and closes PR #1825 and PR #1827 which had incomplete changes and stale lock files
* All breaking changes from OpenZeppelin v5.x have been addressed
* Added multiple Solidity compiler versions (0.8.24, 0.8.20, 0.8.17) to handle various pragma requirements
* Some peer dependency warnings remain for @matterlabs/zksync-contracts expecting v4.6.0
* E2E compatibility fixtures maintained with older OpenZeppelin syntax where required

## PRs that can be closed after this merge:
- [ ] #1825 - Incomplete OpenZeppelin contracts upgrade (dependabot)
- [ ] #1827 - Incomplete OpenZeppelin contracts-upgradeable upgrade (dependabot)