### PR TITLE
docs: remove documentation links for hardhat ZKsync plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,6 @@ Here is an overview of the plugins currently available:
 | hardhat-zksync-node           | Convenient plugin to run the anvil-zksync locally.                                                                        |
 | hardhat-zksync-ethers         | A zksync-ethers SDK wrapper providing additional methods for accelerated development on ZKsync.                                   |
 
-You can find more detailed explanations on how to use hardhat ZKsync plugins on our [documentation page](https://docs.zksync.io/build/tooling/hardhat/getting-started) where each plugin has its own section:
-
-[hardhat-zksync](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync)\
-[hardhat-zksync-solc](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-solc)\
-[hardhat-zksync-deploy](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-deploy)\
-[hardhat-zksync-verify](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-verify)\
-[hardhat-zksync-verify-vyper](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-verify-vyper)\
-[hardhat-zksync-vyper](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-vyper)\
-[hardhat-zksync-upgradable](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-upgradable)\
-[hardhat-zksync-node](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-node)\
-[hardhat-zksync-ethers](https://docs.zksync.io/build/tooling/hardhat/hardhat-zksync-ethers)
-
-
 We hope you find these plugins useful in your development efforts.\
 Happy coding!🙌🎉
 ## License


### PR DESCRIPTION
Removed links to detailed documentation for hardhat ZKsync plugins from the README as these pages will be removed from public docs shortly

# Evidence :camera:
N/A

# Notes :memo:
N/A