### PR TITLE
chore: bump hardhat-zksync-verify to 1.9.2 and hardhat-zksync to 1.6.3

### DIFF
--- a/.github/release-please/manifest.json
+++ b/.github/release-please/manifest.json
@@ -4,8 +4,8 @@
     "packages/hardhat-zksync-solc": "1.5.1",
     "packages/hardhat-zksync-upgradable": "1.10.0",
     "packages/hardhat-zksync-vyper": "1.4.0",
-    "packages/hardhat-zksync-verify": "1.9.1",
-    "packages/hardhat-zksync": "1.6.1",
+    "packages/hardhat-zksync-verify": "1.9.2",
+    "packages/hardhat-zksync": "1.6.3",
     "packages/hardhat-zksync-node": "1.5.3",
     "packages/hardhat-zksync-ethers": "1.4.0",
     "packages/hardhat-zksync-verify-vyper": "0.2.0-alpha.6"

--- a/packages/hardhat-zksync-verify/CHANGELOG.md
+++ b/packages/hardhat-zksync-verify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @matterlabs/hardhat-zksync-verify
 
+## 1.9.2
+
+### Patch Changes
+
+-   Migrate zkSync Etherscan verification to V2 API
+
 ## [1.9.1](https://github.com/matter-labs/hardhat-zksync/compare/@matterlabs/hardhat-zksync-verify-v1.9.0...@matterlabs/hardhat-zksync-verify-v1.9.1) (2025-08-11)
 
 

--- a/packages/hardhat-zksync-verify/package.json
+++ b/packages/hardhat-zksync-verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterlabs/hardhat-zksync-verify",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Hardhat plugin to verify smart contracts for the ZKsync network",
   "repository": "github:matter-labs/hardhat-zksync",
   "homepage": "https://github.com/matter-labs/hardhat-zksync/tree/main/packages/hardhat-zksync-verify",

--- a/packages/hardhat-zksync/CHANGELOG.md
+++ b/packages/hardhat-zksync/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @matterlabs/hardhat-zksync
 
+## 1.6.3
+
+### Patch Changes
+
+-   Update hardhat-zksync umbrella package to include hardhat-zksync-verify v1.9.2
+    -   Includes zkSync Etherscan V2 API migration
+
 ## 1.6.2
 
 ### Patch Changes

--- a/packages/hardhat-zksync/package.json
+++ b/packages/hardhat-zksync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterlabs/hardhat-zksync",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "ZKsync bundle of Hardhat plugins",
   "repository": "github:matter-labs/hardhat-zksync",
   "homepage": "https://github.com/matter-labs/hardhat-zksync/tree/main/packages/hardhat-zksync",


### PR DESCRIPTION
## Summary
- Bump hardhat-zksync-verify from 1.9.1 to 1.9.2
- Bump hardhat-zksync umbrella package from 1.6.2 to 1.6.3

## Context
The verify package includes the Etherscan V2 API migration that was previously merged. To publish these changes, we need to bump the version. Since the umbrella package depends on hardhat-zksync-verify, it also needs a version bump to include the latest verify release.

## Changes
- Updated package.json versions for both packages
- Added changelog entries documenting the changes
- Updated release-please manifest with new versions