### PR TITLE
ci: Update npm-publish workflow to trusted-publishers OIDC

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -31,6 +31,10 @@ on:
           - hardhat-zksync-verify-vyper
           - hardhat-zksync-telemetry
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+  
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -49,7 +53,5 @@ jobs:
         run: pnpm install && pnpm build
 
       - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_NPM_MATTERLABS_AUTOMATION_TOKEN }}
         run: |
-          pnpm publish packages/${{inputs.package}} --tag ${{ inputs.tag }} --access=public
+          pnpm publish packages/${{inputs.package}} --tag ${{ inputs.tag }} --access=public --provenance


### PR DESCRIPTION
# What :computer: 
Added permissions for OIDC and updated publish command.


# Why :hand:
NPNJS token access is deprecated.


<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->

ref ZKD-3244